### PR TITLE
feat(data-grid): editable table grid + horizontal scroll fix

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -14,6 +14,7 @@
     "tauri": "tauri"
   },
   "dependencies": {
+    "@cellar/data-grid": "workspace:*",
     "@tauri-apps/api": "^2.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/apps/desktop/src/components/Workspace.tsx
+++ b/apps/desktop/src/components/Workspace.tsx
@@ -1,62 +1,35 @@
-import { Icon } from "./icons";
+import { useState } from "react";
+import { DataGrid, useGridState } from "@cellar/data-grid";
+import {
+  ORDER_COLUMNS,
+  ORDERS_TOTAL_ROWS,
+  SAMPLE_ORDERS,
+  makeSamplePendingChanges,
+} from "../lib/sampleOrders";
 
 export function Workspace({ onCommit }: { onCommit?: () => void } = {}) {
+  // Stash the seeded pending changes in lazy-init state so React re-renders
+  // (theme toggles, settings panel) don't reset what the user has edited.
+  const [seededChanges] = useState(makeSamplePendingChanges);
+  const grid = useGridState({ initialChanges: seededChanges });
+
   return (
-    <div className="flex flex-1 flex-col min-h-0 overflow-hidden">
-      <div className="flex flex-1 flex-col items-center justify-center gap-[14px] bg-bg-inset px-10 py-10 text-center text-[12.5px] text-fg-2">
-        <span
-          className="relative h-9 w-9 rounded-lg"
-          style={{
-            background:
-              "linear-gradient(135deg, #c4b5fd 0%, var(--accent) 55%, #6d4ed1 100%)",
-            boxShadow: "0 0 24px var(--accent-soft)",
-          }}
-        >
-          <span
-            className="absolute inset-[5px] rounded bg-bg-inset"
-            style={{
-              clipPath:
-                "polygon(0 0, 100% 0, 100% 35%, 35% 35%, 35% 65%, 100% 65%, 100% 100%, 0 100%)",
-            }}
-          />
-        </span>
-        <div>
-          <div className="text-[14px] font-semibold text-fg-0">
-            SQL editor coming soon
-          </div>
-          <div className="max-w-[360px] text-[11.5px] leading-[1.5] text-fg-3">
-            CodeMirror 6 with schema-aware autocomplete and ghost-text AI
-            completion will live here. The data grid for table tabs ships in the
-            same release.
-          </div>
-        </div>
-        <div className="flex gap-3 text-[10.5px] text-fg-3">
-          <span className="inline-flex items-center gap-1">
-            <kbd className="kbd">⌘</kbd>
-            <kbd className="kbd">⏎</kbd>&nbsp;run statement
-          </span>
-          <span className="inline-flex items-center gap-1">
-            <kbd className="kbd">⌘</kbd>
-            <kbd className="kbd">K</kbd>&nbsp;command palette
-          </span>
-          <span className="inline-flex items-center gap-1">
-            <Icon.sparkles size={11} style={{ color: "var(--accent)" }} />
-            <kbd className="kbd">⌘</kbd>
-            <kbd className="kbd">I</kbd>&nbsp;ask AI
-          </span>
-        </div>
-        {onCommit && (
-          <button
-            onClick={onCommit}
-            title="Open the commit review modal"
-            className="mt-1 inline-flex h-[26px] items-center gap-[5px] whitespace-nowrap rounded-[4px] border border-border-default bg-transparent px-2.5 text-[11.5px] font-medium text-fg-1 transition-[background,color,border-color] duration-[120ms] hover:border-border-strong hover:bg-bg-3 hover:text-fg-0"
-          >
-            <Icon.commit size={11} />
-            <span>Review &amp; commit (4 pending)</span>
-            <kbd className="kbd ml-1">⌘S</kbd>
-          </button>
-        )}
-      </div>
+    <div className="flex flex-1 min-h-0 overflow-hidden">
+      <DataGrid
+        columns={ORDER_COLUMNS}
+        rows={SAMPLE_ORDERS}
+        totalRows={ORDERS_TOTAL_ROWS}
+        changes={grid.changes}
+        onChange={grid.setChanges}
+        selection={grid.selection}
+        onSelect={grid.setSelection}
+        editing={grid.editing}
+        onEdit={grid.setEditing}
+        filters={grid.filters}
+        onFiltersChange={grid.setFilters}
+        onCommit={onCommit}
+        onRevert={grid.revert}
+      />
     </div>
   );
 }

--- a/apps/desktop/src/lib/sampleOrders.ts
+++ b/apps/desktop/src/lib/sampleOrders.ts
@@ -1,0 +1,194 @@
+import type { GridColumn, GridRow, PendingChanges } from "@cellar/data-grid";
+
+/**
+ * Placeholder data for the `public.orders` tab. The real grid will hydrate
+ * itself from a streaming query result over Tauri IPC; until those wires are
+ * live, this seed mirrors the design prototype so we can iterate on the grid
+ * UX against realistic shape.
+ */
+export const ORDER_COLUMNS: readonly GridColumn[] = [
+  { key: "id", name: "id", type: "uuid", width: 240, pk: true, mono: true },
+  { key: "order_number", name: "order_number", type: "text", width: 120, mono: true },
+  {
+    key: "customer_id",
+    name: "customer_id",
+    type: "uuid",
+    width: 220,
+    fk: "customers.id",
+    mono: true,
+  },
+  {
+    key: "status",
+    name: "status",
+    type: "order_status",
+    width: 110,
+    enum: [
+      "pending",
+      "paid",
+      "fulfilled",
+      "shipped",
+      "delivered",
+      "cancelled",
+      "refunded",
+    ],
+  },
+  {
+    key: "total_eur",
+    name: "total_eur",
+    type: "numeric(10,2)",
+    width: 110,
+    align: "right",
+    mono: true,
+  },
+  { key: "currency", name: "currency", type: "char(3)", width: 70, mono: true },
+  { key: "channel", name: "channel", type: "text", width: 90 },
+  { key: "country", name: "country", type: "char(2)", width: 70, mono: true },
+  { key: "shipping_method", name: "shipping_method", type: "text", width: 130 },
+  {
+    key: "tax_rate",
+    name: "tax_rate",
+    type: "numeric(4,3)",
+    width: 90,
+    align: "right",
+    mono: true,
+  },
+  {
+    key: "promo_code",
+    name: "promo_code",
+    type: "text",
+    width: 110,
+    mono: true,
+    nullable: true,
+  },
+  { key: "notes", name: "notes", type: "text", width: 200, nullable: true },
+  { key: "created_at", name: "created_at", type: "timestamptz", width: 170, mono: true },
+  { key: "updated_at", name: "updated_at", type: "timestamptz", width: 170, mono: true },
+];
+
+export const ORDERS_TOTAL_ROWS = 1_840_219;
+
+function uuidLike(seed: number, salt: number): string {
+  const chars = "0123456789abcdef";
+  let out = "";
+  let x = (seed * 9301 + salt * 49297 + 1234567) % 0x7fffffff;
+  for (let i = 0; i < 32; i++) {
+    x = (x * 1103515245 + 12345) & 0x7fffffff;
+    out += chars[x & 15];
+    if (i === 7 || i === 11 || i === 15 || i === 19) out += "-";
+  }
+  return out;
+}
+
+function fmtTs(d: Date): string {
+  const pad = (n: number, w = 2) => String(n).padStart(w, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}+00`;
+}
+
+const CHANNELS = ["web", "ios", "android", "pos"] as const;
+const COUNTRIES = [
+  "DE", "FR", "NL", "IT", "ES", "SE", "PL", "AT", "BE", "DK",
+] as const;
+const METHODS = ["standard", "express", "pickup", "next-day"] as const;
+const STATUSES = [
+  "pending",
+  "paid",
+  "fulfilled",
+  "shipped",
+  "delivered",
+  "cancelled",
+  "refunded",
+] as const;
+const PROMOS: (string | null)[] = [
+  null, null, null, null, "WELCOME10", "SUMMER25", "VIP", "FREESHIP",
+];
+
+function pick<T>(arr: readonly T[], i: number): T {
+  const v = arr[i % arr.length];
+  // The runtime length of a non-empty literal ensures this never fails, but
+  // noUncheckedIndexedAccess wants the assertion.
+  return v as T;
+}
+
+/**
+ * Deterministic generator — same seed in, same rows out. Keeps screenshots
+ * stable and gives reviewers consistent fixtures.
+ */
+export function makeSampleOrders(count = 60): GridRow[] {
+  const out: GridRow[] = [];
+  let n = 184_220;
+  for (let i = 0; i < count; i++) {
+    const status = pick(STATUSES, Math.floor(Math.pow((i * 17) % 97 / 97, 1.8) * STATUSES.length));
+    const total = (((i * 73) % 380) + 8 + (i % 7) * 0.13).toFixed(2);
+    const tax = (["0.190", "0.200", "0.210", "0.220"] as const)[i % 4];
+    const country = pick(COUNTRIES, i);
+    const created = new Date(2026, 4, 14 + (i % 12), 8 + (i % 12), (i * 7) % 60, (i * 13) % 60);
+    const updated = new Date(created.getTime() + 1000 * 60 * (5 + (i % 700)));
+    out.push({
+      id: uuidLike(i, 0),
+      order_number: `EU-${String(n++).padStart(7, "0")}`,
+      customer_id: uuidLike(i, 1),
+      status,
+      total_eur: total,
+      currency: "EUR",
+      channel: pick(CHANNELS, i),
+      country,
+      shipping_method: pick(METHODS, i),
+      tax_rate: tax,
+      promo_code: pick(PROMOS, i),
+      notes:
+        i % 9 === 0
+          ? "Gift wrap requested"
+          : i % 13 === 0
+            ? "Customer asked for invoice"
+            : null,
+      created_at: fmtTs(created),
+      updated_at: fmtTs(updated),
+    });
+  }
+  return out;
+}
+
+export const SAMPLE_ORDERS: readonly GridRow[] = makeSampleOrders();
+
+/**
+ * Seed pending changes so the status bar and pending-bar both have something
+ * meaningful to render. Mirrors "4 pending · 1 insert · 2 updates · 1 delete"
+ * from the design.
+ */
+export function makeSamplePendingChanges(): PendingChanges {
+  const seed = SAMPLE_ORDERS;
+  if (seed.length < 8) return {};
+  const r1 = seed[1]!;
+  const r2 = seed[4]!;
+  const r3 = seed[7]!;
+  return {
+    [r1.id]: {
+      kind: "update",
+      edits: {
+        status: { from: (r1.status as string) ?? null, to: "shipped" },
+      },
+    },
+    [r2.id]: {
+      kind: "update",
+      edits: {
+        notes: { from: (r2.notes as string | null) ?? null, to: "VIP — overnight" },
+        promo_code: { from: (r2.promo_code as string | null) ?? null, to: "VIP" },
+      },
+    },
+    [r3.id]: {
+      kind: "delete",
+      edits: {},
+    },
+    "new-row-1": {
+      kind: "insert",
+      edits: {
+        id: { from: null, to: uuidLike(9001, 17) },
+        order_number: { from: null, to: "EU-9000001" },
+        status: { from: null, to: "pending" },
+        total_eur: { from: null, to: "84.20" },
+        currency: { from: null, to: "EUR" },
+        country: { from: null, to: "DE" },
+      },
+    },
+  };
+}

--- a/apps/desktop/src/styles/grid.css
+++ b/apps/desktop/src/styles/grid.css
@@ -1,0 +1,437 @@
+/* Cellar data grid styles — pairs with @cellar/data-grid components. */
+
+.grid-root {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+  /* Stop the wide table inside from blowing out our flex parent. Without
+     `min-width: 0` a flex item's min-width defaults to its intrinsic content
+     width (~1850px here), so `.grid-scroll` never sees overflow to scroll. */
+  min-width: 0;
+  font-size: var(--fs-md);
+  background: var(--bg-inset);
+}
+
+/* ── filter bar ───────────────────────────────────────────── */
+.grid-filterbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 28px;
+  padding: 0 10px;
+  background: var(--bg-1);
+  border-bottom: 1px solid var(--border-default);
+  flex-shrink: 0;
+  font-family: var(--font-sans);
+  font-size: 11px;
+}
+.grid-filterbar-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--fg-2);
+  font-weight: 500;
+}
+.grid-filterbar-chips {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex: 1;
+  min-width: 0;
+}
+.grid-filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 20px;
+  padding: 0 4px 0 7px;
+  background: var(--accent-soft);
+  border: 1px solid var(--accent-line);
+  border-radius: 4px;
+  font-size: 10.5px;
+  color: var(--fg-0);
+}
+.grid-filter-chip .mono { font-family: var(--font-mono); }
+.grid-filter-op { color: var(--accent); }
+.grid-filter-chip button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  border-radius: 2px;
+  color: var(--fg-2);
+}
+.grid-filter-chip button:hover { background: rgba(0,0,0,0.2); color: var(--fg-0); }
+
+.grid-filter-add {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  height: 20px;
+  padding: 0 6px;
+  border: 1px dashed var(--border-default);
+  border-radius: 4px;
+  font-size: 10.5px;
+  color: var(--fg-2);
+}
+.grid-filter-add:hover { color: var(--fg-0); border-color: var(--border-strong); }
+
+.grid-filterbar-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  margin-left: auto;
+  font-size: 10.5px;
+}
+
+/* ── table scroll + rows ──────────────────────────────────── */
+.grid-scroll {
+  flex: 1;
+  overflow: auto;
+}
+.grid-table {
+  display: flex;
+  flex-direction: column;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  line-height: 1;
+}
+.grid-row {
+  display: flex;
+  height: var(--row-h);
+  border-bottom: 1px solid var(--border-divider);
+  position: relative;
+}
+.grid-header-row {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  height: 26px;
+  background: var(--bg-1);
+  border-bottom: 1px solid var(--border-default);
+}
+.grid-cell {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 8px;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  position: relative;
+  flex-shrink: 0;
+  border-right: 1px solid var(--border-divider);
+}
+.grid-row:hover { background: var(--bg-2); }
+
+.grid-row.is-update { background: var(--update-bg); }
+.grid-row.is-update:hover { background: color-mix(in oklab, var(--update-bg) 70%, var(--bg-3)); }
+.grid-row.is-insert { background: var(--insert-bg); }
+.grid-row.is-insert:hover { background: color-mix(in oklab, var(--insert-bg) 70%, var(--bg-3)); }
+.grid-row.is-delete { background: var(--delete-bg); }
+.grid-row.is-delete:hover { background: color-mix(in oklab, var(--delete-bg) 70%, var(--bg-3)); }
+.grid-row.is-delete .grid-cell:not(.grid-cell-rowno) {
+  text-decoration: line-through;
+  text-decoration-color: color-mix(in oklab, var(--delete) 50%, transparent);
+  color: var(--fg-3);
+}
+
+/* ── row number gutter ────────────────────────────────────── */
+.grid-cell-rowno {
+  width: 36px;
+  min-width: 36px;
+  flex-basis: 36px !important;
+  justify-content: center;
+  color: var(--fg-3);
+  background: var(--bg-1);
+  border-right: 1px solid var(--border-divider);
+  font-size: 10px;
+  position: sticky;
+  left: 0;
+  z-index: 2;
+}
+.grid-row.is-update .grid-cell-rowno { background: color-mix(in oklab, var(--update-bg) 60%, var(--bg-1)); }
+.grid-row.is-insert .grid-cell-rowno { background: color-mix(in oklab, var(--insert-bg) 60%, var(--bg-1)); }
+.grid-row.is-delete .grid-cell-rowno { background: color-mix(in oklab, var(--delete-bg) 60%, var(--bg-1)); }
+.grid-rowno-num { font-variant-numeric: tabular-nums; }
+.grid-gutter-mark {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+}
+
+/* ── frozen columns + headers ─────────────────────────────── */
+.grid-cell.frozen {
+  background: var(--bg-inset);
+  position: sticky;
+  z-index: 2;
+}
+.grid-cell.frozen + .grid-cell:not(.frozen) {
+  box-shadow: inset 2px 0 0 -1px var(--border-strong);
+}
+.grid-header-cell {
+  height: 100%;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--fg-0);
+  text-transform: none;
+  background: var(--bg-1);
+  cursor: pointer;
+  border-right: 1px solid var(--border-default);
+}
+.grid-header-cell:hover { background: var(--bg-2); }
+.grid-header-cell.frozen { background: var(--bg-1); }
+.grid-header-icon { color: var(--fg-3); display: inline-flex; }
+.grid-header-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+}
+.grid-header-type {
+  font-size: 9.5px;
+  color: var(--fg-3);
+  font-family: var(--font-mono);
+  margin-left: auto;
+  text-transform: lowercase;
+}
+.grid-header-sort {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  color: var(--fg-3);
+  opacity: 0;
+  transition: opacity 0.1s;
+}
+.grid-header-cell:hover .grid-header-sort { opacity: 1; }
+.grid-col-resize {
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: 4px;
+  cursor: col-resize;
+}
+.grid-col-resize:hover { background: var(--accent-line); }
+
+/* ── selection + cell edit states ─────────────────────────── */
+.grid-cell.is-selected {
+  outline: 1.5px solid var(--accent);
+  outline-offset: -1.5px;
+  background: var(--accent-soft);
+  z-index: 3;
+}
+.grid-cell.is-editing { outline: 2px solid var(--accent); padding: 0; }
+.grid-cell.is-edited { background: var(--update-bg); }
+.grid-row.is-update .grid-cell.is-edited {
+  background: color-mix(in oklab, var(--update) 18%, transparent);
+  box-shadow: inset 0 -2px 0 var(--update-line);
+}
+
+/* ── cell value variants ──────────────────────────────────── */
+.cell-null {
+  color: var(--fg-3);
+  font-style: italic;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+}
+.cell-enum {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--font-sans);
+  font-size: 11px;
+}
+.cell-enum .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  flex-shrink: 0;
+}
+.cell-fk {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+}
+.cell-fk-jump {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  margin-left: auto;
+  border-radius: 2px;
+  color: var(--accent);
+  opacity: 0;
+  transition: opacity 0.1s;
+}
+.grid-cell:hover .cell-fk-jump { opacity: 1; }
+.cell-fk-jump:hover { background: var(--accent-soft); }
+
+.cell-edit-input {
+  width: 100%;
+  height: 100%;
+  padding: 0 8px;
+  background: var(--bg-2);
+  border: none;
+  outline: none;
+  color: var(--fg-0);
+  font-size: 11.5px;
+}
+.cell-edit-enum {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 4px;
+  width: 100%;
+  height: 100%;
+  background: var(--bg-2);
+  overflow-x: auto;
+}
+.cell-edit-opt {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 16px;
+  padding: 0 6px;
+  background: var(--bg-3);
+  border-radius: 3px;
+  font-size: 10px;
+  font-family: var(--font-sans);
+  color: var(--fg-1);
+  flex-shrink: 0;
+}
+.cell-edit-opt:hover { background: var(--bg-4); color: var(--fg-0); }
+.cell-edit-opt.active { background: var(--accent); color: var(--accent-fg); }
+.cell-edit-opt .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  flex-shrink: 0;
+}
+
+/* ── previous-value badge on edited cells ─────────────────── */
+.grid-cell-prev {
+  position: absolute;
+  right: 4px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 9.5px;
+  color: var(--fg-3);
+  pointer-events: none;
+  max-width: 50%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.grid-cell-prev-strike {
+  text-decoration: line-through;
+  padding: 0 4px;
+  background: rgba(0,0,0,0.25);
+  border-radius: 2px;
+}
+
+.grid-row-add {
+  height: 22px;
+  background: transparent;
+  color: var(--fg-3);
+  border-bottom: none;
+}
+.grid-row-add:hover {
+  background: var(--insert-bg);
+  color: var(--accent);
+}
+
+/* ── pending bar ──────────────────────────────────────────── */
+.grid-pending {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 32px;
+  padding: 0 10px;
+  background: var(--bg-1);
+  border-top: 1px solid var(--border-default);
+  font-family: var(--font-sans);
+  font-size: 11.5px;
+  flex-shrink: 0;
+}
+.grid-pending.empty { background: var(--bg-1); }
+.grid-pending-left,
+.grid-pending-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.grid-pending-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+.grid-pending-divider { color: var(--fg-3); }
+.grid-pending-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 18px;
+  padding: 0 6px;
+  border-radius: 3px;
+  font-size: 10.5px;
+  font-weight: 500;
+}
+.grid-pending-chip .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  flex-shrink: 0;
+}
+.grid-pending-chip-update { background: var(--update-bg); color: var(--update); }
+.grid-pending-chip-insert { background: var(--insert-bg); color: var(--insert); }
+.grid-pending-chip-delete { background: var(--delete-bg); color: var(--delete); }
+
+.grid-pending-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 22px;
+  padding: 0 9px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 500;
+  border: 1px solid var(--border-default);
+  color: var(--fg-1);
+  background: transparent;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+.grid-pending-btn:hover:not(:disabled) {
+  background: var(--bg-3);
+  color: var(--fg-0);
+  border-color: var(--border-strong);
+}
+.grid-pending-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.grid-pending-btn.primary {
+  background: var(--accent);
+  color: var(--accent-fg);
+  border-color: var(--accent);
+}
+.grid-pending-btn.primary:hover:not(:disabled) {
+  background: color-mix(in oklab, var(--accent) 88%, white);
+  color: var(--accent-fg);
+  border-color: color-mix(in oklab, var(--accent) 88%, white);
+}
+.grid-pending-btn .kbd {
+  background: rgba(0, 0, 0, 0.18);
+  border-color: transparent;
+  color: inherit;
+}
+
+.tnum { font-variant-numeric: tabular-nums; }

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 @import "./tokens.css";
 @import "./base.css";
+@import "./grid.css";
 
 /* Bridge: expose every design token from tokens.css as a Tailwind v4 theme key
    so utilities like `bg-bg-0`, `text-fg-1`, `border-border-default`, `font-mono`,

--- a/packages/data-grid/package.json
+++ b/packages/data-grid/package.json
@@ -11,5 +11,12 @@
   },
   "exports": {
     ".": "./src/index.ts"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.3",
+    "react": "^18.3.1"
   }
 }

--- a/packages/data-grid/src/Cell.tsx
+++ b/packages/data-grid/src/Cell.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useRef, useState } from "react";
+import { GridIcon } from "./icons";
+import { statusDotColor, statusTextColor } from "./status";
+import type { GridColumn } from "./types";
+
+type Value = string | number | null | undefined;
+
+export function CellValue({ col, value }: { col: GridColumn; value: Value }) {
+  if (value === null || value === undefined) {
+    return <span className="cell-null mono">NULL</span>;
+  }
+  if (col.enum && col.key === "status") {
+    const v = String(value);
+    return (
+      <span className="cell-enum">
+        <span className="dot" style={{ background: statusDotColor(v) }} />
+        <span style={{ color: statusTextColor(v) }}>{v}</span>
+      </span>
+    );
+  }
+  if (col.fk) {
+    return (
+      <span className="cell-fk">
+        <span className={col.mono ? "mono" : ""}>{value}</span>
+        <button className="cell-fk-jump" title={`Jump to ${col.fk}`}>
+          <GridIcon.link2 size={9} />
+        </button>
+      </span>
+    );
+  }
+  if (col.align === "right") {
+    return (
+      <span className="mono tnum" style={{ textAlign: "right", width: "100%" }}>
+        {value}
+      </span>
+    );
+  }
+  return <span className={col.mono ? "mono" : ""}>{value}</span>;
+}
+
+export type CellEditorProps = {
+  col: GridColumn;
+  value: Value;
+  onCommit: (next: Value) => void;
+  onCancel: () => void;
+};
+
+export function CellEditor({ col, value, onCommit, onCancel }: CellEditorProps) {
+  const [v, setV] = useState<string>(value == null ? "" : String(value));
+  const ref = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    ref.current?.focus();
+    ref.current?.select();
+  }, []);
+
+  if (col.enum) {
+    return (
+      <div className="cell-edit-enum">
+        {col.enum.map((opt) => (
+          <button
+            key={opt}
+            className={"cell-edit-opt" + (opt === v ? " active" : "")}
+            onClick={() => onCommit(opt)}
+          >
+            {col.key === "status" && (
+              <span
+                className="dot"
+                style={{ background: statusDotColor(opt) }}
+              />
+            )}
+            <span>{opt}</span>
+          </button>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <input
+      ref={ref}
+      className={"cell-edit-input" + (col.mono ? " mono" : "")}
+      value={v}
+      onChange={(e) => setV(e.target.value)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") onCommit(v);
+        if (e.key === "Escape") onCancel();
+      }}
+      onBlur={() => onCommit(v)}
+    />
+  );
+}

--- a/packages/data-grid/src/DataGrid.tsx
+++ b/packages/data-grid/src/DataGrid.tsx
@@ -1,0 +1,297 @@
+import { useCallback, useMemo, useState } from "react";
+import { CellEditor, CellValue } from "./Cell";
+import { FilterBar } from "./FilterBar";
+import { GridIcon } from "./icons";
+import { PendingBar } from "./PendingBar";
+import { TypeIcon } from "./TypeIcon";
+import type {
+  CellAddress,
+  CellChange,
+  ColumnFilters,
+  GridColumn,
+  GridRow,
+  PendingChange,
+  PendingChanges,
+} from "./types";
+
+const ROWNO_WIDTH = 36;
+
+export type DataGridProps = {
+  columns: readonly GridColumn[];
+  rows: readonly GridRow[];
+
+  /** Live pending edits. Drives the row tint and the bottom pending bar. */
+  changes: PendingChanges;
+  onChange: (next: PendingChanges) => void;
+
+  /** Active selection / inline editor. Both controlled to support keyboard nav. */
+  selection: CellAddress | null;
+  onSelect: (next: CellAddress | null) => void;
+  editing: CellAddress | null;
+  onEdit: (next: CellAddress | null) => void;
+
+  filters: ColumnFilters;
+  onFiltersChange: (next: ColumnFilters) => void;
+
+  /**
+   * Number of leftmost columns to freeze. The frozen columns stick to the left
+   * edge as the user scrolls horizontally — same idea as Excel's freeze panes.
+   */
+  frozenCount?: number;
+
+  /** Total row count on the server (the grid usually only holds a page). */
+  totalRows?: number;
+
+  onCommit?: () => void;
+  onRevert?: () => void;
+};
+
+/**
+ * Editable, virtualization-ready data grid. Renders one page of rows at a time
+ * — virtualization will be layered in once we wire result streaming and a
+ * scroller library. Today the grid is honest about pending edits, supports
+ * inline editing for plain + enum cells, and emits intent through callbacks so
+ * the host can plug it into Zustand or a Tauri command later.
+ */
+export function DataGrid({
+  columns,
+  rows,
+  changes,
+  onChange,
+  selection,
+  onSelect,
+  editing,
+  onEdit,
+  filters,
+  onFiltersChange,
+  frozenCount = 2,
+  totalRows,
+  onCommit,
+  onRevert,
+}: DataGridProps) {
+  // Local search across visible page. Server-side filtering happens upstream
+  // for large tables; the chips drive both.
+  const visibleRows = useMemo(() => {
+    const entries = Object.entries(filters);
+    if (entries.length === 0) return rows;
+    return rows.filter((row) =>
+      entries.every(([k, needle]) =>
+        String(row[k] ?? "")
+          .toLowerCase()
+          .includes(String(needle).toLowerCase()),
+      ),
+    );
+  }, [rows, filters]);
+
+  const minTableWidth = useMemo(
+    () => columns.reduce((acc, c) => acc + c.width, ROWNO_WIDTH + 8),
+    [columns],
+  );
+
+  const handleCellEdit = useCallback(
+    (rowId: string, colKey: string, prev: CellChange["from"], next: CellChange["to"]) => {
+      if (prev === next) return;
+      const existing: PendingChange = changes[rowId] ?? { kind: "update", edits: {} };
+      const baseEdit = existing.edits[colKey];
+      const fromValue = baseEdit ? baseEdit.from : prev;
+
+      // If the user edited back to the original value, drop the per-cell change.
+      const nextEdits = { ...existing.edits };
+      if (fromValue === next) {
+        delete nextEdits[colKey];
+      } else {
+        nextEdits[colKey] = { from: fromValue, to: next };
+      }
+
+      const updated: PendingChanges = { ...changes };
+      const editKeys = Object.keys(nextEdits);
+      if (editKeys.length === 0 && existing.kind === "update") {
+        delete updated[rowId];
+      } else {
+        updated[rowId] = { kind: existing.kind, edits: nextEdits };
+      }
+      onChange(updated);
+    },
+    [changes, onChange],
+  );
+
+  return (
+    <div className="grid-root mono">
+      <FilterBar
+        filters={filters}
+        setFilters={onFiltersChange}
+        totalRows={totalRows ?? rows.length}
+        filteredRows={visibleRows.length}
+      />
+
+      <div className="grid-scroll">
+        <div className="grid-table" style={{ minWidth: minTableWidth }}>
+          <div className="grid-row grid-header-row">
+            <div className="grid-cell grid-cell-rowno">
+              <GridIcon.hash size={9} stroke="var(--fg-3)" />
+            </div>
+            {columns.map((c, ci) => (
+              <div
+                key={c.key}
+                className={
+                  "grid-cell grid-header-cell" +
+                  (ci < frozenCount ? " frozen" : "")
+                }
+                style={{ width: c.width, flexBasis: c.width }}
+              >
+                <span className="grid-header-icon">
+                  <TypeIcon col={c} />
+                </span>
+                <span className="grid-header-name">{c.name}</span>
+                <span className="grid-header-type">{c.type}</span>
+                <button className="grid-header-sort" aria-label={`Sort ${c.name}`}>
+                  <GridIcon.sortAsc size={10} />
+                </button>
+                <span className="grid-col-resize" />
+              </div>
+            ))}
+          </div>
+
+          {visibleRows.map((row, ri) => {
+            const change = changes[row.id];
+            const kind = change?.kind;
+            const rowSelected = selection?.row === ri;
+            return (
+              <div
+                key={row.id}
+                className={
+                  "grid-row" +
+                  (kind ? " is-" + kind : "") +
+                  (rowSelected ? " is-selected-row" : "")
+                }
+              >
+                <div className="grid-cell grid-cell-rowno">
+                  <span className="grid-rowno-num tnum">{ri + 1}</span>
+                  {kind === "update" && (
+                    <span
+                      className="grid-gutter-mark"
+                      style={{ background: "var(--update)" }}
+                      title="Updated"
+                    />
+                  )}
+                  {kind === "insert" && (
+                    <span
+                      className="grid-gutter-mark"
+                      style={{ background: "var(--insert)" }}
+                      title="Inserted"
+                    />
+                  )}
+                  {kind === "delete" && (
+                    <span
+                      className="grid-gutter-mark"
+                      style={{ background: "var(--delete)" }}
+                      title="Marked for delete"
+                    />
+                  )}
+                </div>
+                {columns.map((c, ci) => {
+                  const isSel =
+                    selection?.row === ri && selection?.col === ci;
+                  const isEdit = editing?.row === ri && editing?.col === ci;
+                  const cellChange = change?.edits?.[c.key];
+                  const displayed = cellChange ? cellChange.to : row[c.key];
+                  const original = row[c.key] ?? null;
+
+                  return (
+                    <div
+                      key={c.key}
+                      className={
+                        "grid-cell" +
+                        (ci < frozenCount ? " frozen" : "") +
+                        (cellChange ? " is-edited" : "") +
+                        (isSel ? " is-selected" : "") +
+                        (isEdit ? " is-editing" : "")
+                      }
+                      style={{ width: c.width, flexBasis: c.width }}
+                      onClick={() => onSelect({ row: ri, col: ci })}
+                      onDoubleClick={() => onEdit({ row: ri, col: ci })}
+                    >
+                      {isEdit ? (
+                        <CellEditor
+                          col={c}
+                          value={displayed}
+                          onCommit={(v) => {
+                            handleCellEdit(
+                              row.id,
+                              c.key,
+                              (original ?? null) as CellChange["from"],
+                              (v ?? null) as CellChange["to"],
+                            );
+                            onEdit(null);
+                          }}
+                          onCancel={() => onEdit(null)}
+                        />
+                      ) : (
+                        <CellValue col={c} value={displayed} />
+                      )}
+                      {cellChange && !isEdit && (
+                        <span
+                          className="grid-cell-prev"
+                          title={`Was: ${cellChange.from ?? "NULL"}`}
+                        >
+                          <span className="grid-cell-prev-strike">
+                            {cellChange.from === null ? "NULL" : cellChange.from}
+                          </span>
+                        </span>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            );
+          })}
+
+          <div className="grid-row grid-row-add">
+            <div className="grid-cell grid-cell-rowno">
+              <GridIcon.plus size={9} stroke="var(--fg-3)" />
+            </div>
+            <div className="grid-cell" style={{ width: 600 }}>
+              <span style={{ color: "var(--fg-3)" }}>Insert new row…</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <PendingBar changes={changes} onCommit={onCommit} onRevert={onRevert} />
+    </div>
+  );
+}
+
+export type UseGridStateOptions = {
+  initialFilters?: ColumnFilters;
+  initialChanges?: PendingChanges;
+};
+
+/**
+ * Minimal local controller for the grid. Suits tabs that don't have a backing
+ * Zustand store yet; once we wire `useTabs`, the same pieces can be lifted into
+ * a store and the grid stays exactly the same.
+ */
+export function useGridState({
+  initialFilters = {},
+  initialChanges = {},
+}: UseGridStateOptions = {}) {
+  const [filters, setFilters] = useState<ColumnFilters>(initialFilters);
+  const [changes, setChanges] = useState<PendingChanges>(initialChanges);
+  const [selection, setSelection] = useState<CellAddress | null>(null);
+  const [editing, setEditing] = useState<CellAddress | null>(null);
+
+  const revert = useCallback(() => setChanges({}), []);
+
+  return {
+    filters,
+    setFilters,
+    changes,
+    setChanges,
+    selection,
+    setSelection,
+    editing,
+    setEditing,
+    revert,
+  };
+}

--- a/packages/data-grid/src/FilterBar.tsx
+++ b/packages/data-grid/src/FilterBar.tsx
@@ -1,0 +1,60 @@
+import { GridIcon } from "./icons";
+import type { ColumnFilters } from "./types";
+
+export type FilterBarProps = {
+  filters: ColumnFilters;
+  setFilters: (next: ColumnFilters) => void;
+  totalRows: number;
+  filteredRows: number;
+};
+
+export function FilterBar({
+  filters,
+  setFilters,
+  totalRows,
+  filteredRows,
+}: FilterBarProps) {
+  return (
+    <div className="grid-filterbar">
+      <div className="grid-filterbar-label">
+        <GridIcon.filter size={11} style={{ color: "var(--accent)" }} />
+        <span>where</span>
+      </div>
+      <div className="grid-filterbar-chips">
+        {Object.entries(filters).map(([k, v]) => (
+          <span key={k} className="grid-filter-chip">
+            <span className="mono">{k}</span>
+            <span className="grid-filter-op">=</span>
+            <span className="mono" style={{ color: "var(--syn-str)" }}>
+              {"'"}
+              {v}
+              {"'"}
+            </span>
+            <button
+              onClick={() => {
+                const next = { ...filters };
+                delete next[k];
+                setFilters(next);
+              }}
+              aria-label={`Remove filter on ${k}`}
+            >
+              <GridIcon.close size={9} />
+            </button>
+          </span>
+        ))}
+        <button className="grid-filter-add">
+          <GridIcon.plus size={10} />
+          <span>add</span>
+        </button>
+      </div>
+      <div className="grid-filterbar-summary mono">
+        <span style={{ color: "var(--fg-1)" }}>
+          {filteredRows.toLocaleString()}
+        </span>
+        <span style={{ color: "var(--fg-3)" }}>/</span>
+        <span style={{ color: "var(--fg-2)" }}>{totalRows.toLocaleString()}</span>
+        <span style={{ color: "var(--fg-3)" }}> rows</span>
+      </div>
+    </div>
+  );
+}

--- a/packages/data-grid/src/PendingBar.tsx
+++ b/packages/data-grid/src/PendingBar.tsx
@@ -1,0 +1,77 @@
+import { GridIcon } from "./icons";
+import { countChanges } from "./status";
+import type { PendingChanges } from "./types";
+
+export type PendingBarProps = {
+  changes: PendingChanges;
+  onCommit?: () => void;
+  onRevert?: () => void;
+};
+
+export function PendingBar({ changes, onCommit, onRevert }: PendingBarProps) {
+  const { total, inserts, updates, deletes } = countChanges(changes);
+
+  return (
+    <div className={"grid-pending" + (total === 0 ? " empty" : "")}>
+      <div className="grid-pending-left">
+        <GridIcon.diff
+          size={11}
+          style={{ color: total > 0 ? "var(--update)" : "var(--fg-3)" }}
+        />
+        {total === 0 ? (
+          <span style={{ color: "var(--fg-2)" }}>No pending changes</span>
+        ) : (
+          <span className="grid-pending-summary">
+            <span>{total} pending</span>
+            <span className="grid-pending-divider">·</span>
+            {inserts > 0 && (
+              <span className="grid-pending-chip grid-pending-chip-insert">
+                <span className="dot" style={{ background: "var(--insert)" }} />
+                <span>
+                  {inserts} insert{inserts === 1 ? "" : "s"}
+                </span>
+              </span>
+            )}
+            {updates > 0 && (
+              <span className="grid-pending-chip grid-pending-chip-update">
+                <span className="dot" style={{ background: "var(--update)" }} />
+                <span>
+                  {updates} update{updates === 1 ? "" : "s"}
+                </span>
+              </span>
+            )}
+            {deletes > 0 && (
+              <span className="grid-pending-chip grid-pending-chip-delete">
+                <span className="dot" style={{ background: "var(--delete)" }} />
+                <span>
+                  {deletes} delete{deletes === 1 ? "" : "s"}
+                </span>
+              </span>
+            )}
+            <span className="grid-pending-divider">·</span>
+            <span style={{ color: "var(--fg-3)" }}>wrapped in transaction</span>
+          </span>
+        )}
+      </div>
+      <div className="grid-pending-right">
+        <button
+          className="grid-pending-btn subtle"
+          onClick={onRevert}
+          disabled={total === 0}
+        >
+          <GridIcon.undo size={11} />
+          <span>Revert</span>
+        </button>
+        <button
+          className="grid-pending-btn primary"
+          onClick={onCommit}
+          disabled={total === 0}
+        >
+          <GridIcon.commit size={11} />
+          <span>Review &amp; Commit</span>
+          <span className="kbd">⌘S</span>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/data-grid/src/TypeIcon.tsx
+++ b/packages/data-grid/src/TypeIcon.tsx
@@ -1,0 +1,41 @@
+import { GridIcon, type GridIconProps } from "./icons";
+import type { GridColumn } from "./types";
+
+/**
+ * Renders the small monochrome glyph in a column header that signals what kind
+ * of value the column holds. PKs and FKs win over data type — they're the
+ * structural fact about the column. Otherwise the SQL type drives the icon.
+ */
+export function TypeIcon({ col }: { col: GridColumn }) {
+  const type = col.type.toLowerCase();
+  let Comp: (p: GridIconProps) => JSX.Element = GridIcon.text;
+  if (col.pk) Comp = GridIcon.key;
+  else if (col.fk) Comp = GridIcon.link;
+  else if (type.startsWith("uuid")) Comp = GridIcon.hash;
+  else if (type.startsWith("text") || type.startsWith("char")) Comp = GridIcon.text;
+  else if (
+    type.includes("int") ||
+    type.includes("numeric") ||
+    type.includes("decimal")
+  )
+    Comp = GridIcon.hash;
+  else if (
+    type.includes("timestamp") ||
+    type.includes("date") ||
+    type.includes("time")
+  )
+    Comp = GridIcon.cal;
+  else if (type.includes("bool")) Comp = GridIcon.bool;
+  else if (type.includes("json")) Comp = GridIcon.json;
+  else if (col.enum) Comp = GridIcon.enum;
+
+  const color = col.pk ? "var(--update)" : col.fk ? "var(--accent)" : "var(--fg-3)";
+
+  return (
+    <Comp
+      size={10}
+      stroke={color}
+      fill={col.pk || col.fk ? color : "none"}
+    />
+  );
+}

--- a/packages/data-grid/src/icons.tsx
+++ b/packages/data-grid/src/icons.tsx
@@ -1,0 +1,107 @@
+import type { SVGProps, ReactNode } from "react";
+
+/**
+ * Tiny self-contained icon set used by the grid. Kept inside the data-grid
+ * package so it has no dependency on the desktop app's icon registry — the
+ * grid is meant to live in its own workspace and ship to plugins.
+ */
+type IconProps = SVGProps<SVGSVGElement> & {
+  size?: number;
+  sw?: number;
+  d?: string;
+  children?: ReactNode;
+};
+
+const I = ({
+  d,
+  size = 14,
+  sw = 1.5,
+  fill = "none",
+  stroke = "currentColor",
+  children,
+  ...rest
+}: IconProps) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill={fill}
+    stroke={stroke}
+    strokeWidth={sw}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    style={{ flexShrink: 0, display: "block" }}
+    {...rest}
+  >
+    {d ? <path d={d} /> : children}
+  </svg>
+);
+
+export const GridIcon = {
+  plus: (p: IconProps) => <I {...p} d="M12 5v14M5 12h14" />,
+  close: (p: IconProps) => <I {...p} d="M6 6l12 12M18 6L6 18" />,
+  undo: (p: IconProps) => <I {...p} d="M3 8h10a5 5 0 010 10H8M3 8l4-4M3 8l4 4" />,
+  commit: (p: IconProps) => (
+    <I {...p}>
+      <circle cx="12" cy="12" r="4" />
+      <path d="M16 12h6M2 12h6" />
+    </I>
+  ),
+  diff: (p: IconProps) => (
+    <I {...p}>
+      <path d="M12 3v18M9 6L6 9l3 3M15 18l3-3-3-3" />
+    </I>
+  ),
+  filter: (p: IconProps) => <I {...p} d="M3 5h18l-7 9v6l-4-2v-4z" />,
+  sortAsc: (p: IconProps) => (
+    <I {...p}>
+      <path d="M7 4v16M3 16l4 4 4-4" />
+    </I>
+  ),
+  key: (p: IconProps) => (
+    <I {...p}>
+      <circle cx="8" cy="15" r="4" />
+      <path d="M11 12l8-8M16 7l3 3M14 9l3 3" />
+    </I>
+  ),
+  link: (p: IconProps) => (
+    <I {...p}>
+      <path d="M10 14L4 20M14 10l6-6M10 6V3h11v11h-3M14 18v3H3V10h3" />
+    </I>
+  ),
+  link2: (p: IconProps) => (
+    <I {...p}>
+      <path d="M9 17H7A5 5 0 017 7h2M15 7h2a5 5 0 010 10h-2M8 12h8" />
+    </I>
+  ),
+  text: (p: IconProps) => <I {...p} d="M4 7V5h16v2M12 5v14M9 19h6" />,
+  hash: (p: IconProps) => <I {...p} d="M4 9h16M4 15h16M10 3L8 21M16 3l-2 18" />,
+  cal: (p: IconProps) => (
+    <I {...p}>
+      <rect x="3" y="5" width="18" height="16" rx="1.5" />
+      <path d="M3 10h18M8 3v4M16 3v4" />
+    </I>
+  ),
+  bool: (p: IconProps) => (
+    <I {...p}>
+      <rect x="2" y="6" width="20" height="12" rx="6" />
+      <circle cx="8" cy="12" r="3" fill="currentColor" />
+    </I>
+  ),
+  json: (p: IconProps) => (
+    <I
+      {...p}
+      d="M7 4S4 4 4 8s2 4 2 4-2 0-2 4 3 4 3 4M17 4s3 0 3 4-2 4-2 4 2 0 2 4-3 4-3 4"
+    />
+  ),
+  enum: (p: IconProps) => (
+    <I {...p}>
+      <circle cx="6" cy="6" r="2" />
+      <circle cx="6" cy="12" r="2" />
+      <circle cx="6" cy="18" r="2" />
+      <path d="M11 6h10M11 12h10M11 18h10" />
+    </I>
+  ),
+};
+
+export type GridIconProps = IconProps;

--- a/packages/data-grid/src/index.ts
+++ b/packages/data-grid/src/index.ts
@@ -1,2 +1,19 @@
-// Virtualized, editable data grid (TanStack Table v8) lands here.
-export {};
+export type {
+  CellAddress,
+  CellAlign,
+  CellChange,
+  ChangeKind,
+  ColumnFilters,
+  GridColumn,
+  GridRow,
+  GridStatusCounts,
+  PendingChange,
+  PendingChanges,
+} from "./types";
+
+export { countChanges, statusDotColor, statusTextColor } from "./status";
+export { DataGrid, useGridState, type DataGridProps } from "./DataGrid";
+export { CellEditor, CellValue, type CellEditorProps } from "./Cell";
+export { FilterBar, type FilterBarProps } from "./FilterBar";
+export { PendingBar, type PendingBarProps } from "./PendingBar";
+export { TypeIcon } from "./TypeIcon";

--- a/packages/data-grid/src/status.ts
+++ b/packages/data-grid/src/status.ts
@@ -1,0 +1,45 @@
+import type { PendingChanges, GridStatusCounts } from "./types";
+
+const STATUS_DOT_VAR: Record<string, string> = {
+  pending: "var(--warn)",
+  paid: "var(--accent)",
+  fulfilled: "#60a5fa",
+  shipped: "#a78bfa",
+  delivered: "#34d399",
+  cancelled: "#f87171",
+  refunded: "#fb7185",
+};
+
+const STATUS_TEXT_VAR: Record<string, string> = {
+  pending: "#fbbf24",
+  paid: "var(--accent)",
+  fulfilled: "#60a5fa",
+  shipped: "#a78bfa",
+  delivered: "#34d399",
+  cancelled: "#f87171",
+  refunded: "#fb7185",
+};
+
+/** Color for the dot rendered next to a status enum value. */
+export function statusDotColor(value: string): string {
+  return STATUS_DOT_VAR[value] ?? "var(--fg-2)";
+}
+
+/** Color for the status enum text/label. */
+export function statusTextColor(value: string): string {
+  return STATUS_TEXT_VAR[value] ?? "var(--fg-1)";
+}
+
+/** Tally pending changes by kind. */
+export function countChanges(changes: PendingChanges): GridStatusCounts {
+  const values = Object.values(changes);
+  let inserts = 0;
+  let updates = 0;
+  let deletes = 0;
+  for (const c of values) {
+    if (c.kind === "insert") inserts += 1;
+    else if (c.kind === "update") updates += 1;
+    else if (c.kind === "delete") deletes += 1;
+  }
+  return { total: values.length, inserts, updates, deletes };
+}

--- a/packages/data-grid/src/types.ts
+++ b/packages/data-grid/src/types.ts
@@ -1,0 +1,59 @@
+/** Public types for the Cellar data grid. */
+
+export type CellAlign = "left" | "right" | "center";
+
+/**
+ * A single column definition. Mirrors a SQL column with enough metadata for the
+ * grid to render the type icon, format the value, and offer the right inline
+ * editor.
+ */
+export type GridColumn = {
+  key: string;
+  name: string;
+  type: string;
+  width: number;
+  pk?: boolean;
+  fk?: string;
+  align?: CellAlign;
+  mono?: boolean;
+  nullable?: boolean;
+  enum?: readonly string[];
+};
+
+/** Row values are keyed by column key. Use `null` for SQL NULL. */
+export type GridRow = {
+  id: string;
+  [key: string]: string | number | null | undefined;
+};
+
+export type ChangeKind = "insert" | "update" | "delete";
+
+export type CellChange = {
+  from: string | number | null;
+  to: string | number | null;
+};
+
+/**
+ * A pending change against a row. `edits` is sparse — only the columns the user
+ * has touched — and is empty for `delete` and dense for `insert`.
+ */
+export type PendingChange = {
+  kind: ChangeKind;
+  edits: Record<string, CellChange>;
+};
+
+export type PendingChanges = Record<string, PendingChange>;
+
+export type CellAddress = {
+  row: number;
+  col: number;
+};
+
+export type ColumnFilters = Record<string, string>;
+
+export type GridStatusCounts = {
+  total: number;
+  inserts: number;
+  updates: number;
+  deletes: number;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
 
   apps/desktop:
     dependencies:
+      '@cellar/data-grid':
+        specifier: workspace:*
+        version: link:../../packages/data-grid
       '@tauri-apps/api':
         specifier: ^2.0.0
         version: 2.11.0
@@ -60,7 +63,14 @@ importers:
 
   packages/ai: {}
 
-  packages/data-grid: {}
+  packages/data-grid:
+    devDependencies:
+      '@types/react':
+        specifier: ^18.3.3
+        version: 18.3.29
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
 
   packages/ipc: {}
 

--- a/scripts/check-ts-entry.mjs
+++ b/scripts/check-ts-entry.mjs
@@ -21,6 +21,8 @@ const result = spawnSync(
     "bundler",
     "--lib",
     "ES2022,DOM,DOM.Iterable",
+    "--jsx",
+    "react-jsx",
     "--strict",
     "--noUncheckedIndexedAccess",
     "--noImplicitOverride",


### PR DESCRIPTION
## Summary
- Stand up `@cellar/data-grid` as its own workspace package per SPEC §5.2 — filter bar, frozen columns, row-number gutter, inline cell + enum editing, pending-change tints (insert/update/delete), per-cell "was" badge, and a review-&-commit pending bar.
- Wire the grid into `Workspace.tsx` against seeded `public.orders` data so the table tab now shows realistic rows with 4 pending edits.
- Fix horizontal scrolling: `.grid-root` was a flex item with `min-width: auto`, so its intrinsic content width (~1850px from the table) blew out and got clipped by Workspace's `overflow-hidden` — `.grid-scroll` never saw overflow to scroll. Setting `min-width: 0` + `width: 100%` constrains the grid root to its allotted width and lets the scroll container do its job.
- Teach `scripts/check-ts-entry.mjs` to pass `--jsx react-jsx` so workspace packages can ship `.tsx`.

The grid is driven by callbacks (`onChange`, `onSelect`, `onEdit`, etc.) so it can be re-pointed at a real Zustand `useTabs` store or streaming Tauri query results without touching the component itself.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm exec turbo run lint` clean across all 7 workspace packages
- [x] `pnpm exec turbo run test` (1 passing in `@cellar/ipc`, others have no tests)
- [x] `pnpm exec turbo run build` produces a clean Vite build
- [ ] Manual: open the desktop app, confirm horizontal scroll works on the orders table, confirm enum dropdown editor on `status`, confirm pending-bar chips reflect the seeded changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)