### PR TITLE
chore: add agent guide and readiness gates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist/
 build/
 target/
 .turbo/
+.clawpatch/
 
 # tauri
 apps/desktop/src-tauri/target/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,146 @@
+# AGENTS.md
+
+Guidance for coding agents working in this repository.
+
+## Project
+
+Cellar is an MIT-licensed, open-source, cross-platform desktop database client.
+It targets developers, DBAs, and analysts who need a fast DataGrip/TablePlus/DBeaver-class tool for browsing schemas, querying, editing result sets, and reviewing database changes before they are committed.
+
+The product principles are:
+
+- Desktop-first. There is no web-hosted v1 target.
+- No telemetry by default. Do not add network reporting, analytics, or crash upload without explicit opt-in UX.
+- BYO AI provider. Cellar must not proxy AI requests through a hosted Cellar service.
+- AI is workflow-native: schema-aware editor completion, transparent context chips, generated SQL that is inspectable and gated before execution.
+- The grid is core product surface. It must be virtualized, editable, honest about pending versus committed data, and safe around transactions.
+- Extensibility matters. Drivers, AI providers, exporters, and renderers should be pluggable rather than hardcoded into app-only paths.
+
+Read `SPEC.md` before making product or architectural changes. It is the canonical spec.
+
+## Current Status
+
+This repo is pre-alpha scaffolding. Treat the visible desktop UI as a static shell unless you have verified otherwise.
+
+Implemented today:
+
+- Tauri 2 + React 18 + TypeScript + Vite desktop shell.
+- Static frontend layout: title bar, sidebar, tab strip, workspace placeholder, bottom panel, AI panel, status bar.
+- Cargo and pnpm workspaces.
+- Placeholder Rust crates and TypeScript packages.
+
+Not implemented yet:
+
+- Tauri command layer and generated IPC bindings.
+- Real connection management.
+- Credential storage.
+- Postgres/MySQL/SQLite/SQL Server/Azure SQL drivers.
+- Schema introspection.
+- SQL editor.
+- Query execution and cancellation.
+- Data grid.
+- Pending edit diff/review/commit flow.
+- AI providers and context pipeline.
+- Plugin runtime.
+- Meaningful tests, linting, CI, signing, updater, or packaging gates.
+
+## Architecture
+
+Workspace layout:
+
+- `apps/desktop/` - Tauri app shell, React frontend, Rust app entrypoint.
+- `crates/cellar-core/` - shared traits, errors, schema/query types.
+- `crates/cellar-drivers/` - first-party database drivers.
+- `crates/cellar-sql/` - SQL parsing, formatting, dialect support.
+- `crates/cellar-diff/` - pending grid edits to transactional SQL.
+- `crates/cellar-secrets/` - OS keychain and encrypted fallback credential storage.
+- `crates/cellar-plugin-host/` - plugin process/runtime host.
+- `packages/ui/` - shared UI primitives and design tokens.
+- `packages/data-grid/` - custom virtualized grid package.
+- `packages/sql-editor/` - CodeMirror 6 SQL editor wrapper.
+- `packages/ipc/` - generated TypeScript bindings from Rust commands.
+- `packages/ai/` - AI provider adapters, prompts, context building.
+- `packages/plugin-sdk/` - plugin authoring interfaces and helpers.
+
+The intended runtime is:
+
+React frontend -> typed Tauri IPC -> Rust command/state layer -> driver traits in `cellar-core` -> concrete drivers in `cellar-drivers`.
+
+Large query results should stream through Tauri events keyed by query ID. Do not design APIs that require loading huge result sets into memory at once.
+
+## Build And Validation
+
+Common checks from the repo root:
+
+```bash
+pnpm typecheck
+pnpm build
+cargo check --workspace
+cargo test --workspace
+pnpm lint
+pnpm test
+```
+
+Current caveat: `pnpm lint` and `pnpm test` are scaffold-era gates. They run real checks, but they are not substitutes for future ESLint/Vitest/Playwright coverage once the app has behavior to protect.
+
+Use Clawpatch for automated review when preparing substantial work:
+
+```bash
+clawpatch doctor
+clawpatch review --include-dirty
+```
+
+If Clawpatch reports findings, triage them before claiming the project is ready to ship.
+
+## Coding Rules
+
+- Keep changes scoped. Avoid broad refactors while the architecture is still being made real.
+- Prefer repo patterns over inventing new ones.
+- Use `rg` for searches.
+- Use `apply_patch` for manual edits.
+- Do not revert user changes.
+- Do not commit generated build artifacts such as `dist/` or `target/`.
+- Add dependencies only when they match the spec or are clearly necessary for the current slice.
+- Keep frontend TypeScript strict.
+- Keep Rust errors typed; avoid stringly-typed backend contracts.
+- Generated IPC types should come from Rust command/type definitions, not hand-maintained duplicates.
+
+## Security And Privacy
+
+- Never write database credentials to plain-text config.
+- Store credentials through `cellar-secrets` once implemented: OS keychain first, encrypted fallback only with explicit user-controlled master password.
+- Keep Tauri capabilities narrow. Frontend must not gain arbitrary shell or file access.
+- Do not send credentials to AI providers.
+- AI context must be inspectable before sending.
+- Destructive SQL needs explicit confirmation, especially on production-tagged connections.
+- Production-tagged connections should be visually distinct and may default to read-only.
+
+## UI And Product Notes
+
+- The UI should be dense, technical, and work-focused.
+- Dark theme is default. Light theme should remain possible.
+- Spec says design tokens belong in `packages/ui/src/tokens/`; current scaffold keeps them in `apps/desktop/src/styles/tokens.css`.
+- The spec calls for CSS variables plus selective shadcn/ui source ownership. Tailwind is listed in the spec but is not currently installed.
+- Use keyboard-first interaction patterns. The command palette is `Cmd+K`.
+- Use monospace for SQL, identifiers, and data.
+- Avoid telemetry, cloud sync, collaboration, ETL/job orchestration, and admin/cluster-management features for v1.
+
+## Suggested Implementation Order
+
+The best next vertical slice is:
+
+1. Define core Rust types and traits in `cellar-core`.
+2. Add typed Tauri command modules under `apps/desktop/src-tauri/src/commands/`.
+3. Generate/import TypeScript IPC bindings through `packages/ipc`.
+4. Implement minimal Postgres connection storage, connect, schema introspection, and simple query execution.
+5. Replace static sidebar data with real connection/schema state.
+6. Add a basic CodeMirror editor and read-only results grid.
+7. Add tests around every backend contract before expanding engines or edit flows.
+
+Do not start with the AI panel, plugin marketplace, or multi-engine breadth before the connection/query spine works end-to-end.
+
+## Known Spec Gaps To Resolve
+
+- `SPEC.md` describes plugin loading two ways: dynamic libraries/C ABI in one section, out-of-process JSON-RPC later. Prefer out-of-process JSON-RPC for crash isolation unless an ADR changes it.
+- `SPEC.md` references docs that do not exist yet, including `docs/keymap.md`, `docs/architecture/open-questions.md`, driver authoring docs, plugin authoring docs, and `CONTRIBUTING.md`.
+- Tauri config currently has `csp: null`; this is not acceptable for a security-ready build.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Cellar contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -8,6 +8,8 @@
     "dev:web": "vite",
     "build": "tsc --noEmit && vite build",
     "build:tauri": "tauri build",
