### PR TITLE
feat: implement connection, commit, command palette, and empty state modals

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { TitleBar } from "./components/TitleBar";
 import { StatusBar } from "./components/StatusBar";
 import { Sidebar } from "./components/Sidebar";
@@ -6,8 +6,13 @@ import { TabBar } from "./components/TabBar";
 import { Workspace } from "./components/Workspace";
 import { BottomPanel } from "./components/BottomPanel";
 import { AIPanel } from "./components/AIPanel";
+import { ConnectionDialog } from "./components/modals/ConnectionDialog";
+import { CommitModal } from "./components/modals/CommitModal";
+import { CommandPalette } from "./components/modals/CommandPalette";
+import { EmptyState } from "./components/modals/EmptyState";
 
 type Panels = { left: boolean; right: boolean; bottom: boolean };
+type ModalId = "connection" | "commit" | "palette" | null;
 
 export function App() {
   const [panels, setPanels] = useState<Panels>({
@@ -15,32 +20,73 @@ export function App() {
     right: true,
     bottom: true,
   });
+  const [modal, setModal] = useState<ModalId>(null);
+  const [empty, setEmpty] = useState(false);
 
-  const togglePanel = (k: keyof Panels) =>
-    setPanels((p) => ({ ...p, [k]: !p[k] }));
+  const togglePanel = useCallback(
+    (k: keyof Panels) => setPanels((p) => ({ ...p, [k]: !p[k] })),
+    [],
+  );
+
+  const openModal = useCallback((m: ModalId) => setModal(m), []);
+  const closeModal = useCallback(() => setModal(null), []);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const mod = e.metaKey || e.ctrlKey;
+      if (mod && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        setModal((m) => (m === "palette" ? null : "palette"));
+        return;
+      }
+      if (mod && e.key.toLowerCase() === "n" && !e.shiftKey) {
+        e.preventDefault();
+        setModal("connection");
+        return;
+      }
+      if (mod && e.key.toLowerCase() === "s") {
+        e.preventDefault();
+        setModal("commit");
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
 
   return (
-    <div className="cellar-app">
-      <TitleBar panels={panels} onTogglePanel={togglePanel} />
+    <div className={"cellar-app" + (empty ? " cellar-app-empty" : "")}>
+      <TitleBar
+        panels={panels}
+        onTogglePanel={togglePanel}
+        empty={empty}
+        onToggleEmpty={() => setEmpty((v) => !v)}
+        onOpenPalette={() => openModal("palette")}
+      />
 
       <div className="cellar-main">
-        {panels.left && (
+        {!empty && panels.left && (
           <div className="cellar-pane cellar-pane-left" style={{ width: 256 }}>
-            <Sidebar />
+            <Sidebar onNewConnection={() => openModal("connection")} />
           </div>
         )}
 
         <div className="cellar-center">
-          <TabBar />
-          <Workspace />
-          {panels.bottom && (
-            <div className="cellar-bottom">
-              <BottomPanel onClose={() => togglePanel("bottom")} />
-            </div>
+          {empty ? (
+            <EmptyState onNew={() => openModal("connection")} />
+          ) : (
+            <>
+              <TabBar />
+              <Workspace onCommit={() => openModal("commit")} />
+              {panels.bottom && (
+                <div className="cellar-bottom">
+                  <BottomPanel onClose={() => togglePanel("bottom")} />
+                </div>
+              )}
+            </>
           )}
         </div>
 
-        {panels.right && (
+        {!empty && panels.right && (
           <div className="cellar-pane cellar-pane-right" style={{ width: 380 }}>
             <AIPanel onClose={() => togglePanel("right")} />
           </div>
@@ -48,6 +94,10 @@ export function App() {
       </div>
 
       <StatusBar />
+
+      {modal === "connection" && <ConnectionDialog onClose={closeModal} />}
+      {modal === "commit" && <CommitModal onClose={closeModal} />}
+      {modal === "palette" && <CommandPalette onClose={closeModal} />}
     </div>
   );
 }

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -44,7 +44,11 @@ function StatusDot({ status }: { status: ConnStatus }) {
   );
 }
 
-export function Sidebar() {
+export function Sidebar({
+  onNewConnection,
+}: {
+  onNewConnection?: () => void;
+} = {}) {
   const [filter, setFilter] = useState("");
   const meta = { color: "var(--eng-postgres)" };
   return (
@@ -55,7 +59,11 @@ export function Sidebar() {
           <span className="sb-header-count mono">{SAMPLE_CONNECTIONS.length}</span>
         </div>
         <div className="sb-header-actions">
-          <button className="icon-btn" title="New connection">
+          <button
+            className="icon-btn"
+            title="New connection"
+            onClick={onNewConnection}
+          >
             <Icon.plus size={12} />
           </button>
           <button className="icon-btn" title="More">
@@ -183,7 +191,7 @@ export function Sidebar() {
           </div>
         ))}
 
-        <button className="sb-add-connection">
+        <button className="sb-add-connection" onClick={onNewConnection}>
           <Icon.plus size={11} />
           <span>New connection</span>
         </button>

--- a/apps/desktop/src/components/TitleBar.tsx
+++ b/apps/desktop/src/components/TitleBar.tsx
@@ -5,9 +5,15 @@ type Panels = { left: boolean; right: boolean; bottom: boolean };
 export function TitleBar({
   panels,
   onTogglePanel,
+  empty,
+  onToggleEmpty,
+  onOpenPalette,
 }: {
   panels: Panels;
   onTogglePanel: (k: keyof Panels) => void;
+  empty?: boolean;
+  onToggleEmpty?: () => void;
+  onOpenPalette?: () => void;
 }) {
   return (
     <div className="cellar-titlebar">
@@ -21,26 +27,30 @@ export function TitleBar({
           <span className="cellar-brand-mark" />
           <span className="cellar-brand-name">Cellar</span>
         </div>
-        <div className="cellar-titlebar-divider" />
-        <div className="cellar-breadcrumbs">
-          <button className="cellar-bc">
-            <Icon.database size={12} />
-            <span>shop-eu (prod)</span>
-          </button>
-          <Icon.chevronRight size={11} style={{ opacity: 0.4 }} />
-          <button className="cellar-bc">
-            <span style={{ color: "var(--eng-postgres)" }}>●</span>
-            <span>shop_eu</span>
-          </button>
-          <Icon.chevronRight size={11} style={{ opacity: 0.4 }} />
-          <button className="cellar-bc">
-            <Icon.schema size={11} />
-            <span>public</span>
-          </button>
-        </div>
+        {!empty && (
+          <>
+            <div className="cellar-titlebar-divider" />
+            <div className="cellar-breadcrumbs">
+              <button className="cellar-bc">
+                <Icon.database size={12} />
+                <span>shop-eu (prod)</span>
+              </button>
+              <Icon.chevronRight size={11} style={{ opacity: 0.4 }} />
+              <button className="cellar-bc">
+                <span style={{ color: "var(--eng-postgres)" }}>●</span>
+                <span>shop_eu</span>
+              </button>
+              <Icon.chevronRight size={11} style={{ opacity: 0.4 }} />
+              <button className="cellar-bc">
+                <Icon.schema size={11} />
+                <span>public</span>
+              </button>
+            </div>
+          </>
+        )}
       </div>
 
-      <button className="cellar-cmdk">
+      <button className="cellar-cmdk" onClick={onOpenPalette}>
         <Icon.search size={11} />
         <span className="cellar-cmdk-text">Search tables, columns, queries…</span>
         <span className="cellar-cmdk-kbd">
@@ -50,28 +60,41 @@ export function TitleBar({
       </button>
 
       <div className="cellar-titlebar-right">
-        <button
-          className={"icon-btn" + (panels.left ? " active" : "")}
-          onClick={() => onTogglePanel("left")}
-          title="Toggle connections panel"
-        >
-          <Icon.panelLeft size={13} />
-        </button>
-        <button
-          className={"icon-btn" + (panels.bottom ? " active" : "")}
-          onClick={() => onTogglePanel("bottom")}
-          title="Toggle output panel"
-        >
-          <Icon.panelBottom size={13} />
-        </button>
-        <button
-          className={"icon-btn" + (panels.right ? " active" : "")}
-          onClick={() => onTogglePanel("right")}
-          title="Toggle AI panel"
-        >
-          <Icon.panelRight size={13} />
-        </button>
-        <div className="cellar-titlebar-divider" />
+        {!empty && (
+          <>
+            <button
+              className={"icon-btn" + (panels.left ? " active" : "")}
+              onClick={() => onTogglePanel("left")}
+              title="Toggle connections panel"
+            >
+              <Icon.panelLeft size={13} />
+            </button>
+            <button
+              className={"icon-btn" + (panels.bottom ? " active" : "")}
+              onClick={() => onTogglePanel("bottom")}
+              title="Toggle output panel"
+            >
+              <Icon.panelBottom size={13} />
+            </button>
+            <button
+              className={"icon-btn" + (panels.right ? " active" : "")}
+              onClick={() => onTogglePanel("right")}
+              title="Toggle AI panel"
+            >
+              <Icon.panelRight size={13} />
+            </button>
+            <div className="cellar-titlebar-divider" />
+          </>
+        )}
+        {onToggleEmpty && (
+          <button
+            className={"icon-btn" + (empty ? " active" : "")}
+            onClick={onToggleEmpty}
+            title={empty ? "Show workspace" : "Show empty state"}
+          >
+            <Icon.layout size={13} />
+          </button>
+        )}
         <button className="icon-btn" title="Settings">
           <Icon.settings size={13} />
         </button>

--- a/apps/desktop/src/components/Workspace.tsx
+++ b/apps/desktop/src/components/Workspace.tsx
@@ -1,6 +1,6 @@
 import { Icon } from "./icons";
 
-export function Workspace() {
+export function Workspace({ onCommit }: { onCommit?: () => void } = {}) {
   return (
     <div className="cellar-workspace">
       <div className="ws-placeholder">
@@ -28,6 +28,20 @@ export function Workspace() {
             <kbd className="kbd">I</kbd>&nbsp;ask AI
           </span>
         </div>
+        {onCommit && (
+          <button
+            className="ed-run subtle"
+            onClick={onCommit}
+            style={{ marginTop: 4 }}
+            title="Open the commit review modal"
+          >
+            <Icon.commit size={11} />
+            <span>Review &amp; commit (4 pending)</span>
+            <kbd className="kbd" style={{ marginLeft: 4 }}>
+              ⌘S
+            </kbd>
+          </button>
+        )}
       </div>
     </div>
   );

--- a/apps/desktop/src/components/icons.tsx
+++ b/apps/desktop/src/components/icons.tsx
@@ -35,6 +35,7 @@ const I = ({
 export const Icon = {
   chevronRight: (p: IconProps) => <I {...p} d="M9 6l6 6-6 6" />,
   chevronDown: (p: IconProps) => <I {...p} d="M6 9l6 6 6-6" />,
+  chevronLeft: (p: IconProps) => <I {...p} d="M15 6l-6 6 6 6" />,
   chevronsDown: (p: IconProps) => (
     <I {...p}>
       <path d="M6 6l6 6 6-6" />
@@ -201,6 +202,46 @@ export const Icon = {
       <path d="M12 3v18M9 6L6 9l3 3M15 18l3-3-3-3" />
     </I>
   ),
+  commit: (p: IconProps) => (
+    <I {...p}>
+      <circle cx="12" cy="12" r="4" />
+      <path d="M16 12h6M2 12h6" />
+    </I>
+  ),
+  copy: (p: IconProps) => (
+    <I {...p}>
+      <rect x="9" y="9" width="11" height="11" rx="1.5" />
+      <path d="M5 15H4a1 1 0 01-1-1V4a1 1 0 011-1h10a1 1 0 011 1v1" />
+    </I>
+  ),
+  edit: (p: IconProps) => (
+    <I {...p} d="M11 4H5a2 2 0 00-2 2v12a2 2 0 002 2h12a2 2 0 002-2v-6M18 2l4 4-10 10H8v-4z" />
+  ),
+  undo: (p: IconProps) => (
+    <I {...p} d="M3 8h10a5 5 0 010 10H8M3 8l4-4M3 8l4 4" />
+  ),
+  ssh: (p: IconProps) => (
+    <I {...p}>
+      <rect x="2" y="4" width="20" height="16" rx="1.5" />
+      <path d="M6 9l3 3-3 3M13 15h5" />
+    </I>
+  ),
+  cloud: (p: IconProps) => (
+    <I
+      {...p}
+      d="M17.5 19a4.5 4.5 0 000-9c-.4-2.8-2.8-5-5.7-5a5.8 5.8 0 00-5.6 4.3A4.4 4.4 0 002 14a4 4 0 004 4z"
+    />
+  ),
+  bolt: (p: IconProps) => (
+    <I {...p} fill="currentColor" stroke="none" d="M13 2L4 14h6l-1 8 9-12h-6z" />
+  ),
+  layout: (p: IconProps) => (
+    <I {...p}>
+      <rect x="3" y="3" width="18" height="18" rx="1.5" />
+      <path d="M3 9h18M9 9v12" />
+    </I>
+  ),
+  bracket: (p: IconProps) => <I {...p} d="M8 4H4v16h4M16 4h4v16h-4" />,
 };
 
 export type IconName = keyof typeof Icon;

--- a/apps/desktop/src/components/modals/CommandPalette.tsx
+++ b/apps/desktop/src/components/modals/CommandPalette.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useState, type ReactNode } from "react";
+import { Icon } from "../icons";
+
+type Group = "Recent" | "Actions" | "Navigate" | "AI" | "View";
+
+type Entry = {
+  grp: Group;
+  label: string;
+  hint?: string;
+  kbd?: string[];
+};
+
+const ENTRIES: Entry[] = [
+  { grp: "Recent", label: "public.orders", hint: "table" },
+  { grp: "Recent", label: "revenue_by_country.sql", hint: "query tab" },
+  { grp: "Recent", label: "shop-eu (prod)", hint: "connection" },
+  { grp: "Actions", label: "Run current statement", hint: "executes statement under cursor", kbd: ["⌘", "⏎"] },
+  { grp: "Actions", label: "Run all", hint: "executes the full editor", kbd: ["⌘", "⇧", "⏎"] },
+  { grp: "Actions", label: "Commit pending changes", hint: "review SQL diff before commit", kbd: ["⌘", "S"] },
+  { grp: "Actions", label: "Revert pending changes", hint: "discard 4 staged edits", kbd: ["⌘", "⇧", "Z"] },
+  { grp: "Navigate", label: "Go to table…", hint: "search across all schemas", kbd: ["⌘", "O"] },
+  { grp: "Navigate", label: "Go to column…", hint: "fuzzy across catalog", kbd: ["⌘", "⇧", "O"] },
+  { grp: "Navigate", label: "Switch connection…", hint: "6 connections", kbd: ["⌘", "K", "C"] },
+  { grp: "AI", label: "Ask AI about selected text", hint: "starts a new thread", kbd: ["⌘", "L"] },
+  { grp: "AI", label: "Generate query from prompt…", hint: "context: public.orders", kbd: ["⌘", "I"] },
+  { grp: "AI", label: "Explain selected SQL", hint: "shows plan + line notes" },
+  { grp: "View", label: "Split editor horizontally", kbd: ["⌘", "\\"] },
+  { grp: "View", label: "Split editor vertically", kbd: ["⌘", "⇧", "\\"] },
+  { grp: "View", label: "Toggle AI panel", kbd: ["⌘", "J"] },
+];
+
+function groupIcon(grp: Group): ReactNode {
+  switch (grp) {
+    case "AI":
+      return <Icon.sparkles size={11} stroke="var(--accent)" />;
+    case "Actions":
+      return <Icon.bolt size={11} stroke="var(--update)" />;
+    case "Navigate":
+      return <Icon.chevronRight size={11} stroke="var(--fg-2)" />;
+    case "View":
+      return <Icon.layout size={11} stroke="var(--fg-2)" />;
+    case "Recent":
+      return <Icon.history size={11} stroke="var(--fg-2)" />;
+  }
+}
+
+export function CommandPalette({ onClose }: { onClose: () => void }) {
+  const [q, setQ] = useState("");
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const filtered = q
+    ? ENTRIES.filter((c) => c.label.toLowerCase().includes(q.toLowerCase()))
+    : ENTRIES;
+
+  const grouped: Record<string, Entry[]> = {};
+  for (const c of filtered) (grouped[c.grp] ||= []).push(c);
+
+  return (
+    <div className="modal-scrim cmd-scrim" onClick={onClose}>
+      <div className="cmd-shell" onClick={(e) => e.stopPropagation()}>
+        <div className="cmd-input">
+          <Icon.search size={13} stroke="var(--fg-3)" />
+          <input
+            placeholder="Search tables, columns, commands, AI prompts…"
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            autoFocus
+          />
+          <span className="kbd">esc</span>
+        </div>
+
+        <div className="cmd-list">
+          {Object.entries(grouped).map(([grp, items]) => (
+            <div key={grp} className="cmd-group">
+              <div className="cmd-group-head">{grp}</div>
+              {items.map((c, i) => (
+                <button
+                  key={c.label}
+                  className={
+                    "cmd-item" + (grp === "Recent" && i === 0 ? " active" : "")
+                  }
+                >
+                  <span className="cmd-item-icon">{groupIcon(grp as Group)}</span>
+                  <span className="cmd-item-label">{c.label}</span>
+                  {c.hint && <span className="cmd-item-hint">{c.hint}</span>}
+                  {c.kbd && (
+                    <span className="cmd-item-kbd">
+                      {c.kbd.map((k, j) => (
+                        <kbd key={j} className="kbd">
+                          {k}
+                        </kbd>
+                      ))}
+                    </span>
+                  )}
+                </button>
+              ))}
+            </div>
+          ))}
+          {filtered.length === 0 && (
+            <div
+              style={{
+                padding: "20px 14px",
+                fontSize: 11.5,
+                color: "var(--fg-3)",
+                textAlign: "center",
+              }}
+            >
+              No matches for &ldquo;{q}&rdquo;
+            </div>
+          )}
+        </div>
+
+        <div className="cmd-foot">
+          <span>
+            <kbd className="kbd">↑↓</kbd>
+            <span>navigate</span>
+          </span>
+          <span>
+            <kbd className="kbd">⏎</kbd>
+            <span>select</span>
+          </span>
+          <span>
+            <kbd className="kbd">⌘⏎</kbd>
+            <span>open in new tab</span>
+          </span>
+          <div style={{ flex: 1 }} />
+          <span>
+            <Icon.sparkles size={10} stroke="var(--accent)" />
+            <span style={{ color: "var(--accent)" }}>type / to ask AI</span>
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/modals/CommitModal.tsx
+++ b/apps/desktop/src/components/modals/CommitModal.tsx
@@ -1,0 +1,318 @@
+import { Icon } from "../icons";
+import { Modal } from "./Modal";
+import { tokenizeSql, tokensToLines, renderTokens } from "../../lib/sqlTokens";
+
+type Edit = { from: string | number | null; to: string | number | null };
+type UpdateChange = {
+  kind: "update";
+  row: { order_number: string };
+  edits: Record<string, Edit>;
+};
+type InsertChange = { kind: "insert"; row: Record<string, unknown> };
+type DeleteChange = { kind: "delete"; row: { order_number: string } };
+export type Change = UpdateChange | InsertChange | DeleteChange;
+
+export type ChangeSet = Record<string, Change>;
+
+/* Demo changeset matching the design's commit preview. */
+export const SAMPLE_CHANGES: ChangeSet = {
+  "0a14b9b2-7f6c-4f2d-8a17-3e9f30caa101": {
+    kind: "update",
+    row: { order_number: "EU-0184237" },
+    edits: {
+      status: { from: "paid", to: "fulfilled" },
+      shipping_method: { from: "standard", to: "express" },
+    },
+  },
+  "2c4dd1a3-9914-4d12-9f8b-1c0e0a3bbf24": {
+    kind: "update",
+    row: { order_number: "EU-0184244" },
+    edits: {
+      status: { from: "paid", to: "cancelled" },
+      notes: { from: null, to: "customer requested cancel" },
+    },
+  },
+  "9f1c2c50-22d0-43a8-9d12-aa3f6e5210ef": {
+    kind: "insert",
+    row: {
+      id: "9f1c2c50-22d0-43a8-9d12-aa3f6e5210ef",
+      order_number: "EU-0184902",
+      customer_id: "1d4e2-...",
+      status: "pending",
+      total_eur: 84.5,
+      currency: "EUR",
+      channel: "web",
+      country: "DE",
+    },
+  },
+  "ba27e1f8-1d61-4b09-bc44-9e102239f48a": {
+    kind: "delete",
+    row: { order_number: "EU-0184121" },
+  },
+};
+
+function formatVal(v: unknown): string {
+  if (v === null || v === undefined) return "NULL";
+  if (typeof v === "number") return String(v);
+  return "'" + v + "'";
+}
+
+export function CommitModal({
+  onClose,
+  changes = SAMPLE_CHANGES,
+  table = "orders",
+}: {
+  onClose: () => void;
+  changes?: ChangeSet;
+  table?: string;
+}) {
+  const entries = Object.entries(changes);
+  const updates = entries.filter(([, c]) => c.kind === "update") as [
+    string,
+    UpdateChange,
+  ][];
+  const inserts = entries.filter(([, c]) => c.kind === "insert") as [
+    string,
+    InsertChange,
+  ][];
+  const deletes = entries.filter(([, c]) => c.kind === "delete") as [
+    string,
+    DeleteChange,
+  ][];
+
+  const sqlLines: string[] = ["BEGIN;", ""];
+  updates.forEach(([id, c]) => {
+    sqlLines.push(`-- ${c.row.order_number} · updated by alice@laptop`);
+    sqlLines.push(`UPDATE public.${table}`);
+    const sets = Object.entries(c.edits).map(
+      ([col, e]) => `  ${col} = ${formatVal(e.to)}`,
+    );
+    sqlLines.push("SET");
+    sqlLines.push(sets.join(",\n"));
+    sqlLines.push(`WHERE id = '${id}';`);
+    sqlLines.push("");
+  });
+  inserts.forEach(([id, c]) => {
+    const cols = Object.keys(c.row);
+    const vals = cols.map((k) => formatVal(c.row[k]));
+    sqlLines.push(
+      `INSERT INTO public.${table} (${cols.join(", ")})`,
+    );
+    sqlLines.push(`VALUES (${vals.join(", ")});`);
+    sqlLines.push("");
+    void id;
+  });
+  deletes.forEach(([id, c]) => {
+    sqlLines.push(`-- ${c.row.order_number} · marked for deletion`);
+    sqlLines.push(`DELETE FROM public.${table} WHERE id = '${id}';`);
+    sqlLines.push("");
+  });
+  sqlLines.push("COMMIT;");
+  const lines = tokensToLines(tokenizeSql(sqlLines.join("\n")));
+
+  return (
+    <Modal onClose={onClose} width={880}>
+      <div className="cd-head">
+        <div className="cd-head-left">
+          <span className="cd-head-icon">
+            <Icon.commit size={14} />
+          </span>
+          <span className="cd-head-title">Review &amp; commit</span>
+          <span className="cm-target">
+            public.{table} <span style={{ color: "var(--fg-3)" }}>·</span>{" "}
+            shop-eu (prod)
+          </span>
+        </div>
+        <button className="icon-btn" onClick={onClose} title="Close">
+          <Icon.close size={13} />
+        </button>
+      </div>
+
+      <div className="cm-summary">
+        <div className="cm-summary-item">
+          <span
+            className="cm-summary-icon"
+            style={{ background: "var(--insert-bg)", color: "var(--insert)" }}
+          >
+            <Icon.plus size={11} />
+          </span>
+          <span className="cm-summary-n tnum mono">{inserts.length}</span>
+          <span className="cm-summary-label">
+            insert{inserts.length === 1 ? "" : "s"}
+          </span>
+        </div>
+        <div className="cm-summary-item">
+          <span
+            className="cm-summary-icon"
+            style={{ background: "var(--update-bg)", color: "var(--update)" }}
+          >
+            <Icon.diff size={11} />
+          </span>
+          <span className="cm-summary-n tnum mono">{updates.length}</span>
+          <span className="cm-summary-label">
+            update{updates.length === 1 ? "" : "s"}
+          </span>
+        </div>
+        <div className="cm-summary-item">
+          <span
+            className="cm-summary-icon"
+            style={{ background: "var(--delete-bg)", color: "var(--delete)" }}
+          >
+            <Icon.close size={11} />
+          </span>
+          <span className="cm-summary-n tnum mono">{deletes.length}</span>
+          <span className="cm-summary-label">
+            delete{deletes.length === 1 ? "" : "s"}
+          </span>
+        </div>
+        <div className="cm-summary-spacer" />
+        <span className="cm-summary-tx mono">
+          <Icon.bracket size={10} />
+          <span>BEGIN … COMMIT — atomic</span>
+        </span>
+      </div>
+
+      <div className="cm-body">
+        <div className="cm-changes">
+          <div className="cm-changes-head">
+            <span>Changes</span>
+            <span className="cm-changes-count mono">{entries.length}</span>
+          </div>
+          <div className="cm-changes-list">
+            {updates.map(([id, c]) => (
+              <div key={id} className="cm-change cm-change-update">
+                <span className="cm-change-tag">UPDATE</span>
+                <div className="cm-change-body">
+                  <div className="cm-change-row">
+                    <span className="cm-change-id">{c.row.order_number}</span>
+                    <span style={{ color: "var(--fg-3)" }}>·</span>
+                    <span
+                      className="mono"
+                      style={{ color: "var(--fg-3)", fontSize: 10 }}
+                    >
+                      {id.slice(0, 8)}
+                    </span>
+                  </div>
+                  {Object.entries(c.edits).map(([col, e]) => (
+                    <div key={col} className="cm-edit">
+                      <span className="cm-edit-col">{col}</span>
+                      <span className="cm-edit-from">{formatVal(e.from)}</span>
+                      <Icon.chevronRight size={10} stroke="var(--fg-3)" />
+                      <span className="cm-edit-to">{formatVal(e.to)}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+            {inserts.map(([id, c]) => (
+              <div key={id} className="cm-change cm-change-insert">
+                <span className="cm-change-tag">INSERT</span>
+                <div className="cm-change-body">
+                  <div className="cm-change-row">
+                    <span className="cm-change-id">
+                      {String((c.row as { order_number?: string }).order_number ?? "new")}
+                    </span>
+                    <span style={{ color: "var(--fg-3)" }}>·</span>
+                    <span
+                      className="mono"
+                      style={{ color: "var(--fg-3)", fontSize: 10 }}
+                    >
+                      new
+                    </span>
+                  </div>
+                  <div
+                    className="cm-edit"
+                    style={{
+                      color: "var(--fg-2)",
+                      gridTemplateColumns: "1fr",
+                    }}
+                  >
+                    new row · {Object.keys(c.row).length} columns set
+                  </div>
+                </div>
+              </div>
+            ))}
+            {deletes.map(([id, c]) => (
+              <div key={id} className="cm-change cm-change-delete">
+                <span className="cm-change-tag">DELETE</span>
+                <div className="cm-change-body">
+                  <div className="cm-change-row">
+                    <span
+                      className="cm-change-id"
+                      style={{ textDecoration: "line-through" }}
+                    >
+                      {c.row.order_number}
+                    </span>
+                    <span style={{ color: "var(--fg-3)" }}>·</span>
+                    <span
+                      className="mono"
+                      style={{ color: "var(--fg-3)", fontSize: 10 }}
+                    >
+                      {id.slice(0, 8)}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="cm-sql">
+          <div className="cm-sql-head">
+            <span>Generated SQL</span>
+            <div className="cm-sql-head-right">
+              <button className="cd-pick">
+                <Icon.edit size={11} />
+                <span>Edit</span>
+              </button>
+              <button className="cd-pick">
+                <Icon.copy size={11} />
+                <span>Copy</span>
+              </button>
+            </div>
+          </div>
+          <div className="cm-sql-body mono">
+            {lines.map((toks, i) => (
+              <div key={i} className="cm-sql-line">
+                <span className="cm-sql-ln">{i + 1}</span>
+                <span className="cm-sql-text">{renderTokens(toks)}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="cd-foot">
+        <div className="cd-foot-left">
+          <label className="cd-check">
+            <input type="checkbox" defaultChecked /> Rollback on error
+          </label>
+          <label className="cd-check">
+            <input type="checkbox" defaultChecked /> Confirm if rows affected
+            &gt; 100
+          </label>
+          <span className="cm-foot-warn">
+            <Icon.warn size={10} stroke="var(--warn)" />
+            <span style={{ color: "var(--warn)" }}>prod</span>
+            <span style={{ color: "var(--fg-2)" }}>
+              · you'll be asked to type the connection name
+            </span>
+          </span>
+        </div>
+        <div className="cd-foot-right">
+          <button className="ed-run subtle" onClick={onClose}>
+            Cancel
+          </button>
+          <button className="ed-run subtle">
+            <Icon.undo size={11} />
+            <span>Save as migration</span>
+          </button>
+          <button className="ed-run primary danger">
+            <Icon.commit size={11} />
+            <span>Commit transaction</span>
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/desktop/src/components/modals/ConnectionDialog.tsx
+++ b/apps/desktop/src/components/modals/ConnectionDialog.tsx
@@ -1,0 +1,450 @@
+import { useEffect, useState, type ReactNode } from "react";
+import { Icon } from "../icons";
+import { ENGINE_META, type Engine } from "../EngineBadge";
+import { Modal } from "./Modal";
+
+const ENGINE_ORDER: Engine[] = ["postgres", "mssql", "azure", "mysql", "sqlite"];
+
+const ENGINE_HEX: Record<Engine, string> = {
+  postgres: "#4f8ff7",
+  mysql: "#f6a44a",
+  mssql: "#d97a5a",
+  azure: "#5bb8e0",
+  sqlite: "#a78bfa",
+};
+
+const SWATCH_COLORS = ["#4f8ff7", "#f6a44a", "#d97a5a", "#5bb8e0", "#a78bfa", "#4ade80", "#f87171"];
+
+const DEFAULT_PORT: Record<Engine, string> = {
+  postgres: "5432",
+  mysql: "3306",
+  mssql: "1433",
+  azure: "1433",
+  sqlite: "—",
+};
+
+type Auth = "password" | "kerberos" | "azure-ad" | "managed-id" | "windows";
+type Tab = "general" | "ssh" | "ssl" | "options";
+
+export function ConnectionDialog({ onClose }: { onClose: () => void }) {
+  const [engine, setEngine] = useState<Engine>("postgres");
+  const [tab, setTab] = useState<Tab>("general");
+  const [auth, setAuth] = useState<Auth>("password");
+  const [ssh, setSsh] = useState(false);
+  const [ssl, setSsl] = useState(true);
+  const [swatch, setSwatch] = useState<string>(ENGINE_HEX.postgres);
+
+  useEffect(() => {
+    if (engine === "azure") setAuth("azure-ad");
+    else if (auth === "azure-ad" && engine !== "mssql") setAuth("password");
+    setSwatch(ENGINE_HEX[engine]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [engine]);
+
+  return (
+    <Modal onClose={onClose} width={760}>
+      <div className="cd-head">
+        <div className="cd-head-left">
+          <span className="cd-head-icon">
+            <Icon.database size={14} />
+          </span>
+          <span className="cd-head-title">New connection</span>
+        </div>
+        <button className="icon-btn" onClick={onClose} title="Close">
+          <Icon.close size={13} />
+        </button>
+      </div>
+
+      <div className="cd-body">
+        <div className="cd-engines">
+          {ENGINE_ORDER.map((e) => {
+            const m = ENGINE_META[e];
+            const hex = ENGINE_HEX[e];
+            const active = engine === e;
+            return (
+              <button
+                key={e}
+                className={"cd-engine" + (active ? " active" : "")}
+                onClick={() => setEngine(e)}
+              >
+                <span
+                  className="cd-engine-letter mono"
+                  style={{
+                    color: hex,
+                    background: `color-mix(in oklab, ${hex} 14%, transparent)`,
+                    borderColor: `color-mix(in oklab, ${hex} 30%, transparent)`,
+                  }}
+                >
+                  {m.letter}
+                </span>
+                <span className="cd-engine-name">{m.label}</span>
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="cd-tabs">
+          {(["general", "ssh", "ssl", "options"] as Tab[]).map((t) => (
+            <button
+              key={t}
+              className={"cd-tab" + (tab === t ? " active" : "")}
+              onClick={() => setTab(t)}
+            >
+              {t === "general" && <Icon.database size={11} />}
+              {t === "ssh" && <Icon.ssh size={11} />}
+              {t === "ssl" && <Icon.lock size={11} />}
+              {t === "options" && <Icon.settings size={11} />}
+              <span>
+                {t === "ssh"
+                  ? "SSH tunnel"
+                  : t === "ssl"
+                    ? "SSL / TLS"
+                    : t}
+              </span>
+              {t === "ssh" && ssh && <span className="cd-tab-dot" />}
+              {t === "ssl" && ssl && <span className="cd-tab-dot" />}
+            </button>
+          ))}
+        </div>
+
+        {tab === "general" && (
+          <div className="cd-form">
+            <FormRow label="Name" hint="Shown in the sidebar">
+              <input className="cd-input" defaultValue="shop-eu (prod)" />
+            </FormRow>
+
+            <FormRow label="Host">
+              <input
+                className="cd-input mono"
+                defaultValue="prod-pg.internal.shop.eu"
+                style={{ flex: 1 }}
+              />
+              <span className="cd-form-sep">:</span>
+              <input
+                className="cd-input mono cd-input-port"
+                defaultValue={DEFAULT_PORT[engine]}
+              />
+            </FormRow>
+
+            {engine !== "sqlite" && (
+              <FormRow label="Database">
+                <input className="cd-input mono" defaultValue="shop_eu" />
+              </FormRow>
+            )}
+
+            {engine === "sqlite" && (
+              <FormRow label="File">
+                <input
+                  className="cd-input mono"
+                  defaultValue="~/projects/shop/local.db"
+                  style={{ flex: 1 }}
+                />
+                <button className="cd-pick">
+                  <Icon.fileText size={11} />
+                  <span>Browse</span>
+                </button>
+              </FormRow>
+            )}
+
+            <FormRow label="Auth">
+              <div className="cd-segment">
+                <button
+                  className={"cd-seg" + (auth === "password" ? " active" : "")}
+                  onClick={() => setAuth("password")}
+                >
+                  Password
+                </button>
+                {engine === "postgres" && (
+                  <button
+                    className={"cd-seg" + (auth === "kerberos" ? " active" : "")}
+                    onClick={() => setAuth("kerberos")}
+                  >
+                    Kerberos
+                  </button>
+                )}
+                {(engine === "azure" || engine === "mssql") && (
+                  <button
+                    className={"cd-seg" + (auth === "azure-ad" ? " active" : "")}
+                    onClick={() => setAuth("azure-ad")}
+                  >
+                    Azure AD
+                  </button>
+                )}
+                {engine === "azure" && (
+                  <button
+                    className={
+                      "cd-seg" + (auth === "managed-id" ? " active" : "")
+                    }
+                    onClick={() => setAuth("managed-id")}
+                  >
+                    Managed identity
+                  </button>
+                )}
+                {(engine === "mssql" || engine === "azure") && (
+                  <button
+                    className={"cd-seg" + (auth === "windows" ? " active" : "")}
+                    onClick={() => setAuth("windows")}
+                  >
+                    Windows
+                  </button>
+                )}
+              </div>
+            </FormRow>
+
+            {auth === "password" && (
+              <>
+                <FormRow label="User">
+                  <input className="cd-input mono" defaultValue="analytics_ro" />
+                </FormRow>
+                <FormRow label="Password" hint="Stored in OS keychain">
+                  <input
+                    className="cd-input mono"
+                    type="password"
+                    defaultValue="••••••••••••••"
+                    style={{ flex: 1 }}
+                  />
+                  <label className="cd-check">
+                    <input type="checkbox" /> save
+                  </label>
+                </FormRow>
+              </>
+            )}
+
+            {auth === "azure-ad" && (
+              <>
+                <FormRow label="Tenant" hint="leave empty for default">
+                  <input
+                    className="cd-input mono"
+                    placeholder="contoso.onmicrosoft.com"
+                  />
+                </FormRow>
+                <FormRow label="Account">
+                  <div className="cd-azure-account">
+                    <span className="cd-azure-avatar">A</span>
+                    <span>alice@contoso.com</span>
+                    <button className="cd-link">change</button>
+                  </div>
+                </FormRow>
+              </>
+            )}
+
+            {auth === "managed-id" && (
+              <FormRow label="Client ID" hint="user-assigned identity">
+                <input
+                  className="cd-input mono"
+                  placeholder="(system-assigned)"
+                />
+              </FormRow>
+            )}
+
+            <div className="cd-divider" />
+
+            <FormRow
+              label="Accent"
+              hint="visual marker — protects against running on prod by mistake"
+            >
+              <div className="cd-swatches">
+                {SWATCH_COLORS.map((c) => (
+                  <button
+                    key={c}
+                    className={"cd-swatch" + (c === swatch ? " active" : "")}
+                    style={{ background: c }}
+                    onClick={() => setSwatch(c)}
+                    title={c}
+                  />
+                ))}
+              </div>
+            </FormRow>
+
+            <FormRow label="Environment">
+              <div className="cd-segment">
+                <button className="cd-seg active">prod</button>
+                <button className="cd-seg">staging</button>
+                <button className="cd-seg">dev</button>
+                <button className="cd-seg">local</button>
+              </div>
+              <span className="cd-warn">
+                <Icon.warn size={10} />
+                <span>prod requires confirmation for DML</span>
+              </span>
+            </FormRow>
+          </div>
+        )}
+
+        {tab === "ssh" && (
+          <div className="cd-form">
+            <FormRow label="Use SSH tunnel">
+              <Toggle on={ssh} onChange={setSsh} />
+            </FormRow>
+            {ssh && (
+              <>
+                <FormRow label="SSH host">
+                  <input
+                    className="cd-input mono"
+                    defaultValue="bastion.shop.eu"
+                    style={{ flex: 1 }}
+                  />
+                  <span className="cd-form-sep">:</span>
+                  <input
+                    className="cd-input mono cd-input-port"
+                    defaultValue="22"
+                  />
+                </FormRow>
+                <FormRow label="SSH user">
+                  <input className="cd-input mono" defaultValue="alice" />
+                </FormRow>
+                <FormRow label="Auth">
+                  <div className="cd-segment">
+                    <button className="cd-seg active">Key pair</button>
+                    <button className="cd-seg">Password</button>
+                    <button className="cd-seg">Agent</button>
+                  </div>
+                </FormRow>
+                <FormRow label="Private key">
+                  <input
+                    className="cd-input mono"
+                    defaultValue="~/.ssh/id_ed25519"
+                    style={{ flex: 1 }}
+                  />
+                  <button className="cd-pick">
+                    <Icon.fileText size={11} />
+                    <span>Browse</span>
+                  </button>
+                </FormRow>
+              </>
+            )}
+          </div>
+        )}
+
+        {tab === "ssl" && (
+          <div className="cd-form">
+            <FormRow label="Use SSL / TLS">
+              <Toggle on={ssl} onChange={setSsl} />
+            </FormRow>
+            {ssl && (
+              <>
+                <FormRow label="SSL mode">
+                  <div className="cd-segment">
+                    <button className="cd-seg">disable</button>
+                    <button className="cd-seg">prefer</button>
+                    <button className="cd-seg">require</button>
+                    <button className="cd-seg active">verify-full</button>
+                  </div>
+                </FormRow>
+                <FormRow label="Server CA">
+                  <input
+                    className="cd-input mono"
+                    defaultValue="~/.cellar/certs/shop-eu-ca.pem"
+                    style={{ flex: 1 }}
+                  />
+                </FormRow>
+                <FormRow label="Client cert" hint="optional, for mTLS">
+                  <input
+                    className="cd-input mono"
+                    placeholder="…"
+                    style={{ flex: 1 }}
+                  />
+                </FormRow>
+              </>
+            )}
+          </div>
+        )}
+
+        {tab === "options" && (
+          <div className="cd-form">
+            <FormRow label="Read-only by default">
+              <Toggle on={true} />
+            </FormRow>
+            <FormRow label="Connection timeout">
+              <input
+                className="cd-input mono cd-input-port"
+                defaultValue="10"
+              />
+              <span style={{ color: "var(--fg-3)" }}>seconds</span>
+            </FormRow>
+            <FormRow label="Application name">
+              <input
+                className="cd-input mono"
+                defaultValue="cellar (alice@laptop)"
+              />
+            </FormRow>
+            <FormRow label="Schema search path">
+              <input
+                className="cd-input mono"
+                defaultValue="public, audit, analytics"
+              />
+            </FormRow>
+          </div>
+        )}
+      </div>
+
+      <div className="cd-foot">
+        <div className="cd-foot-left">
+          <button className="ed-run subtle">
+            <Icon.power size={11} />
+            <span>Test connection</span>
+          </button>
+          <span className="cd-foot-status">
+            <Icon.check size={10} stroke="var(--accent)" />
+            <span style={{ color: "var(--accent)" }}>Connected</span>
+            <span style={{ color: "var(--fg-3)" }}>·</span>
+            <span style={{ color: "var(--fg-2)" }} className="mono">
+              214 ms
+            </span>
+            <span style={{ color: "var(--fg-3)" }}>·</span>
+            <span style={{ color: "var(--fg-2)" }} className="mono">
+              PostgreSQL 16.2 on x86_64-linux-gnu
+            </span>
+          </span>
+        </div>
+        <div className="cd-foot-right">
+          <button className="ed-run subtle" onClick={onClose}>
+            Cancel
+          </button>
+          <button className="ed-run primary">
+            <Icon.plus size={11} />
+            <span>Save &amp; connect</span>
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+function FormRow({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="cd-row">
+      <div className="cd-row-label">
+        <span>{label}</span>
+        {hint && <span className="cd-row-hint">{hint}</span>}
+      </div>
+      <div className="cd-row-content">{children}</div>
+    </div>
+  );
+}
+
+function Toggle({
+  on,
+  onChange,
+}: {
+  on: boolean;
+  onChange?: (v: boolean) => void;
+}) {
+  return (
+    <button
+      className={"cd-toggle" + (on ? " on" : "")}
+      onClick={() => onChange?.(!on)}
+      type="button"
+    >
+      <span className="cd-toggle-knob" />
+    </button>
+  );
+}

--- a/apps/desktop/src/components/modals/EmptyState.tsx
+++ b/apps/desktop/src/components/modals/EmptyState.tsx
@@ -1,0 +1,105 @@
+import { Icon } from "../icons";
+import { ENGINE_META, type Engine } from "../EngineBadge";
+
+const ENGINE_ORDER: Engine[] = ["postgres", "mssql", "azure", "mysql", "sqlite"];
+
+const ENGINE_HEX: Record<Engine, string> = {
+  postgres: "#4f8ff7",
+  mysql: "#f6a44a",
+  mssql: "#d97a5a",
+  azure: "#5bb8e0",
+  sqlite: "#a78bfa",
+};
+
+const SHORT: Record<Engine, string> = {
+  postgres: "Postgres",
+  mysql: "MySQL",
+  mssql: "MSSQL",
+  azure: "Azure",
+  sqlite: "SQLite",
+};
+
+export function EmptyState({ onNew }: { onNew: () => void }) {
+  return (
+    <div className="empty-root">
+      <div className="empty-card">
+        <div className="empty-logo">
+          <span className="empty-logo-mark" />
+        </div>
+        <h1 className="empty-title">Welcome to Cellar</h1>
+        <p className="empty-sub">
+          A fast, native database client with AI built in. Open-source, BYO key.
+        </p>
+
+        <div className="empty-actions">
+          <button className="empty-action primary" onClick={onNew}>
+            <Icon.plus size={12} />
+            <span>New connection</span>
+          </button>
+          <button className="empty-action">
+            <Icon.fileText size={12} />
+            <span>Import from DataGrip / DBeaver</span>
+          </button>
+          <button className="empty-action">
+            <Icon.cloud size={12} />
+            <span>Connect to demo database</span>
+          </button>
+        </div>
+
+        <div className="empty-engines-label">or pick an engine to start</div>
+        <div className="empty-engines">
+          {ENGINE_ORDER.map((e) => {
+            const m = ENGINE_META[e];
+            const hex = ENGINE_HEX[e];
+            return (
+              <button
+                key={e}
+                className="empty-engine"
+                onClick={onNew}
+                title={m.label}
+              >
+                <span
+                  className="empty-engine-letter mono"
+                  style={{
+                    color: hex,
+                    background: `color-mix(in oklab, ${hex} 12%, transparent)`,
+                    borderColor: `color-mix(in oklab, ${hex} 30%, transparent)`,
+                  }}
+                >
+                  {m.letter}
+                </span>
+                <span className="empty-engine-name">{SHORT[e]}</span>
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="empty-shortcut-row">
+          <span className="empty-shortcut">
+            <kbd className="kbd">⌘</kbd>
+            <kbd className="kbd">K</kbd>
+            <span>command palette</span>
+          </span>
+          <span className="empty-shortcut">
+            <kbd className="kbd">⌘</kbd>
+            <kbd className="kbd">N</kbd>
+            <span>new connection</span>
+          </span>
+          <span className="empty-shortcut">
+            <kbd className="kbd">⌘</kbd>
+            <kbd className="kbd">,</kbd>
+            <span>settings</span>
+          </span>
+        </div>
+
+        <div className="empty-foot">
+          <span>
+            v0.1.0 · MIT licensed ·{" "}
+            <button className="cd-link">docs</button> ·{" "}
+            <button className="cd-link">github</button>
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/modals/Modal.tsx
+++ b/apps/desktop/src/components/modals/Modal.tsx
@@ -1,0 +1,33 @@
+import { useEffect, type ReactNode } from "react";
+
+export function Modal({
+  children,
+  onClose,
+  width = 720,
+  height,
+}: {
+  children: ReactNode;
+  onClose: () => void;
+  width?: number;
+  height?: number;
+}) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  return (
+    <div className="modal-scrim" onClick={onClose}>
+      <div
+        className="modal-shell"
+        style={{ width, height }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/lib/sqlTokens.tsx
+++ b/apps/desktop/src/lib/sqlTokens.tsx
@@ -1,0 +1,120 @@
+import { Fragment, type ReactNode } from "react";
+
+export type Token = { kind: TokKind; text: string };
+export type TokKind =
+  | "kw"
+  | "fn"
+  | "str"
+  | "num"
+  | "comment"
+  | "op"
+  | "tbl"
+  | "ident"
+  | "ws"
+  | "nl";
+
+const KEYWORDS = new Set([
+  "select", "from", "where", "and", "or", "not", "in", "is", "null", "as",
+  "join", "left", "right", "inner", "outer", "on", "group", "by", "order",
+  "having", "limit", "offset", "with", "case", "when", "then", "else", "end",
+  "insert", "into", "values", "update", "set", "delete", "begin", "commit",
+  "rollback", "create", "alter", "drop", "table", "view", "index", "if",
+  "exists", "filter", "distinct", "interval", "now", "between", "like",
+  "ilike", "nulls", "first", "last", "asc", "desc", "returning", "default",
+]);
+
+const FUNCTIONS = new Set([
+  "count", "sum", "avg", "min", "max", "round", "nullif", "coalesce",
+  "date_trunc", "now", "concat", "length", "lower", "upper",
+]);
+
+const isSpace = (c: string) => c === " " || c === "\t";
+const isDigit = (c: string) => c >= "0" && c <= "9";
+const isAlpha = (c: string) =>
+  (c >= "a" && c <= "z") || (c >= "A" && c <= "Z") || c === "_";
+const isAlphaNum = (c: string) => isAlpha(c) || isDigit(c);
+
+/** Tokenize a single SQL string, preserving whitespace and newlines. */
+export function tokenizeSql(sql: string): Token[] {
+  const out: Token[] = [];
+  let i = 0;
+  while (i < sql.length) {
+    const ch = sql.charAt(i);
+    if (ch === "\n") {
+      out.push({ kind: "nl", text: "\n" });
+      i++;
+      continue;
+    }
+    if (isSpace(ch)) {
+      let j = i;
+      while (j < sql.length && isSpace(sql.charAt(j))) j++;
+      out.push({ kind: "ws", text: sql.slice(i, j) });
+      i = j;
+      continue;
+    }
+    if (ch === "-" && sql.charAt(i + 1) === "-") {
+      let j = i;
+      while (j < sql.length && sql.charAt(j) !== "\n") j++;
+      out.push({ kind: "comment", text: sql.slice(i, j) });
+      i = j;
+      continue;
+    }
+    if (ch === "'") {
+      let j = i + 1;
+      while (j < sql.length && sql.charAt(j) !== "'") j++;
+      j++;
+      out.push({ kind: "str", text: sql.slice(i, j) });
+      i = j;
+      continue;
+    }
+    if (isDigit(ch)) {
+      let j = i;
+      while (j < sql.length) {
+        const c = sql.charAt(j);
+        if (!(isDigit(c) || c === ".")) break;
+        j++;
+      }
+      out.push({ kind: "num", text: sql.slice(i, j) });
+      i = j;
+      continue;
+    }
+    if (isAlpha(ch)) {
+      let j = i;
+      while (j < sql.length && isAlphaNum(sql.charAt(j))) j++;
+      const word = sql.slice(i, j);
+      const lower = word.toLowerCase();
+      let kind: TokKind = "ident";
+      if (KEYWORDS.has(lower)) kind = "kw";
+      else if (FUNCTIONS.has(lower) && sql.charAt(j) === "(") kind = "fn";
+      else if (i > 0 && sql.charAt(i - 1) === ".") kind = "tbl";
+      out.push({ kind, text: word });
+      i = j;
+      continue;
+    }
+    out.push({ kind: "op", text: ch });
+    i++;
+  }
+  return out;
+}
+
+/** Split tokens into one array per source line. */
+export function tokensToLines(tokens: Token[]): Token[][] {
+  const lines: Token[][] = [[]];
+  for (const t of tokens) {
+    if (t.kind === "nl") lines.push([]);
+    else (lines[lines.length - 1] as Token[]).push(t);
+  }
+  return lines;
+}
+
+export function renderTokens(tokens: Token[]): ReactNode {
+  return tokens.map((t, i) => {
+    if (t.kind === "ws") return t.text;
+    const cls = `syn-${t.kind}`;
+    return (
+      <Fragment key={i}>
+        <span className={cls}>{t.text}</span>
+      </Fragment>
+    );
+  });
+}

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -6,3 +6,4 @@
 @import "./workspace.css";
 @import "./bottom.css";
 @import "./ai.css";
+@import "./modals.css";

--- a/apps/desktop/src/styles/modals.css
+++ b/apps/desktop/src/styles/modals.css
@@ -1,0 +1,821 @@
+/* Modal shell, Connection dialog, Commit review, Command palette, Empty state.
+   Mirrors the Cellar design bundle (database-editor/project/app/styles-4.css). */
+
+/* ─────────────────────────────────────────────────────────────
+   Modal shell
+   ───────────────────────────────────────────────────────────── */
+.modal-scrim {
+  position: fixed;
+  inset: 0;
+  background: var(--bg-overlay);
+  backdrop-filter: blur(4px);
+  z-index: 100;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 8vh;
+  animation: scrim-in 0.18s ease-out;
+}
+@keyframes scrim-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.modal-shell {
+  background: var(--bg-1);
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+  box-shadow: var(--shadow-lg);
+  max-height: 84vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: modal-in 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+}
+@keyframes modal-in {
+  from { opacity: 0; transform: translateY(-6px) scale(0.99); }
+  to { opacity: 1; transform: none; }
+}
+
+/* Shared filled / outlined button used by modal footers (matches ed-run). */
+.ed-run {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 26px;
+  padding: 0 10px;
+  border-radius: 4px;
+  font-size: 11.5px;
+  font-weight: 500;
+  color: var(--fg-1);
+  white-space: nowrap;
+  transition: background 0.12s, color 0.12s, border-color 0.12s, filter 0.12s;
+  border: 1px solid transparent;
+}
+.ed-run.primary {
+  background: var(--accent);
+  color: var(--accent-fg);
+  border-color: color-mix(in oklab, var(--accent) 30%, black);
+}
+.ed-run.primary:hover { filter: brightness(1.07); }
+.ed-run.primary:disabled { opacity: 0.4; cursor: not-allowed; }
+.ed-run.primary.danger {
+  background: var(--delete);
+  border-color: color-mix(in oklab, var(--delete) 40%, black);
+  color: white;
+}
+.ed-run.subtle {
+  background: transparent;
+  color: var(--fg-1);
+  border-color: var(--border-default);
+}
+.ed-run.subtle:hover { background: var(--bg-3); border-color: var(--border-strong); color: var(--fg-0); }
+.ed-run.subtle:disabled { opacity: 0.4; cursor: not-allowed; }
+
+/* ─────────────────────────────────────────────────────────────
+   Connection dialog
+   ───────────────────────────────────────────────────────────── */
+.cd-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 38px;
+  padding: 0 8px 0 14px;
+  border-bottom: 1px solid var(--border-default);
+  flex-shrink: 0;
+}
+.cd-head-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.cd-head-icon { color: var(--accent); display: inline-flex; }
+.cd-head-title { font-size: 12.5px; font-weight: 600; color: var(--fg-0); white-space: nowrap; }
+
+.cd-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 16px 16px;
+}
+
+.cd-engines {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 6px;
+  margin-bottom: 14px;
+}
+.cd-engine {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 6px 9px;
+  background: var(--bg-2);
+  border: 1px solid var(--border-default);
+  border-radius: 6px;
+  transition: all 0.15s;
+}
+.cd-engine:hover { border-color: var(--border-strong); }
+.cd-engine.active { box-shadow: 0 0 0 1px var(--accent) inset; }
+
+.cd-engine-letter {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  font-size: 13px;
+  font-weight: 600;
+  border: 1px solid;
+  border-radius: 6px;
+  font-family: var(--font-mono);
+}
+.cd-engine-name { font-size: 10.5px; color: var(--fg-1); }
+.cd-engine.active .cd-engine-name { color: var(--fg-0); font-weight: 500; }
+
+.cd-tabs {
+  display: flex;
+  gap: 2px;
+  border-bottom: 1px solid var(--border-default);
+  margin-bottom: 14px;
+}
+.cd-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 26px;
+  padding: 0 10px;
+  font-size: 11.5px;
+  color: var(--fg-2);
+  border-bottom: 1.5px solid transparent;
+  margin-bottom: -1px;
+  text-transform: capitalize;
+  position: relative;
+}
+.cd-tab:hover { color: var(--fg-0); }
+.cd-tab.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+.cd-tab-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--accent);
+  margin-left: 2px;
+}
+
+.cd-form { display: flex; flex-direction: column; gap: 10px; }
+
+.cd-row {
+  display: grid;
+  grid-template-columns: 110px 1fr;
+  align-items: center;
+  gap: 12px;
+  min-height: 24px;
+}
+.cd-row-label {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  font-size: 11.5px;
+  color: var(--fg-1);
+  font-weight: 500;
+  padding-top: 2px;
+}
+.cd-row-hint { font-size: 10px; color: var(--fg-3); font-weight: 400; }
+.cd-row-content {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11.5px;
+  min-width: 0;
+}
+
+.cd-input {
+  height: 26px;
+  padding: 0 8px;
+  background: var(--bg-inset);
+  border: 1px solid var(--border-default);
+  border-radius: 4px;
+  font-size: 11.5px;
+  color: var(--fg-0);
+  outline: none;
+  font-family: var(--font-sans);
+  min-width: 0;
+  flex: 1;
+}
+.cd-input.mono { font-family: var(--font-mono); }
+.cd-input:focus { border-color: var(--accent-line); background: var(--bg-2); }
+.cd-input-port { width: 70px; flex: none; }
+
+.cd-form-sep { color: var(--fg-3); }
+
+.cd-segment {
+  display: inline-flex;
+  background: var(--bg-inset);
+  border: 1px solid var(--border-default);
+  border-radius: 4px;
+  padding: 2px;
+  gap: 1px;
+}
+.cd-seg {
+  height: 20px;
+  padding: 0 10px;
+  font-size: 11px;
+  color: var(--fg-2);
+  border-radius: 3px;
+}
+.cd-seg:hover { color: var(--fg-0); }
+.cd-seg.active {
+  background: var(--bg-3);
+  color: var(--fg-0);
+  font-weight: 500;
+}
+
+.cd-check {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  color: var(--fg-2);
+  cursor: pointer;
+}
+.cd-check input { accent-color: var(--accent); width: 12px; height: 12px; }
+
+.cd-pick {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 26px;
+  padding: 0 8px;
+  background: var(--bg-2);
+  border: 1px solid var(--border-default);
+  border-radius: 4px;
+  font-size: 11px;
+  color: var(--fg-1);
+}
+.cd-pick:hover { background: var(--bg-3); }
+
+.cd-link {
+  color: var(--accent);
+  font-size: 11px;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  background: none;
+}
+
+.cd-azure-account {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 8px 2px 2px;
+  background: var(--bg-inset);
+  border: 1px solid var(--border-default);
+  border-radius: 4px;
+  font-size: 11px;
+}
+.cd-azure-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  background: var(--eng-azure);
+  color: white;
+  border-radius: 3px;
+  font-size: 10px;
+  font-weight: 600;
+}
+
+.cd-divider {
+  height: 1px;
+  background: var(--border-divider);
+  margin: 4px 0;
+}
+
+.cd-swatches { display: flex; gap: 4px; }
+.cd-swatch {
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  transition: transform 0.1s;
+  padding: 0;
+}
+.cd-swatch:hover { transform: scale(1.1); }
+.cd-swatch.active { box-shadow: 0 0 0 2px var(--bg-1), 0 0 0 3px var(--fg-0); }
+
+.cd-warn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10.5px;
+  color: var(--warn);
+  margin-left: 8px;
+}
+
+.cd-toggle {
+  width: 28px;
+  height: 16px;
+  background: var(--bg-3);
+  border-radius: 10px;
+  position: relative;
+  transition: background 0.15s;
+  flex-shrink: 0;
+}
+.cd-toggle.on { background: var(--accent); }
+.cd-toggle-knob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+  background: white;
+  border-radius: 50%;
+  transition: left 0.15s;
+}
+.cd-toggle.on .cd-toggle-knob { left: 14px; }
+
+.cd-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 44px;
+  padding: 0 12px;
+  background: var(--bg-2);
+  border-top: 1px solid var(--border-default);
+  flex-shrink: 0;
+  gap: 12px;
+}
+.cd-foot-left,
+.cd-foot-right { display: flex; align-items: center; gap: 8px; }
+.cd-foot-status { display: inline-flex; align-items: center; gap: 5px; font-size: 11px; }
+
+/* ─────────────────────────────────────────────────────────────
+   Commit review modal
+   ───────────────────────────────────────────────────────────── */
+.cm-target {
+  font-size: 11px;
+  color: var(--fg-2);
+  font-family: var(--font-mono);
+  padding-left: 6px;
+  border-left: 1px solid var(--border-divider);
+  margin-left: 4px;
+}
+
+.cm-summary {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 10px 16px;
+  background: var(--bg-2);
+  border-bottom: 1px solid var(--border-default);
+  flex-shrink: 0;
+}
+.cm-summary-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.cm-summary-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 4px;
+}
+.cm-summary-n { font-size: 14px; font-weight: 600; color: var(--fg-0); }
+.cm-summary-label { font-size: 11px; color: var(--fg-2); }
+.cm-summary-spacer { flex: 1; }
+.cm-summary-tx {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 10.5px;
+  color: var(--fg-2);
+  padding: 4px 8px;
+  background: var(--bg-inset);
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+.cm-body {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.cm-changes {
+  border-right: 1px solid var(--border-default);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.cm-changes-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 26px;
+  padding: 0 12px;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--fg-3);
+  font-weight: 600;
+  border-bottom: 1px solid var(--border-divider);
+  flex-shrink: 0;
+}
+.cm-changes-count {
+  font-size: 10px;
+  padding: 1px 5px;
+  background: var(--bg-2);
+  color: var(--fg-2);
+  border-radius: 8px;
+  font-family: var(--font-mono);
+}
+.cm-changes-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 6px 0;
+}
+
+.cm-change {
+  display: flex;
+  gap: 8px;
+  padding: 6px 12px;
+  border-bottom: 1px dashed var(--border-divider);
+}
+.cm-change-tag {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  font-weight: 600;
+  padding: 1px 4px;
+  border-radius: 3px;
+  height: 14px;
+  align-self: flex-start;
+  letter-spacing: 0.04em;
+  margin-top: 1px;
+  display: inline-flex;
+  align-items: center;
+}
+.cm-change-update .cm-change-tag { background: var(--update-bg); color: var(--update); }
+.cm-change-insert .cm-change-tag { background: var(--insert-bg); color: var(--insert); }
+.cm-change-delete .cm-change-tag { background: var(--delete-bg); color: var(--delete); }
+.cm-change-body { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 3px; }
+.cm-change-row { display: flex; align-items: center; gap: 5px; font-size: 11px; }
+.cm-change-id { color: var(--fg-0); font-weight: 500; font-family: var(--font-mono); }
+.cm-edit {
+  display: grid;
+  grid-template-columns: 90px auto auto auto;
+  align-items: center;
+  gap: 5px;
+  font-size: 10.5px;
+  padding-left: 4px;
+  font-family: var(--font-mono);
+}
+.cm-edit-col { color: var(--fg-2); overflow: hidden; text-overflow: ellipsis; }
+.cm-edit-from {
+  color: var(--delete);
+  background: var(--delete-bg);
+  padding: 1px 5px;
+  border-radius: 3px;
+  text-decoration: line-through;
+  text-decoration-color: rgba(255, 255, 255, 0.2);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.cm-edit-to {
+  color: var(--accent);
+  background: var(--accent-soft);
+  padding: 1px 5px;
+  border-radius: 3px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cm-sql {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: var(--bg-inset);
+}
+.cm-sql-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 26px;
+  padding: 0 12px;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--fg-3);
+  font-weight: 600;
+  border-bottom: 1px solid var(--border-divider);
+  background: var(--bg-1);
+  flex-shrink: 0;
+}
+.cm-sql-head-right { display: flex; gap: 4px; }
+
+.cm-sql-body {
+  flex: 1;
+  overflow: auto;
+  padding: 8px 0;
+  font-size: 11.5px;
+  line-height: 1.55;
+}
+.cm-sql-line { display: flex; padding: 0 12px; }
+.cm-sql-ln {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  width: 28px;
+  padding-right: 10px;
+  color: var(--fg-3);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  user-select: none;
+  flex-shrink: 0;
+}
+.cm-sql-text { white-space: pre; font-family: var(--font-mono); }
+
+.cm-foot-warn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 10.5px;
+  margin-left: 8px;
+}
+
+/* Syntax-highlight pieces reused inside generated SQL */
+.syn-kw { color: var(--syn-kw); }
+.syn-fn { color: var(--syn-fn); }
+.syn-str { color: var(--syn-str); }
+.syn-num { color: var(--syn-num); }
+.syn-comment { color: var(--syn-comment); font-style: italic; }
+.syn-op { color: var(--syn-op); }
+.syn-tbl { color: var(--syn-tbl); }
+.syn-ident { color: var(--syn-ident); }
+
+/* ─────────────────────────────────────────────────────────────
+   Command palette
+   ───────────────────────────────────────────────────────────── */
+.cmd-scrim { padding-top: 14vh; }
+
+.cmd-shell {
+  width: 580px;
+  background: var(--bg-1);
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  animation: modal-in 0.18s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.cmd-input {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 0 12px;
+  height: 38px;
+  border-bottom: 1px solid var(--border-default);
+}
+.cmd-input input {
+  flex: 1;
+  background: none;
+  border: none;
+  outline: none;
+  font-size: 13px;
+  color: var(--fg-0);
+}
+.cmd-input input::placeholder { color: var(--fg-3); }
+
+.cmd-list {
+  max-height: 420px;
+  overflow-y: auto;
+  padding: 4px 0 8px;
+}
+
+.cmd-group { padding: 6px 0 4px; }
+.cmd-group-head {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--fg-3);
+  font-weight: 600;
+  padding: 2px 14px;
+}
+
+.cmd-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 14px;
+  font-size: 12px;
+  color: var(--fg-1);
+  cursor: pointer;
+  border: none;
+  background: none;
+  width: 100%;
+  text-align: left;
+}
+.cmd-item:hover { background: var(--bg-2); color: var(--fg-0); }
+.cmd-item.active { background: var(--accent-soft); color: var(--accent); }
+
+.cmd-item-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  flex-shrink: 0;
+}
+.cmd-item-label { font-weight: 500; white-space: nowrap; flex-shrink: 0; }
+.cmd-item-hint {
+  font-size: 11px;
+  color: var(--fg-3);
+  margin-left: auto;
+  padding-right: 6px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+.cmd-item-kbd { display: inline-flex; gap: 2px; flex-shrink: 0; }
+
+.cmd-foot {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 12px;
+  background: var(--bg-2);
+  border-top: 1px solid var(--border-default);
+  font-size: 10.5px;
+  color: var(--fg-3);
+}
+.cmd-foot span { display: inline-flex; align-items: center; gap: 4px; }
+
+/* ─────────────────────────────────────────────────────────────
+   Empty state
+   ───────────────────────────────────────────────────────────── */
+.empty-root {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-0);
+  position: relative;
+  overflow: hidden;
+}
+.empty-root::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image:
+    radial-gradient(circle at 30% 20%, var(--accent-soft), transparent 40%),
+    radial-gradient(circle at 70% 80%, color-mix(in oklab, var(--syn-kw) 10%, transparent), transparent 50%);
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.empty-card {
+  width: 540px;
+  padding: 36px 36px 28px;
+  background: var(--bg-1);
+  border: 1px solid var(--border-default);
+  border-radius: 12px;
+  box-shadow: var(--shadow-md);
+  position: relative;
+  text-align: center;
+}
+
+.empty-logo {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 18px;
+}
+.empty-logo-mark {
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  background: linear-gradient(135deg, #c4b5fd 0%, var(--accent) 55%, #6d4ed1 100%);
+  position: relative;
+  box-shadow: 0 0 24px var(--accent-soft);
+}
+.empty-logo-mark::after {
+  content: "";
+  position: absolute;
+  inset: 5px;
+  border-radius: 4px;
+  background: var(--bg-1);
+  clip-path: polygon(0 0, 100% 0, 100% 35%, 35% 35%, 35% 65%, 100% 65%, 100% 100%, 0 100%);
+}
+
+.empty-title {
+  font-size: 20px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0 0 4px;
+  color: var(--fg-0);
+}
+.empty-sub {
+  font-size: 12.5px;
+  color: var(--fg-2);
+  margin: 0 0 22px;
+  text-wrap: pretty;
+}
+
+.empty-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 22px;
+}
+.empty-action {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  justify-content: center;
+  height: 32px;
+  padding: 0 12px;
+  background: var(--bg-2);
+  border: 1px solid var(--border-default);
+  border-radius: 6px;
+  font-size: 12px;
+  color: var(--fg-0);
+  white-space: nowrap;
+  transition: background 0.12s, border-color 0.12s;
+}
+.empty-action:hover { background: var(--bg-3); border-color: var(--border-strong); }
+.empty-action.primary {
+  background: linear-gradient(135deg, #c4b5fd 0%, var(--accent) 55%, #6d4ed1 100%);
+  color: var(--accent-fg);
+  border-color: color-mix(in oklab, var(--accent) 40%, black);
+  font-weight: 500;
+}
+.empty-action.primary:hover { filter: brightness(1.07); }
+
+.empty-engines-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--fg-3);
+  margin-bottom: 8px;
+}
+.empty-engines {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 6px;
+  margin-bottom: 22px;
+}
+.empty-engine {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 6px 8px;
+  background: var(--bg-2);
+  border: 1px solid var(--border-default);
+  border-radius: 6px;
+  transition: all 0.15s;
+}
+.empty-engine:hover { border-color: var(--border-strong); transform: translateY(-1px); }
+.empty-engine-letter {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  font-size: 12px;
+  font-weight: 600;
+  border: 1px solid;
+  border-radius: 5px;
+  font-family: var(--font-mono);
+}
+.empty-engine-name { font-size: 10px; color: var(--fg-1); white-space: nowrap; }
+
+.empty-shortcut-row {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+.empty-shortcut {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10.5px;
+  color: var(--fg-3);
+  white-space: nowrap;
+}
+
+.empty-foot {
+  font-size: 10.5px;
+  color: var(--fg-3);
+  padding-top: 16px;
+  border-top: 1px solid var(--border-divider);
+}
+.empty-foot .cd-link { font-size: 10.5px; }


### PR DESCRIPTION
## Summary
- Builds 4 of the design bundle's deliverables that were missing from the v0.1.0 shell — based on the `Cellar.html` design handoff at `database-editor/project/`.
- **New connection dialog** ([ConnectionDialog.tsx](apps/desktop/src/components/modals/ConnectionDialog.tsx)) — engine picker with per-engine letter tiles, General / SSH / SSL / Options sub-tabs, conditional auth methods per engine (Password / Kerberos / Azure AD / Managed identity / Windows), accent swatches, environment segment with prod-DML warning, test-connection footer.
- **Review & commit modal** ([CommitModal.tsx](apps/desktop/src/components/modals/CommitModal.tsx)) — summary tiles, UPDATE / INSERT / DELETE change list with from→to diff pills, generated SQL panel with line numbers and tokenized highlighting via a small SQL tokenizer ([sqlTokens.tsx](apps/desktop/src/lib/sqlTokens.tsx)), prod-confirmation footer.
- **Command palette** ([CommandPalette.tsx](apps/desktop/src/components/modals/CommandPalette.tsx)) — grouped fuzzy search (Recent / Actions / Navigate / AI / View), keyboard-hint kbds, `/ → ask AI` footer.
- **Empty state** ([EmptyState.tsx](apps/desktop/src/components/modals/EmptyState.tsx)) — welcome card with primary actions, engine quick-picks, shortcut row, gradient backdrop.
- Wiring in [App.tsx](apps/desktop/src/App.tsx): ⌘K opens the palette, ⌘N opens the connection dialog, ⌘S opens the commit modal, and a layout toggle in the title bar flips the workspace into the empty state for demoing.

### Notes / known follow-ups
- The "Review & commit" trigger currently lives in the workspace placeholder. Per the original design it belongs on the data grid's pending-changes footer (`3 updates, 1 insert · Review & Commit · Revert`); it'll move there when the grid is built.
- Static demo data only — no DB calls. The commit modal renders against a hard-coded `SAMPLE_CHANGES` set.
- Out of scope (still placeholders): SQL editor with AI ghost-text, data grid with diff tints, execution-plan visualization.

## Test plan
- [x] `pnpm lint` — passes (turbo cache hit on all 7 packages).
- [x] `pnpm test` — passes (cargo workspace tests, vitest across all packages, typecheck).
- [x] `pnpm build` in `apps/desktop` — passes (`tsc --noEmit && vite build`).
- [ ] Manual: ⌘K opens the palette and filter-by-text shows the right groups.
- [ ] Manual: Sidebar `+` / `New connection` footer opens the connection dialog; engine picker swaps the default port + available auth methods.
- [ ] Manual: ⌘S (or the workspace-placeholder "Review & commit" button) opens the commit modal; the SQL panel renders highlighted `BEGIN … COMMIT` with line numbers.
- [ ] Manual: Title-bar layout-icon toggle flips into the empty state; clicking any engine quick-pick opens the connection dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)