### PR TITLE
[codex] Fix desktop top bar alignment

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -18,6 +18,12 @@
         "minWidth": 960,
         "minHeight": 600,
         "decorations": true,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true,
+        "trafficLightPosition": {
+          "x": 12,
+          "y": 20
+        },
         "transparent": false,
         "backgroundColor": "#0c0d10"
       }

--- a/apps/desktop/src/components/TitleBar.tsx
+++ b/apps/desktop/src/components/TitleBar.tsx
@@ -12,11 +12,7 @@ export function TitleBar({
   return (
     <div className="cellar-titlebar">
       <div className="cellar-titlebar-left">
-        <div className="cellar-traffic">
-          <span style={{ background: "#ed6a5e" }} />
-          <span style={{ background: "#f5bf4f" }} />
-          <span style={{ background: "#61c554" }} />
-        </div>
+        <div className="cellar-native-controls-spacer" aria-hidden="true" />
         <div className="cellar-brand">
           <span className="cellar-brand-mark" />
           <span className="cellar-brand-name">Cellar</span>

--- a/apps/desktop/src/styles/chrome.css
+++ b/apps/desktop/src/styles/chrome.css
@@ -48,6 +48,7 @@
 
 /* ─── title bar ─── */
 .cellar-titlebar {
+  position: relative;
   height: var(--titlebar-h);
   display: flex;
   align-items: center;
@@ -78,11 +79,11 @@
   .cellar-breadcrumbs > svg { display: none; }
 }
 
-.cellar-traffic { display: flex; gap: 6px; padding: 0 6px 0 0; }
-.cellar-traffic span {
-  width: 11px;
-  height: 11px;
-  border-radius: 50%;
+.cellar-native-controls-spacer {
+  width: 68px;
+  height: 100%;
+  flex-shrink: 0;
+  pointer-events: none;
 }
 
 .cellar-brand {
@@ -140,13 +141,16 @@
 .cellar-bc:hover { background: var(--bg-3); color: var(--fg-0); }
 
 .cellar-cmdk {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
   display: flex;
   align-items: center;
   gap: 8px;
   height: 22px;
   width: 320px;
   max-width: 320px;
-  margin: 0 auto;
   padding: 0 8px;
   background: var(--bg-inset);
   border: 1px solid var(--border-default);

--- a/apps/desktop/src/styles/tokens.css
+++ b/apps/desktop/src/styles/tokens.css
@@ -71,7 +71,7 @@
   --row-h: 22px;
   --row-h-tight: 20px;
   --tab-h: 30px;
-  --titlebar-h: 36px;
+  --titlebar-h: 34px;
   --statusbar-h: 22px;
   --pad-1: 4px;
   --pad-2: 6px;


### PR DESCRIPTION
## What changed

- Use Tauri's native macOS overlay title bar instead of React-drawn traffic-light controls.
- Reserve left toolbar space for the native window controls.
- Tune the desktop title bar height and center the command/search field independently from the left and right toolbar groups.

## Why

The desktop shell previously showed duplicate or rough-looking top bar controls. The final version keeps native macOS controls while aligning the React chrome around them.

## Validation

- `pnpm --filter @cellar/desktop typecheck`
- `pnpm --filter @cellar/desktop build`
- `cargo check --workspace`