+    "lint": "tsc --noEmit",
+    "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit",
     "tauri": "tauri"
   },

--- a/package.json
+++ b/package.json
@@ -7,14 +7,15 @@
   "packageManager": "pnpm@9.0.0",
   "scripts": {
     "dev": "pnpm --filter @cellar/desktop dev",
-    "build": "turbo run build",
-    "lint": "turbo run lint",
-    "test": "turbo run test",
-    "typecheck": "turbo run typecheck"
+    "build": "node scripts/turbo-guard.mjs build",
+    "lint": "cargo fmt --all --check && node scripts/turbo-guard.mjs lint",
+    "test": "cargo test --workspace && node scripts/turbo-guard.mjs test && pnpm typecheck",
+    "typecheck": "node scripts/turbo-guard.mjs typecheck"
   },
   "devDependencies": {
     "turbo": "^2.1.0",
-    "typescript": "^5.5.4"
+    "typescript": "^5.5.4",
+    "vitest": "^2.1.9"
   },
   "engines": {
     "node": ">=20",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -5,6 +5,10 @@
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
+  "scripts": {
+    "lint": "node ../../scripts/check-ts-entry.mjs src/index.ts",
+    "test": "vitest run --passWithNoTests"
+  },
   "exports": {
     ".": "./src/index.ts"
   }

--- a/packages/data-grid/package.json
+++ b/packages/data-grid/package.json
@@ -5,6 +5,10 @@
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
+  "scripts": {
+    "lint": "node ../../scripts/check-ts-entry.mjs src/index.ts",
+    "test": "vitest run --passWithNoTests"
+  },
   "exports": {
     ".": "./src/index.ts"
   }

--- a/packages/ipc/package.json
+++ b/packages/ipc/package.json
@@ -5,6 +5,10 @@
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
+  "scripts": {
+    "lint": "node ../../scripts/check-ts-entry.mjs src/index.ts src/index.test.ts",
+    "test": "vitest run"
+  },
   "exports": {
     ".": "./src/index.ts"
   }

--- a/packages/ipc/src/index.test.ts
+++ b/packages/ipc/src/index.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+describe("@cellar/ipc scaffold", () => {
+  it("has no hand-written IPC surface before bindings are generated", async () => {
+    const module = await import("./index");
+
+    expect(Object.keys(module)).toEqual([]);
+  });
+});

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -5,6 +5,10 @@
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
+  "scripts": {
+    "lint": "node ../../scripts/check-ts-entry.mjs src/index.ts",
+    "test": "vitest run --passWithNoTests"
+  },
   "exports": {
     ".": "./src/index.ts"
   }

--- a/packages/sql-editor/package.json
+++ b/packages/sql-editor/package.json
@@ -5,6 +5,10 @@
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
+  "scripts": {
+    "lint": "node ../../scripts/check-ts-entry.mjs src/index.ts",
+    "test": "vitest run --passWithNoTests"
+  },
   "exports": {
     ".": "./src/index.ts"
   }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,6 +5,10 @@
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
+  "scripts": {
+    "lint": "node ../../scripts/check-ts-entry.mjs src/index.ts",
+    "test": "vitest run --passWithNoTests"
+  },
   "exports": {
     ".": "./src/index.ts"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       typescript:
         specifier: ^5.5.4
         version: 5.9.3
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@20.19.41)
 
   apps/desktop:
     dependencies:
@@ -567,6 +570,39 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   baseline-browser-mapping@2.10.32:
     resolution: {integrity: sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==}
     engines: {node: '>=6.0.0'}
@@ -577,8 +613,20 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -595,8 +643,15 @@ packages:
       supports-color:
         optional: true
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   electron-to-chromium@1.5.361:
     resolution: {integrity: sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
@@ -606,6 +661,13 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -633,8 +695,14 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -647,6 +715,13 @@ packages:
   node-releases@2.0.46:
     resolution: {integrity: sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==}
     engines: {node: '>=18'}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -680,9 +755,36 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   turbo@2.9.14:
     resolution: {integrity: sha512-BQqXRr4UoWI3UPFrtznCLykYHxwxWh53iCB57x092jPMjIlW1wnm3N895g5irpiXmnxUhREBB0n6+y8BHhs4nw==}
@@ -701,6 +803,11 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
 
   vite@5.4.21:
     resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
@@ -732,6 +839,36 @@ packages:
         optional: true
       terser:
         optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -1132,6 +1269,48 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@20.19.41))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@20.19.41)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
