### PR TITLE
docs: document file length limit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,7 @@ If Clawpatch reports findings, triage them before claiming the project is ready 
 - Keep Rust errors typed; avoid stringly-typed backend contracts.
 - Generated IPC types should come from Rust command/type definitions, not hand-maintained duplicates.
 - Pull request titles must not use `codex:` or `[codex]` prefixes. Use conventional prefixes such as `feat:`, `fix:`, `bug:`, `chore:`, `docs:`, `test:`, `build:`, `ci:`, or `refactor:`.
+- No human-authored source, documentation, or configuration file may exceed 800 lines. If a file approaches that size, split it by responsibility before adding more code. Generated lockfiles and binary assets are exempt, but do not hand-edit them except through their owning tools.
 
 ## Security And Privacy
 


### PR DESCRIPTION
## Summary

- Add the project rule that human-authored source, documentation, and configuration files should not exceed 800 lines.
- Clarify that generated lockfiles and binary assets are exempt because they cannot be split meaningfully.

## Validation

- pnpm typecheck
