### PR TITLE
feat(desktop): resizable panels and double-click-to-maximize title bar

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -15,12 +15,82 @@ import { SettingsModal } from "./components/modals/Settings";
 type Panels = { left: boolean; right: boolean; bottom: boolean };
 type ModalId = "connection" | "commit" | "palette" | "settings" | null;
 
+const LEFT_MIN = 200;
+const LEFT_MAX = 600;
+const RIGHT_MIN = 280;
+const RIGHT_MAX = 720;
+const BOTTOM_MIN = 140;
+
+function startResize(
+  axis: "x" | "y",
+  startValue: number,
+  setValue: (v: number) => void,
+  sign: 1 | -1,
+  min: number,
+  max: number,
+) {
+  return (e: React.MouseEvent) => {
+    e.preventDefault();
+    const start = axis === "x" ? e.clientX : e.clientY;
+    const onMove = (ev: MouseEvent) => {
+      const cur = axis === "x" ? ev.clientX : ev.clientY;
+      const next = Math.max(min, Math.min(max, startValue + (cur - start) * sign));
+      setValue(next);
+    };
+    const onUp = () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+    document.body.style.cursor = axis === "x" ? "col-resize" : "row-resize";
+    document.body.style.userSelect = "none";
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+  };
+}
+
+function ResizeHandle({
+  axis,
+  onMouseDown,
+}: {
+  axis: "x" | "y";
+  onMouseDown: (e: React.MouseEvent) => void;
+}) {
+  const vertical = axis === "x";
+  return (
+    <div
+      role="separator"
+      aria-orientation={vertical ? "vertical" : "horizontal"}
+      onMouseDown={onMouseDown}
+      className={
+        "group relative z-10 shrink-0 " +
+        (vertical
+          ? "w-[7px] -mx-[3px] cursor-col-resize"
+          : "h-[7px] -my-[3px] cursor-row-resize")
+      }
+    >
+      <div
+        className={
+          "absolute bg-border-default transition-colors duration-100 group-hover:bg-accent-line group-active:bg-accent " +
+          (vertical
+            ? "inset-y-0 left-1/2 w-px -translate-x-1/2"
+            : "inset-x-0 top-1/2 h-px -translate-y-1/2")
+        }
+      />
+    </div>
+  );
+}
+
 export function App() {
   const [panels, setPanels] = useState<Panels>({
     left: true,
     right: true,
     bottom: true,
   });
+  const [leftWidth, setLeftWidth] = useState(256);
+  const [rightWidth, setRightWidth] = useState(380);
+  const [bottomHeight, setBottomHeight] = useState(280);
   const [modal, setModal] = useState<ModalId>(null);
   const [empty, setEmpty] = useState(false);
 
@@ -72,12 +142,25 @@ export function App() {
 
       <div className="flex flex-1 min-h-0">
         {!empty && panels.left && (
-          <div
-            className="flex min-w-0 flex-col border-r border-border-default bg-bg-1"
-            style={{ width: 256 }}
-          >
-            <Sidebar onNewConnection={() => openModal("connection")} />
-          </div>
+          <>
+            <div
+              className="flex min-w-0 flex-col bg-bg-1"
+              style={{ width: leftWidth }}
+            >
+              <Sidebar onNewConnection={() => openModal("connection")} />
+            </div>
+            <ResizeHandle
+              axis="x"
+              onMouseDown={startResize(
+                "x",
+                leftWidth,
+                setLeftWidth,
+                1,
+                LEFT_MIN,
+                LEFT_MAX,
+              )}
+            />
+          </>
         )}
 
         <div className="flex flex-1 min-w-0 flex-col bg-bg-0">
@@ -88,21 +171,50 @@ export function App() {
               <TabBar />
               <Workspace onCommit={() => openModal("commit")} />
               {panels.bottom && (
-                <div className="flex h-[280px] flex-col border-t border-border-default bg-bg-1">
-                  <BottomPanel onClose={() => togglePanel("bottom")} />
-                </div>
+                <>
+                  <ResizeHandle
+                    axis="y"
+                    onMouseDown={startResize(
+                      "y",
+                      bottomHeight,
+                      setBottomHeight,
+                      -1,
+                      BOTTOM_MIN,
+                      Math.max(BOTTOM_MIN, Math.round(window.innerHeight * 0.7)),
+                    )}
+                  />
+                  <div
+                    className="flex flex-col bg-bg-1"
+                    style={{ height: bottomHeight }}
+                  >
+                    <BottomPanel onClose={() => togglePanel("bottom")} />
+                  </div>
+                </>
               )}
             </>
           )}
         </div>
 
         {!empty && panels.right && (
-          <div
-            className="flex min-w-0 flex-col border-l border-border-default bg-bg-1"
-            style={{ width: 380 }}
-          >
-            <AIPanel onClose={() => togglePanel("right")} />
-          </div>
+          <>
+            <ResizeHandle
+              axis="x"
+              onMouseDown={startResize(
+                "x",
+                rightWidth,
+                setRightWidth,
+                -1,
+                RIGHT_MIN,
+                RIGHT_MAX,
+              )}
+            />
+            <div
+              className="flex min-w-0 flex-col bg-bg-1"
+              style={{ width: rightWidth }}
+            >
+              <AIPanel onClose={() => togglePanel("right")} />
+            </div>
+          </>
         )}
       </div>
 

--- a/apps/desktop/src/components/TitleBar.tsx
+++ b/apps/desktop/src/components/TitleBar.tsx
@@ -1,6 +1,17 @@
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { Icon } from "./icons";
 
 type Panels = { left: boolean; right: boolean; bottom: boolean };
+
+function onTitleBarDoubleClick(e: React.MouseEvent<HTMLDivElement>) {
+  let el: HTMLElement | null = e.target as HTMLElement;
+  while (el && el !== e.currentTarget) {
+    if (getComputedStyle(el).getPropertyValue("-webkit-app-region") === "no-drag") return;
+    el = el.parentElement;
+  }
+  if (!("__TAURI_INTERNALS__" in window)) return;
+  void getCurrentWindow().toggleMaximize();
+}
 
 export function TitleBar({
   panels,
@@ -19,6 +30,7 @@ export function TitleBar({
 }) {
   return (
     <div
+      onDoubleClick={onTitleBarDoubleClick}
       className={
         "relative flex shrink-0 h-[34px] items-center gap-2.5 px-2.5 [-webkit-app-region:drag] " +
         (empty


### PR DESCRIPTION
## Summary
- Double-clicking a drag region of the title bar now toggles window maximize via the Tauri window API (skipping `no-drag` regions like buttons and the search bar).
- Left sidebar, right AI panel, and bottom output panel are now resizable via thin drag handles (1px line, 7px hit area, accent on hover/drag). Clamped to sensible min/max sizes; bottom panel maxes at 70% of viewport height.
- Replaced the redundant panel-edge borders with the handle itself so there is no double-seam.

## Test plan
- [ ] `pnpm install && pnpm --filter @cellar/desktop dev`
- [ ] Double-click the empty area of the title bar → window zooms; double-click again → restores.
- [ ] Double-clicking a title-bar button or the search bar does **not** toggle maximize.
- [ ] Drag the right edge of the left sidebar — resizes between ~200px and ~600px.
- [ ] Drag the left edge of the right AI panel — resizes between ~280px and ~720px.
- [ ] Drag the top edge of the bottom panel — resizes between 140px and ~70% of viewport height.
- [ ] Cursor changes to col/row-resize over each handle; selection is suppressed during drag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)