+  assertion-error@2.0.1: {}
+
   baseline-browser-mapping@2.10.32: {}
 
   browserslist@4.28.2:
@@ -1142,7 +1321,19 @@ snapshots:
       node-releases: 2.0.46
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
+  cac@6.7.14: {}
+
   caniuse-lite@1.0.30001793: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
 
   convert-source-map@2.0.0: {}
 
@@ -1152,7 +1343,11 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  deep-eql@5.0.2: {}
+
   electron-to-chromium@1.5.361: {}
+
+  es-module-lexer@1.7.0: {}
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -1182,6 +1377,12 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
   fsevents@2.3.3:
     optional: true
 
@@ -1197,15 +1398,25 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@3.2.1: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   ms@2.1.3: {}
 
   nanoid@3.3.12: {}
 
   node-releases@2.0.46: {}
+
+  pathe@1.1.2: {}
+
+  pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -1264,7 +1475,23 @@ snapshots:
 
   semver@6.3.1: {}
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
 
   turbo@2.9.14:
     optionalDependencies:
@@ -1285,6 +1512,24 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
+  vite-node@2.1.9(@types/node@20.19.41):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@20.19.41)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite@5.4.21(@types/node@20.19.41):
     dependencies:
       esbuild: 0.21.5
@@ -1293,5 +1538,45 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.41
       fsevents: 2.3.3
+
+  vitest@2.1.9(@types/node@20.19.41):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@20.19.41))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@20.19.41)
+      vite-node: 2.1.9(@types/node@20.19.41)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.41
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   yallist@3.1.1: {}

--- a/scripts/check-ts-entry.mjs
+++ b/scripts/check-ts-entry.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+
+const entries = process.argv.slice(2);
+
+if (entries.length === 0) {
+  console.error("usage: node scripts/check-ts-entry.mjs <file.ts> [...file.ts]");
+  process.exit(2);
+}
+
+const tsc = process.platform === "win32" ? "tsc.cmd" : "tsc";
+const result = spawnSync(
+  tsc,
+  [
+    "--noEmit",
+    "--target",
+    "ES2022",
+    "--module",
+    "ESNext",
+    "--moduleResolution",
+    "bundler",
+    "--lib",
+    "ES2022,DOM,DOM.Iterable",
+    "--strict",
+    "--noUncheckedIndexedAccess",
+    "--noImplicitOverride",
+    "--isolatedModules",
+    "--resolveJsonModule",
+    "--skipLibCheck",
+    "--forceConsistentCasingInFileNames",
+    ...entries,
+  ],
+  {
+    cwd: process.cwd(),
+    stdio: "inherit",
+  },
+);
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);

--- a/scripts/turbo-guard.mjs
+++ b/scripts/turbo-guard.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+
+const [task, ...extraArgs] = process.argv.slice(2);
+
+if (!task) {
+  console.error("usage: node scripts/turbo-guard.mjs <task> [...turbo args]");
+  process.exit(2);
+}
+
+const pnpm = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+const result = spawnSync(
+  pnpm,
+  ["exec", "turbo", "run", task, ...extraArgs],
+  {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    stdio: ["inherit", "pipe", "pipe"],
+  },
+);
+
+if (result.stdout) process.stdout.write(result.stdout);
+if (result.stderr) process.stderr.write(result.stderr);
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+if (result.status !== 0) {
+  process.exit(result.status ?? 1);
+}
+
+const output = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+const ranZeroTasks =
+  /\bTasks:\s+0 successful,\s+0 total\b/.test(output) ||
+  /\bNo tasks were executed as part of this run\./.test(output);
+
+if (ranZeroTasks) {
+  console.error(
+    `turbo run ${task} completed without executing any tasks; add workspace scripts or remove this release gate.`,
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

- Add a root AGENTS.md with project-specific guidance for future coding agents.
- Add the MIT LICENSE file promised by package metadata and README.
- Add guarded Turbo release gates plus workspace lint/test scripts so checks cannot pass with zero tasks.
- Add Vitest wiring and a small @cellar/ipc scaffold smoke test.

## Why

The project is pre-alpha, but the repo should have honest build/readiness signals before deeper implementation starts. Clawpatch flagged false-green lint/test commands and missing license text; this PR resolves those findings.

## Validation

- pnpm build
- pnpm lint
- pnpm test
- pnpm typecheck
- cargo check --workspace
- cargo test --workspace
- cargo fmt --all --check
- clawpatch revalidate --all --include-dirty: 4 fixed, 0 open
