### PR TITLE
chore: refresh project audit guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,29 +20,33 @@ Read `SPEC.md` before making product or architectural changes. It is the canonic
 
 ## Current Status
 
-This repo is pre-alpha scaffolding. Treat the visible desktop UI as a static shell unless you have verified otherwise.
+This repo is pre-alpha, but it is no longer just a static shell. Treat it as a working vertical slice with Postgres-only database connectivity, typed IPC, live schema browsing, and a read-only table-data path.
 
 Implemented today:
 
 - Tauri 2 + React 18 + TypeScript + Vite desktop shell.
-- Static frontend layout: title bar, sidebar, tab strip, workspace placeholder, bottom panel, AI panel, status bar.
-- Cargo and pnpm workspaces.
-- Placeholder Rust crates and TypeScript packages.
+- Tailwind v4 utility styling plus CSS design tokens in `apps/desktop/src/styles/tokens.css`.
+- Zustand stores for connection, tab, and status state.
+- `cellar-core` shared Rust contracts for engines, connections, schemas, queries, typed cell values, and errors.
+- `tauri-specta` command registration and generated TypeScript bindings in `packages/ipc/src/generated.ts`.
+- Tauri commands for listing/saving/deleting/testing/connecting/disconnecting connections, schema introspection, and query execution.
+- OS-keychain credential storage in `cellar-secrets`; encrypted file fallback is documented but not built.
+- First-party Postgres driver crate at `crates/cellar-drivers/postgres`.
+- Live Postgres connection management, schema introspection, sidebar tree, table tabs, and read-only table loading.
+- `@cellar/data-grid` package with editable-cell UI, pending-change state, filter chips, sticky/frozen-column styling, and commit/revert hooks.
+- Settings, command palette, connection dialog, commit-preview modal, empty state, resizable panels, and title-bar window behavior.
+- Scaffold tests/gates for Rust contracts, IPC, package lint/test tasks, and TypeScript typechecking.
 
 Not implemented yet:
 
-- Tauri command layer and generated IPC bindings.
-- Real connection management.
-- Credential storage.
-- Postgres/MySQL/SQLite/SQL Server/Azure SQL drivers.
-- Schema introspection.
-- SQL editor.
-- Query execution and cancellation.
-- Data grid.
-- Pending edit diff/review/commit flow.
+- MySQL, SQLite, SQL Server, and Azure SQL drivers.
+- SQL editor / CodeMirror integration.
+- Query cancellation, query history, execution plans, and streaming result events.
+- Server-side grid pagination, virtualization, sorting, and type-aware filtering at scale.
+- Real pending edit diff/review/commit execution through `cellar-diff`; current grid edits are local UI state only.
 - AI providers and context pipeline.
 - Plugin runtime.
-- Meaningful tests, linting, CI, signing, updater, or packaging gates.
+- Broad unit/integration/e2e coverage, CI, signing, updater, and release packaging.
 
 ## Architecture
 
@@ -50,7 +54,7 @@ Workspace layout:
 
 - `apps/desktop/` - Tauri app shell, React frontend, Rust app entrypoint.
 - `crates/cellar-core/` - shared traits, errors, schema/query types.
-- `crates/cellar-drivers/` - first-party database drivers.
+- `crates/cellar-drivers/` - driver workspace root; Postgres lives in `crates/cellar-drivers/postgres/`.
 - `crates/cellar-sql/` - SQL parsing, formatting, dialect support.
 - `crates/cellar-diff/` - pending grid edits to transactional SQL.
 - `crates/cellar-secrets/` - OS keychain and encrypted fallback credential storage.
@@ -66,13 +70,14 @@ The intended runtime is:
 
 React frontend -> typed Tauri IPC -> Rust command/state layer -> driver traits in `cellar-core` -> concrete drivers in `cellar-drivers`.
 
-Large query results should stream through Tauri events keyed by query ID. Do not design APIs that require loading huge result sets into memory at once.
+Current query execution is materialized: the Postgres driver uses `fetch_all`, applies a host-side cap, and reports `truncated`. Large query results should still be moved to Tauri events keyed by query ID before this is considered production-safe. Do not add new APIs that require loading huge result sets into memory at once.
 
 ## Build And Validation
 
 Common checks from the repo root:
 
 ```bash
+pnpm install
 pnpm typecheck
 pnpm build
 cargo check --workspace
@@ -81,7 +86,9 @@ pnpm lint
 pnpm test
 ```
 
-Current caveat: `pnpm lint` and `pnpm test` are scaffold-era gates. They run real checks, but they are not substitutes for future ESLint/Vitest/Playwright coverage once the app has behavior to protect.
+Run `pnpm install` after pulling `main` when package dependencies or workspace links have changed. Stale `node_modules` commonly shows up as missing `@cellar/*`, `zustand`, or Tailwind plugin types.
+
+Current caveat: `pnpm lint` and `pnpm test` run real checks, but they are not substitutes for future ESLint/Vitest/Playwright coverage once the app has more behavior to protect.
 
 Use Clawpatch for automated review when preparing substantial work:
 
@@ -104,15 +111,20 @@ If Clawpatch reports findings, triage them before claiming the project is ready 
 - Keep frontend TypeScript strict.
 - Keep Rust errors typed; avoid stringly-typed backend contracts.
 - Generated IPC types should come from Rust command/type definitions, not hand-maintained duplicates.
+- After changing Tauri commands or Rust IPC-facing types, regenerate `packages/ipc/src/generated.ts` with the desktop codegen binary before updating frontend call sites.
+- Do not hand-build executable SQL in React components. Use typed Rust/SQL/diff builders for execution paths; UI previews must at least quote identifiers and escape literals safely until the shared builder exists.
+- Do not render stub controls as if they work. Unimplemented buttons, toggles, and settings must be disabled/read-only or wired to real state and callbacks.
 - Pull request titles must not use `codex:` or `[codex]` prefixes. Use conventional prefixes such as `feat:`, `fix:`, `bug:`, `chore:`, `docs:`, `test:`, `build:`, `ci:`, or `refactor:`.
 - No human-authored source, documentation, or configuration file may exceed 800 lines. If a file approaches that size, split it by responsibility before adding more code. Generated lockfiles and binary assets are exempt, but do not hand-edit them except through their owning tools.
 
 ## Security And Privacy
 
 - Never write database credentials to plain-text config.
-- Store credentials through `cellar-secrets` once implemented: OS keychain first, encrypted fallback only with explicit user-controlled master password.
+- Store credentials through `cellar-secrets`: OS keychain first. The encrypted fallback is documented in `docs/architecture/adr/0001-secret-fallback.md` but not implemented yet.
+- Connection configs are persisted under `~/.cellar/connections.json`; that file must never contain passwords or secrets.
 - Keep Tauri capabilities narrow. Frontend must not gain arbitrary shell or file access.
 - Do not send credentials to AI providers.
+- Do not reuse AI provider keys for unrelated app encryption, sync, telemetry, or account features.
 - AI context must be inspectable before sending.
 - Destructive SQL needs explicit confirmation, especially on production-tagged connections.
 - Production-tagged connections should be visually distinct and may default to read-only.
@@ -121,25 +133,24 @@ If Clawpatch reports findings, triage them before claiming the project is ready 
 
 - The UI should be dense, technical, and work-focused.
 - Dark theme is default. Light theme should remain possible.
-- Spec says design tokens belong in `packages/ui/src/tokens/`; current scaffold keeps them in `apps/desktop/src/styles/tokens.css`.
-- The spec calls for CSS variables plus selective shadcn/ui source ownership. Tailwind is listed in the spec but is not currently installed.
+- Tailwind v4 is installed and used for most component styling. Design tokens still live in `apps/desktop/src/styles/tokens.css`.
+- Keep repeated modal/settings UI split into small files under `apps/desktop/src/components/modals/`; do not grow single modal files past the 800-line rule.
 - Use keyboard-first interaction patterns. The command palette is `Cmd+K`.
 - Use monospace for SQL, identifiers, and data.
 - Avoid telemetry, cloud sync, collaboration, ETL/job orchestration, and admin/cluster-management features for v1.
 
 ## Suggested Implementation Order
 
-The best next vertical slice is:
+Best next vertical slices from the current state:
 
-1. Define core Rust types and traits in `cellar-core`.
-2. Add typed Tauri command modules under `apps/desktop/src-tauri/src/commands/`.
-3. Generate/import TypeScript IPC bindings through `packages/ipc`.
-4. Implement minimal Postgres connection storage, connect, schema introspection, and simple query execution.
-5. Replace static sidebar data with real connection/schema state.
-6. Add a basic CodeMirror editor and read-only results grid.
-7. Add tests around every backend contract before expanding engines or edit flows.
+1. Stabilize the Postgres vertical slice: integration setup, clearer errors, reconnect behavior, query cancellation, and row-limit safety.
+2. Move query results from materialized `fetch_all` to streamed/page-style Tauri events before chasing huge-grid performance.
+3. Add the CodeMirror SQL editor and wire run-current-statement / run-selection through existing typed IPC.
+4. Implement `cellar-diff` for generated transactional SQL, then connect the grid's pending edits to a real Review & Commit path.
+5. Add server-side sort/filter/pagination and real virtualization to the data grid.
+6. Broaden tests around `cellar-core`, Postgres introspection/decoding, Tauri command contracts, and the grid's pending-change behavior.
 
-Do not start with the AI panel, plugin marketplace, or multi-engine breadth before the connection/query spine works end-to-end.
+Do not prioritize AI providers, plugin runtime, or multi-engine breadth until the Postgres query/edit spine is stable and tested.
 
 ## Known Spec Gaps To Resolve
 

--- a/apps/desktop/src/components/modals/CommitModal.tsx
+++ b/apps/desktop/src/components/modals/CommitModal.tsx
@@ -53,7 +53,16 @@ export const SAMPLE_CHANGES: ChangeSet = {
 function formatVal(v: unknown): string {
   if (v === null || v === undefined) return "NULL";
   if (typeof v === "number") return String(v);
-  return "'" + v + "'";
+  if (typeof v === "boolean") return v ? "TRUE" : "FALSE";
+  return "'" + String(v).replaceAll("'", "''") + "'";
+}
+
+function quoteIdent(value: string): string {
+  return `"${value.replaceAll('"', '""')}"`;
+}
+
+function sqlComment(value: string): string {
+  return value.replaceAll("\n", " ").replaceAll("\r", " ");
 }
 
 const ED_RUN_BASE =
@@ -91,32 +100,34 @@ export function CommitModal({
   ][];
 
   const sqlLines: string[] = ["BEGIN;", ""];
+  const tableIdent = `public.${quoteIdent(table)}`;
   updates.forEach(([id, c]) => {
-    sqlLines.push(`-- ${c.row.order_number} · updated by alice@laptop`);
-    sqlLines.push(`UPDATE public.${table}`);
+    sqlLines.push(`-- ${sqlComment(c.row.order_number)} · updated by alice@laptop`);
+    sqlLines.push(`UPDATE ${tableIdent}`);
     const sets = Object.entries(c.edits).map(
-      ([col, e]) => `  ${col} = ${formatVal(e.to)}`,
+      ([col, e]) => `  ${quoteIdent(col)} = ${formatVal(e.to)}`,
     );
     sqlLines.push("SET");
     sqlLines.push(sets.join(",\n"));
-    sqlLines.push(`WHERE id = '${id}';`);
+    sqlLines.push(`WHERE ${quoteIdent("id")} = ${formatVal(id)};`);
     sqlLines.push("");
   });
   inserts.forEach(([id, c]) => {
     const cols = Object.keys(c.row);
     const vals = cols.map((k) => formatVal(c.row[k]));
-    sqlLines.push(`INSERT INTO public.${table} (${cols.join(", ")})`);
+    sqlLines.push(`INSERT INTO ${tableIdent} (${cols.map(quoteIdent).join(", ")})`);
     sqlLines.push(`VALUES (${vals.join(", ")});`);
     sqlLines.push("");
     void id;
   });
   deletes.forEach(([id, c]) => {
-    sqlLines.push(`-- ${c.row.order_number} · marked for deletion`);
-    sqlLines.push(`DELETE FROM public.${table} WHERE id = '${id}';`);
+    sqlLines.push(`-- ${sqlComment(c.row.order_number)} · marked for deletion`);
+    sqlLines.push(`DELETE FROM ${tableIdent} WHERE ${quoteIdent("id")} = ${formatVal(id)};`);
     sqlLines.push("");
   });
   sqlLines.push("COMMIT;");
-  const lines = tokensToLines(tokenizeSql(sqlLines.join("\n")));
+  const sqlText = sqlLines.join("\n");
+  const lines = tokensToLines(tokenizeSql(sqlText));
 
   return (
     <Modal onClose={onClose} width={880}>
@@ -133,7 +144,7 @@ export function CommitModal({
             shop-eu (prod)
           </span>
         </div>
-        <button className="icon-btn" onClick={onClose} title="Close">
+        <button type="button" className="icon-btn" onClick={onClose} title="Close">
           <Icon.close size={13} />
         </button>
       </div>
@@ -251,11 +262,20 @@ export function CommitModal({
           <div className="flex h-[26px] shrink-0 items-center justify-between border-b border-border-divider bg-bg-1 px-3 text-[10px] font-semibold uppercase tracking-[0.05em] text-fg-3">
             <span>Generated SQL</span>
             <div className="flex gap-1">
-              <button className="inline-flex h-[26px] items-center gap-1 rounded-[4px] border border-border-default bg-bg-2 px-2 text-[11px] text-fg-1 hover:bg-bg-3">
+              <button
+                type="button"
+                disabled
+                title="SQL editing is not wired yet"
+                className="inline-flex h-[26px] cursor-not-allowed items-center gap-1 rounded-[4px] border border-border-default bg-bg-2 px-2 text-[11px] text-fg-2 opacity-70"
+              >
                 <Icon.edit size={11} />
                 <span>Edit</span>
               </button>
-              <button className="inline-flex h-[26px] items-center gap-1 rounded-[4px] border border-border-default bg-bg-2 px-2 text-[11px] text-fg-1 hover:bg-bg-3">
+              <button
+                type="button"
+                onClick={() => void navigator.clipboard?.writeText(sqlText)}
+                className="inline-flex h-[26px] items-center gap-1 rounded-[4px] border border-border-default bg-bg-2 px-2 text-[11px] text-fg-1 hover:bg-bg-3"
+              >
                 <Icon.copy size={11} />
                 <span>Copy</span>
               </button>
@@ -305,15 +325,23 @@ export function CommitModal({
           </span>
         </div>
         <div className="flex items-center gap-2">
-          <button className={ED_RUN_SUBTLE} onClick={onClose}>
+          <button type="button" className={ED_RUN_SUBTLE} onClick={onClose}>
             Cancel
           </button>
-          <button className={ED_RUN_SUBTLE}>
+          <button
+            type="button"
+            disabled
+            title="Migration export is not wired yet"
+            className={ED_RUN_SUBTLE + " cursor-not-allowed opacity-60"}
+          >
             <Icon.undo size={11} />
             <span>Save as migration</span>
           </button>
           <button
-            className={ED_RUN_DANGER}
+            type="button"
+            disabled
+            title="Committing pending edits is not wired yet"
+            className={ED_RUN_DANGER + " cursor-not-allowed opacity-60"}
             style={{
               borderColor: "color-mix(in oklab, var(--delete) 40%, black)",
             }}

--- a/apps/desktop/src/components/modals/Settings.tsx
+++ b/apps/desktop/src/components/modals/Settings.tsx
@@ -1,14 +1,28 @@
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Icon, type IconName } from "../icons";
 import { Modal } from "./Modal";
+import { SettingsAI } from "./settingsAIPanel";
 import {
-  ACCENT_SWATCHES,
-  FONT_SIZE_MAX,
-  FONT_SIZE_MIN,
-  useSettings,
-  type Density,
-  type Theme,
-} from "../../lib/settings";
+  SettingsBackups,
+  SettingsConnections,
+  SettingsHistory,
+} from "./settingsDataPanels";
+import {
+  SettingsAbout,
+  SettingsPrivacy,
+  SettingsUpdates,
+} from "./settingsSystemPanels";
+import {
+  SettingsAppearance,
+  SettingsEditor,
+  SettingsGeneral,
+  SettingsGrid,
+  SettingsKeymap,
+} from "./settingsWorkspacePanels";
+import {
+  ED_RUN_PRIMARY,
+  ED_RUN_SUBTLE,
+} from "./settingsPrimitives";
 
 type CatId =
   | "general"
@@ -62,20 +76,6 @@ const SETTINGS_CATS: CatGroup[] = [
   },
 ];
 
-const ED_RUN_BASE =
-  "inline-flex h-[26px] items-center gap-[5px] whitespace-nowrap rounded-[4px] border border-transparent px-2.5 text-[11.5px] font-medium text-fg-1 transition-[background,color,border-color,filter] duration-[120ms]";
-const ED_RUN_SUBTLE =
-  ED_RUN_BASE +
-  " bg-transparent border-border-default hover:bg-bg-3 hover:border-border-strong hover:text-fg-0";
-const ED_RUN_PRIMARY =
-  ED_RUN_BASE + " bg-accent text-accent-fg hover:brightness-[1.07]";
-const ED_RUN_DANGER =
-  ED_RUN_BASE +
-  " bg-transparent border-[color-mix(in_oklab,var(--delete)_30%,var(--border-default))] text-delete hover:bg-delete-bg hover:border-delete";
-
-const CD_INPUT =
-  "h-[26px] min-w-0 flex-1 rounded-[4px] border border-border-default bg-bg-inset px-2 text-[11.5px] text-fg-0 outline-none focus:border-accent-line focus:bg-bg-2";
-
 export function SettingsModal({
   onClose,
   initialCat = "appearance",
@@ -103,7 +103,6 @@ export function SettingsModal({
 
   return (
     <Modal onClose={onClose} width={960} height={660} className="!max-h-[90vh]">
-      {/* Head */}
       <div className="flex h-[42px] shrink-0 items-center gap-3 border-b border-border-default pl-3 pr-2">
         <span className="inline-flex text-accent">
           <Icon.settings size={14} />
@@ -128,12 +127,11 @@ export function SettingsModal({
           </span>
         </div>
 
-        <button className="icon-btn" onClick={onClose} title="Close">
+        <button type="button" className="icon-btn" onClick={onClose} title="Close">
           <Icon.close size={13} />
         </button>
       </div>
 
-      {/* Body */}
       <div className="grid min-h-0 flex-1 overflow-hidden grid-cols-[200px_1fr]">
         <SettingsNav cat={cat} setCat={setCat} q={q} />
         <div className="flex min-h-0 min-w-0 flex-col bg-bg-1">
@@ -152,31 +150,37 @@ export function SettingsModal({
         </div>
       </div>
 
-      {/* Foot */}
       <div className="flex h-11 shrink-0 items-center justify-between gap-3 border-t border-border-default bg-bg-2 px-3">
         <span className="inline-flex items-center gap-1.5 text-[11px]">
           <span
             className="h-1.5 w-1.5 rounded-full"
             style={{ background: "var(--insert)" }}
           />
-          <span className="text-fg-2">Synced to</span>
-          <span className="font-mono text-fg-1">~/.cellar/settings.toml</span>
+          <span className="text-fg-2">Saved locally</span>
+          <span className="font-mono text-fg-1">browser storage</span>
           <span className="text-fg-3">·</span>
-          <button className="text-[11px] text-accent underline underline-offset-2">
+          <button
+            type="button"
+            disabled
+            className="cursor-not-allowed text-[11px] text-fg-3 underline underline-offset-2"
+            title="Raw settings editing is not wired yet"
+          >
             edit raw
           </button>
         </span>
         <div className="flex items-center gap-2">
-          <button className={ED_RUN_SUBTLE} onClick={onClose}>
-            Cancel
-          </button>
-          <button className={ED_RUN_SUBTLE}>
+          <button
+            type="button"
+            disabled
+            title="Section reset is not wired yet"
+            className={ED_RUN_SUBTLE + " cursor-not-allowed opacity-60"}
+          >
             <Icon.undo size={11} />
             <span>Reset section</span>
           </button>
-          <button className={ED_RUN_PRIMARY} onClick={onClose}>
+          <button type="button" className={ED_RUN_PRIMARY} onClick={onClose}>
             <Icon.check size={11} />
-            <span>Apply</span>
+            <span>Done</span>
           </button>
         </div>
       </div>
@@ -211,6 +215,7 @@ function SettingsNav({
               const active = cat === i.id;
               return (
                 <button
+                  type="button"
                   key={i.id}
                   onClick={() => setCat(i.id)}
                   className={
@@ -248,996 +253,12 @@ function SettingsNav({
         );
       })}
       <div className="mt-auto flex items-center gap-1.5 border-t border-border-divider px-[14px] py-2.5 text-[10px]">
-        <span className="font-mono text-fg-3">v0.4.2</span>
+        <span className="font-mono text-fg-3">v0.1.0-alpha</span>
         <span className="text-fg-3">·</span>
-        <button className="text-[10px] text-accent underline underline-offset-2">
+        <button type="button" className="text-[10px] text-accent underline underline-offset-2">
           docs
         </button>
       </div>
     </nav>
-  );
-}
-
-/* ─── Section primitives ─── */
-
-function Section({
-  title,
-  sub,
-  children,
-}: {
-  title: string;
-  sub?: string;
-  children: ReactNode;
-}) {
-  return (
-    <section className="px-6 pb-1 pt-[18px] [&+section]:mt-1.5 [&+section]:border-t [&+section]:border-border-divider">
-      <header className="mb-3">
-        <h2 className="m-0 text-[13px] font-semibold tracking-[-0.005em] text-fg-0">
-          {title}
-        </h2>
-        {sub && (
-          <p className="m-0 mt-px max-w-[60ch] text-[11.5px] text-fg-2 text-pretty">
-            {sub}
-          </p>
-        )}
-      </header>
-      <div className="flex flex-col gap-2">{children}</div>
-    </section>
-  );
-}
-
-function Row({
-  label,
-  hint,
-  children,
-  stack,
-}: {
-  label: string;
-  hint?: string;
-  children: ReactNode;
-  stack?: boolean;
-}) {
-  return (
-    <div
-      className={
-        "grid min-h-[24px] grid-cols-[180px_1fr] gap-[14px] py-1 " +
-        (stack ? "items-start" : "items-center")
-      }
-    >
-      <div className="flex flex-col gap-[2px] text-[11.5px] font-medium text-fg-1">
-        <span>{label}</span>
-        {hint && (
-          <span className="text-[10.5px] font-normal text-fg-3 text-pretty">
-            {hint}
-          </span>
-        )}
-      </div>
-      <div
-        className={
-          "min-w-0 text-[11.5px] " +
-          (stack
-            ? "block"
-            : "flex flex-wrap items-center gap-2")
-        }
-      >
-        {children}
-      </div>
-    </div>
-  );
-}
-
-function Toggle({
-  on,
-  onChange,
-  locked,
-}: {
-  on: boolean;
-  onChange?: (v: boolean) => void;
-  locked?: boolean;
-}) {
-  return (
-    <button
-      onClick={() => !locked && onChange?.(!on)}
-      title={locked ? "Forced on for prod connections" : undefined}
-      className={
-        "relative h-4 w-7 shrink-0 rounded-[10px] transition-colors duration-150 " +
-        (on ? (locked ? "bg-warn" : "bg-accent") : "bg-bg-3") +
-        (locked ? " cursor-not-allowed opacity-85" : "")
-      }
-    >
-      <span
-        className={
-          "absolute top-[2px] h-3 w-3 rounded-full bg-white transition-[left] duration-150 " +
-          (on ? "left-[14px]" : "left-[2px]")
-        }
-      />
-    </button>
-  );
-}
-
-function Segment<T extends string>({
-  options,
-  value,
-  onChange,
-}: {
-  options: { value: T; label: string }[];
-  value: T;
-  onChange?: (v: T) => void;
-}) {
-  return (
-    <div className="inline-flex gap-px rounded-[4px] border border-border-default bg-bg-inset p-[2px]">
-      {options.map((o) => (
-        <button
-          key={o.value}
-          onClick={() => onChange?.(o.value)}
-          className={
-            "h-5 rounded-[3px] px-2.5 text-[11px] " +
-            (value === o.value
-              ? "bg-bg-3 font-medium text-fg-0"
-              : "text-fg-2 hover:text-fg-0")
-          }
-        >
-          {o.label}
-        </button>
-      ))}
-    </div>
-  );
-}
-
-function StaticSegment({ values, activeIdx }: { values: string[]; activeIdx: number }) {
-  return (
-    <div className="inline-flex gap-px rounded-[4px] border border-border-default bg-bg-inset p-[2px]">
-      {values.map((v, i) => (
-        <button
-          key={v}
-          className={
-            "h-5 rounded-[3px] px-2.5 text-[11px] " +
-            (i === activeIdx
-              ? "bg-bg-3 font-medium text-fg-0"
-              : "text-fg-2 hover:text-fg-0")
-          }
-        >
-          {v}
-        </button>
-      ))}
-    </div>
-  );
-}
-
-function StubBanner({ children }: { children: ReactNode }) {
-  return (
-    <div className="mx-6 my-2 flex items-center gap-1.5 rounded-[4px] border border-dashed border-border-default bg-bg-inset px-3 py-2 text-[11px] text-fg-2">
-      <Icon.info size={12} stroke="var(--fg-3)" />
-      <span>{children}</span>
-    </div>
-  );
-}
-
-/* ─── Appearance (real settings) ─── */
-
-function SettingsAppearance() {
-  const { settings, set } = useSettings();
-
-  return (
-    <div className="flex-1 overflow-y-auto pb-6 pt-1">
-      <Section title="Theme">
-        <Row label="Theme">
-          <Segment<Theme>
-            value={settings.theme}
-            onChange={(v) => set("theme", v)}
-            options={[
-              { value: "system", label: "system" },
-              { value: "dark", label: "dark" },
-              { value: "light", label: "light" },
-            ]}
-          />
-        </Row>
-        <Row label="Accent">
-          <div className="flex flex-wrap gap-1">
-            {ACCENT_SWATCHES.map((c) => {
-              const active = settings.accent.toLowerCase() === c.toLowerCase();
-              return (
-                <button
-                  key={c}
-                  onClick={() => set("accent", c)}
-                  className={
-                    "h-[18px] w-[18px] rounded-[4px] border border-white/10 transition-transform hover:scale-110 " +
-                    (active
-                      ? "shadow-[0_0_0_2px_var(--bg-1),0_0_0_3px_var(--fg-0)]"
-                      : "")
-                  }
-                  style={{ background: c }}
-                  title={c}
-                />
-              );
-            })}
-          </div>
-        </Row>
-        <Row label="Density">
-          <Segment<Density>
-            value={settings.density}
-            onChange={(v) => set("density", v)}
-            options={[
-              { value: "compact", label: "compact" },
-              { value: "comfortable", label: "comfortable" },
-            ]}
-          />
-        </Row>
-      </Section>
-
-      <Section title="Type">
-        <Row label="Interface font">
-          <input
-            className={CD_INPUT + " font-sans"}
-            value={settings.interfaceFont}
-            onChange={(e) => set("interfaceFont", e.target.value)}
-            style={{ flex: 1 }}
-          />
-        </Row>
-        <Row label="Editor / mono font">
-          <input
-            className={CD_INPUT + " font-mono"}
-            value={settings.monoFont}
-            onChange={(e) => set("monoFont", e.target.value)}
-            style={{ flex: 1 }}
-          />
-        </Row>
-        <Row
-          label="Font size"
-          hint="Scales the entire interface. Default is 12.5 px."
-        >
-          <input
-            className={CD_INPUT + " font-mono"}
-            style={{ width: 70, flex: "none" }}
-            type="number"
-            min={FONT_SIZE_MIN}
-            max={FONT_SIZE_MAX}
-            step={0.5}
-            value={settings.fontSizePx}
-            onChange={(e) => {
-              const v = parseFloat(e.target.value);
-              if (Number.isFinite(v)) set("fontSizePx", v);
-            }}
-          />
-          <span className="text-[11px] text-fg-2">px</span>
-          <div className="relative ml-2 w-[220px] pt-[14px]">
-            <span className="absolute top-0 left-0 -translate-x-1/2 whitespace-nowrap text-[9.5px] text-fg-3">
-              {FONT_SIZE_MIN}
-            </span>
-            <span className="absolute top-0 left-1/2 -translate-x-1/2 whitespace-nowrap text-[9.5px] text-fg-3">
-              12.5
-            </span>
-            <span className="absolute top-0 right-0 translate-x-1/2 whitespace-nowrap text-[9.5px] text-fg-3">
-              {FONT_SIZE_MAX}
-            </span>
-            <input
-              type="range"
-              min={FONT_SIZE_MIN}
-              max={FONT_SIZE_MAX}
-              step={0.5}
-              value={settings.fontSizePx}
-              onChange={(e) => set("fontSizePx", parseFloat(e.target.value))}
-              className="m-0 h-[18px] w-full"
-              style={{ accentColor: "var(--accent)" }}
-            />
-          </div>
-        </Row>
-      </Section>
-
-      <Section title="Window">
-        <Row label="Show traffic lights">
-          <Toggle on={true} />
-        </Row>
-        <Row label="Native window controls">
-          <Toggle on={false} />
-        </Row>
-      </Section>
-    </div>
-  );
-}
-
-/* ─── Stub panels ─── */
-
-function SettingsGeneral() {
-  return (
-    <div className="flex-1 overflow-y-auto pb-6 pt-1">
-      <Section title="General">
-        <Row label="Startup">
-          <StaticSegment
-            values={["Restore last session", "Empty workspace", "Show welcome"]}
-            activeIdx={0}
-          />
-        </Row>
-        <Row label="Default schema search path">
-          <input
-            className={CD_INPUT + " font-mono"}
-            defaultValue="public, audit, analytics"
-            style={{ flex: 1 }}
-          />
-        </Row>
-        <Row label="Confirm before quitting">
-          <Toggle on={true} />
-        </Row>
-        <Row label="Allow background queries">
-          <Toggle on={true} />
-        </Row>
-      </Section>
-      <Section title="Updates">
-        <Row label="Channel">
-          <StaticSegment values={["stable", "beta", "nightly"]} activeIdx={0} />
-        </Row>
-        <Row label="Auto-install on quit">
-          <Toggle on={true} />
-        </Row>
-      </Section>
-    </div>
-  );
-}
-
-function SettingsEditor() {
-  return (
-    <div className="flex-1 overflow-y-auto pb-6 pt-1">
-      <Section title="SQL editor">
-        <Row label="Tab size">
-          <StaticSegment values={["2", "4", "8"]} activeIdx={1} />
-        </Row>
-        <Row label="Indent with">
-          <StaticSegment values={["spaces", "tabs"]} activeIdx={0} />
-        </Row>
-        <Row label="Auto-format on save">
-          <Toggle on={true} />
-        </Row>
-        <Row label="Keyword case">
-          <StaticSegment values={["UPPER", "lower", "Preserve"]} activeIdx={0} />
-        </Row>
-        <Row label="Show line numbers">
-          <Toggle on={true} />
-        </Row>
-        <Row label="Soft wrap">
-          <Toggle on={false} />
-        </Row>
-        <Row label="Bracket matching">
-          <Toggle on={true} />
-        </Row>
-      </Section>
-      <Section title="Execution">
-        <Row label="Statement at cursor runs">
-          <StaticSegment
-            values={["current statement", "selection", "whole file"]}
-            activeIdx={0}
-          />
-        </Row>
-        <Row label="LIMIT applied to SELECT *">
-          <input
-            className={CD_INPUT + " font-mono"}
-            defaultValue="500"
-            style={{ width: 70, flex: "none" }}
-          />
-        </Row>
-      </Section>
-    </div>
-  );
-}
-
-function SettingsGrid() {
-  return (
-    <div className="flex-1 overflow-y-auto pb-6 pt-1">
-      <Section title="Data grid">
-        <Row label="Row height">
-          <StaticSegment values={["20px", "22px", "28px", "36px"]} activeIdx={1} />
-        </Row>
-        <Row label="NULL display">
-          <input
-            className={CD_INPUT + " font-mono"}
-            defaultValue="NULL"
-            style={{ width: 120, flex: "none" }}
-          />
-          <StaticSegment values={["dim italic", "strong"]} activeIdx={0} />
-        </Row>
-        <Row label="Number alignment">
-          <StaticSegment values={["left", "right"]} activeIdx={1} />
-        </Row>
-        <Row label="Stripe alternating rows">
-          <Toggle on={false} />
-        </Row>
-        <Row label="Sticky pkey column">
-          <Toggle on={true} />
-        </Row>
-        <Row label="Truncate cells over">
-          <input
-            className={CD_INPUT + " font-mono"}
-            defaultValue="200"
-            style={{ width: 70, flex: "none" }}
-          />
-          <span className="text-[11px] text-fg-2">chars</span>
-        </Row>
-      </Section>
-    </div>
-  );
-}
-
-function SettingsKeymap() {
-  const SHORTCUTS: { grp: string; items: { k: string; kbd: string }[] }[] = [
-    {
-      grp: "Workspace",
-      items: [
-        { k: "Command palette", kbd: "⌘K" },
-        { k: "New connection", kbd: "⌘N" },
-        { k: "New SQL tab", kbd: "⌘T" },
-        { k: "Close tab", kbd: "⌘W" },
-        { k: "Settings", kbd: "⌘," },
-        { k: "Toggle sidebar", kbd: "⌘B" },
-        { k: "Toggle AI panel", kbd: "⌘J" },
-        { k: "Toggle results panel", kbd: "⌘↓" },
-      ],
-    },
-    {
-      grp: "Editor",
-      items: [
-        { k: "Run statement", kbd: "⌘⏎" },
-        { k: "Run selection", kbd: "⌥⏎" },
-        { k: "Format", kbd: "⌥⇧F" },
-        { k: "Accept ghost text", kbd: "Tab" },
-        { k: "Show schema for symbol", kbd: "F12" },
-      ],
-    },
-    {
-      grp: "Grid",
-      items: [
-        { k: "Edit cell", kbd: "⏎" },
-        { k: "Revert cell", kbd: "Esc" },
-        { k: "Commit changes", kbd: "⌘S" },
-        { k: "Revert all pending", kbd: "⌘⇧Z" },
-        { k: "Set NULL", kbd: "⌘⌫" },
-      ],
-    },
-  ];
-
-  return (
-    <div className="flex-1 overflow-y-auto pb-6 pt-1">
-      <Section title="Keymap" sub="Pick a preset or rebind any individual shortcut.">
-        <Row label="Preset">
-          <StaticSegment
-            values={["Cellar", "DataGrip", "VS Code", "Linear"]}
-            activeIdx={0}
-          />
-        </Row>
-      </Section>
-      {SHORTCUTS.map((g) => (
-        <Section key={g.grp} title={g.grp}>
-          <div className="flex flex-col">
-            {g.items.map((s) => (
-              <div
-                key={s.k}
-                className="grid grid-cols-[1fr_auto_auto] items-center gap-3 border-b border-dashed border-border-divider py-1.5 last:border-b-0"
-              >
-                <span className="text-[11.5px] text-fg-1">{s.k}</span>
-                <span className="inline-flex gap-0.5">
-                  {[...s.kbd].map((k, i) => (
-                    <kbd key={i} className="kbd">
-                      {k}
-                    </kbd>
-                  ))}
-                </span>
-                <button className="icon-btn" title="rebind">
-                  <Icon.edit size={10} />
-                </button>
-              </div>
-            ))}
-          </div>
-        </Section>
-      ))}
-    </div>
-  );
-}
-
-function SettingsConnections() {
-  return (
-    <div className="flex-1 overflow-y-auto pb-6 pt-1">
-      <Section
-        title="Defaults for new connections"
-        sub="Applied when you create a connection. Per-connection overrides win."
-      >
-        <Row label="Read-only by default">
-          <Toggle on={true} />
-        </Row>
-        <Row label="Connection timeout">
-          <input
-            className={CD_INPUT + " font-mono"}
-            defaultValue="10"
-            style={{ width: 70, flex: "none" }}
-          />
-          <span className="text-[11px] text-fg-2">seconds</span>
-        </Row>
-        <Row label="Keep-alive interval">
-          <input
-            className={CD_INPUT + " font-mono"}
-            defaultValue="30"
-            style={{ width: 70, flex: "none" }}
-          />
-          <span className="text-[11px] text-fg-2">seconds</span>
-        </Row>
-        <Row label="Application name">
-          <input
-            className={CD_INPUT + " font-mono"}
-            defaultValue="cellar (alice@laptop)"
-            style={{ flex: 1 }}
-          />
-        </Row>
-      </Section>
-      <Section
-        title="Production safety"
-        sub="Cellar will require you to type the connection name before running these against any 'prod' connection."
-      >
-        <Row label="Confirm DML on prod">
-          <Toggle on={true} locked />
-        </Row>
-        <Row label="Confirm DROP / TRUNCATE on prod">
-          <Toggle on={true} locked />
-        </Row>
-        <Row label="Block UPDATE without WHERE">
-          <Toggle on={true} />
-        </Row>
-        <Row label="Block DELETE without WHERE">
-          <Toggle on={true} />
-        </Row>
-        <Row label="Max rows affected before warn">
-          <input
-            className={CD_INPUT + " font-mono"}
-            defaultValue="100"
-            style={{ width: 70, flex: "none" }}
-          />
-          <span className="text-[11px] text-fg-2">rows</span>
-        </Row>
-      </Section>
-    </div>
-  );
-}
-
-function SettingsHistory() {
-  return (
-    <div className="flex-1 overflow-y-auto pb-6 pt-1">
-      <Section title="Query history">
-        <Row label="Retain history for">
-          <StaticSegment
-            values={["7 days", "30 days", "90 days", "forever"]}
-            activeIdx={2}
-          />
-        </Row>
-        <Row label="Store query results">
-          <Toggle on={false} />
-        </Row>
-        <Row
-          label="Sync history across machines"
-          hint="end-to-end encrypted via your Anthropic key"
-        >
-          <Toggle on={false} />
-        </Row>
-      </Section>
-      <StubBanner>23,418 queries · 14.2 MB · last cleared 12 days ago</StubBanner>
-    </div>
-  );
-}
-
-function SettingsBackups() {
-  return (
-    <div className="flex-1 overflow-y-auto pb-6 pt-1">
-      <Section title="Backups">
-        <Row
-          label="Auto-snapshot before commits"
-          hint="pg_dump --schema-only + affected rows"
-        >
-          <Toggle on={true} />
-        </Row>
-        <Row label="Snapshot location">
-          <input
-            className={CD_INPUT + " font-mono"}
-            defaultValue="~/.cellar/snapshots"
-            style={{ flex: 1 }}
-          />
-          <button className="inline-flex h-[26px] items-center gap-1 rounded-[4px] border border-border-default bg-bg-2 px-2 text-[11px] text-fg-1 hover:bg-bg-3">
-            <Icon.fileText size={11} />
-            <span>Browse</span>
-          </button>
-        </Row>
-        <Row label="Retain snapshots for">
-          <input
-            className={CD_INPUT + " font-mono"}
-            defaultValue="30"
-            style={{ width: 70, flex: "none" }}
-          />
-          <span className="text-[11px] text-fg-2">days</span>
-        </Row>
-      </Section>
-      <Section title="Export defaults">
-        <Row label="Format">
-          <StaticSegment
-            values={["CSV", "JSON", "Parquet", "SQL INSERT"]}
-            activeIdx={0}
-          />
-        </Row>
-        <Row label="NULL as">
-          <input
-            className={CD_INPUT + " font-mono"}
-            defaultValue="\\N"
-            style={{ width: 120, flex: "none" }}
-          />
-        </Row>
-        <Row label="Include headers">
-          <Toggle on={true} />
-        </Row>
-      </Section>
-    </div>
-  );
-}
-
-function SettingsAI() {
-  const [provider, setProvider] = useState("anthropic");
-  const [model, setModel] = useState("claude-sonnet-4.5");
-  const [reveal, setReveal] = useState(false);
-
-  const PROVIDERS = [
-    { id: "anthropic", label: "Anthropic", sub: "claude-* family" },
-    { id: "openai", label: "OpenAI", sub: "gpt-* family" },
-    { id: "google", label: "Google", sub: "gemini-* family" },
-    { id: "local", label: "Local", sub: "Ollama, LM Studio" },
-    { id: "custom", label: "Custom", sub: "OpenAI-compatible URL" },
-  ];
-  const MODELS = [
-    {
-      id: "claude-sonnet-4.5",
-      ctx: "200k",
-      tag: "balanced" as const,
-      def: true,
-    },
-    { id: "claude-opus-4", ctx: "200k", tag: "max" as const },
-    { id: "claude-haiku-4.5", ctx: "200k", tag: "fast" as const },
-  ];
-  const tagClass: Record<"balanced" | "max" | "fast", string> = {
-    balanced: "text-accent bg-accent-soft",
-    max: "text-update bg-update-bg",
-    fast: "text-insert bg-insert-bg",
-  };
-
-  return (
-    <div className="flex-1 overflow-y-auto pb-6 pt-1">
-      <Section
-        title="AI Assistant"
-        sub="Cellar's AI runs entirely on your key. Your queries, schemas and results never touch our servers."
-      >
-        <div className="flex gap-2.5 rounded-[6px] border border-accent-line bg-accent-soft px-3.5 py-3">
-          <span className="inline-flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-[5px] border border-accent-line bg-bg-1">
-            <Icon.sparkles size={12} stroke="var(--accent)" />
-          </span>
-          <div className="text-pretty">
-            <div className="mb-0.5 text-[12px] font-semibold text-fg-0">
-              Bring-your-own-key, by design
-            </div>
-            <div className="text-[11.5px] leading-[1.45] text-fg-1">
-              All AI requests go directly from your machine to the provider. We
-              see nothing. Cellar is open-source — verify the network path at{" "}
-              <span className="font-mono text-fg-0">
-                github.com/cellar/ai-router
-              </span>
-              .
-            </div>
-          </div>
-        </div>
-      </Section>
-
-      <Section title="Provider">
-        <Row label="Provider">
-          <div className="grid w-full grid-cols-5 gap-1.5">
-            {PROVIDERS.map((p) => {
-              const active = provider === p.id;
-              return (
-                <button
-                  key={p.id}
-                  onClick={() => setProvider(p.id)}
-                  className={
-                    "relative flex flex-col items-start gap-0.5 rounded-[5px] border px-[9px] py-2 text-left " +
-                    (active
-                      ? "border-accent bg-accent-soft shadow-[inset_0_0_0_1px_var(--accent)]"
-                      : "border-border-default bg-bg-2 hover:border-border-strong")
-                  }
-                >
-                  <span className="text-[11.5px] font-medium text-fg-0">
-                    {p.label}
-                  </span>
-                  <span
-                    className={
-                      "font-mono text-[9.5px] " +
-                      (active ? "text-accent opacity-85" : "text-fg-3")
-                    }
-                  >
-                    {p.sub}
-                  </span>
-                  {active && (
-                    <span className="absolute right-[5px] top-[5px] inline-flex h-3 w-3 items-center justify-center rounded-full bg-accent text-accent-fg">
-                      <Icon.check size={9} />
-                    </span>
-                  )}
-                </button>
-              );
-            })}
-          </div>
-        </Row>
-
-        <Row label="Model" hint="used for chat, generation, ghost text">
-          <div className="flex w-full flex-col gap-[3px]">
-            {MODELS.map((m) => {
-              const active = model === m.id;
-              return (
-                <label
-                  key={m.id}
-                  className={
-                    "grid cursor-pointer grid-cols-[14px_1fr_auto_auto_auto] items-center gap-2.5 rounded-[4px] border px-2.5 py-1.5 " +
-                    (active
-                      ? "border-accent-line bg-accent-soft"
-                      : "border-border-default bg-bg-2 hover:border-border-strong")
-                  }
-                >
-                  <span
-                    className={
-                      "relative inline-block h-3 w-3 rounded-full border " +
-                      (active ? "border-accent" : "border-border-strong")
-                    }
-                  >
-                    {active && (
-                      <span
-                        className="absolute inset-[2px] rounded-full"
-                        style={{ background: "var(--accent)" }}
-                      />
-                    )}
-                  </span>
-                  <input
-                    type="radio"
-                    className="hidden"
-                    checked={active}
-                    onChange={() => setModel(m.id)}
-                  />
-                  <span className="font-mono text-[11.5px] text-fg-0">
-                    {m.id}
-                  </span>
-                  <span className="font-mono text-[10px] text-fg-3">
-                    {m.ctx} ctx
-                  </span>
-                  <span
-                    className={
-                      "rounded-[3px] px-1.5 py-px font-mono text-[9.5px] uppercase tracking-[0.04em] " +
-                      tagClass[m.tag]
-                    }
-                  >
-                    {m.tag}
-                  </span>
-                  {m.def && (
-                    <span className="text-[9.5px] italic text-fg-2">
-                      recommended
-                    </span>
-                  )}
-                </label>
-              );
-            })}
-          </div>
-        </Row>
-
-        <Row
-          label="API key"
-          hint="stored in OS keychain, never written to disk"
-        >
-          <div className="inline-flex min-w-0 flex-1 items-center gap-1">
-            <span className="inline-flex h-[26px] items-center rounded-l-[4px] border border-r-0 border-border-default bg-bg-inset px-1.5 font-mono text-[11px] text-fg-2">
-              sk-ant-
-            </span>
-            <input
-              className="-ml-px h-[26px] min-w-0 flex-1 border border-border-default bg-bg-inset px-2 font-mono text-[11.5px] text-fg-0 outline-none focus:border-accent-line focus:bg-bg-2"
-              type={reveal ? "text" : "password"}
-              defaultValue={
-                reveal
-                  ? "api03-rXg7vQ2hN8jK4pL6mZ9bW3yT1uF5aE0dC2sB"
-                  : "•••••••••••••••••••••••••••••••••••"
-              }
-              spellCheck={false}
-            />
-            <button
-              onClick={() => setReveal(!reveal)}
-              className="inline-flex h-[26px] items-center gap-1 rounded-[4px] border border-border-default bg-bg-2 px-2 text-[10.5px] text-fg-1 hover:bg-bg-3"
-            >
-              {reveal ? "hide" : "reveal"}
-            </button>
-            <button className="inline-flex h-[26px] items-center gap-1 rounded-[4px] border border-border-default bg-bg-2 px-2 text-[11px] text-fg-1 hover:bg-bg-3">
-              <Icon.edit size={11} />
-              <span>change</span>
-            </button>
-          </div>
-          <span className="inline-flex items-center gap-1.5 text-[10.5px]">
-            <Icon.check size={10} stroke="var(--insert)" />
-            <span className="text-insert">Verified</span>
-            <span className="text-fg-3">·</span>
-            <span className="font-mono text-fg-2">tier 3</span>
-            <span className="text-fg-3">·</span>
-            <span className="font-mono text-fg-2">last used 4m ago</span>
-          </span>
-        </Row>
-
-        <Row label="Endpoint" hint="override for proxies, custom routers">
-          <input
-            className={CD_INPUT + " font-mono"}
-            defaultValue="https://api.anthropic.com/v1"
-            style={{ flex: 1 }}
-          />
-        </Row>
-      </Section>
-
-      <Section title="Danger zone">
-        <Row
-          label="Clear AI conversation history"
-          hint="20 conversations, 3.2 MB locally"
-        >
-          <button className={ED_RUN_DANGER}>
-            <Icon.trash size={11} />
-            <span>Clear all</span>
-          </button>
-        </Row>
-        <Row
-          label="Revoke API key"
-          hint="remove from keychain — does not affect provider"
-        >
-          <button className={ED_RUN_DANGER}>
-            <Icon.close size={11} />
-            <span>Revoke</span>
-          </button>
-        </Row>
-      </Section>
-    </div>
-  );
-}
-
-function SettingsPrivacy() {
-  return (
-    <div className="flex-1 overflow-y-auto pb-6 pt-1">
-      <Section title="Telemetry">
-        <Row
-          label="Send anonymous usage stats"
-          hint="counts of feature use, no query content"
-        >
-          <Toggle on={false} />
-        </Row>
-        <Row label="Send crash reports" hint="stack traces only, never DB contents">
-          <Toggle on={true} />
-        </Row>
-      </Section>
-      <Section
-        title="Stored locally only"
-        sub="Cellar never uploads any of these. Open ~/.cellar to inspect."
-      >
-        <div className="w-full overflow-hidden rounded-[5px] border border-border-default">
-          {[
-            { k: "Connections", v: "12 connections", path: "connections.toml" },
-            {
-              k: "Query history",
-              v: "23,418 queries · 14.2 MB",
-              path: "history.sqlite",
-            },
-            {
-              k: "AI conversations",
-              v: "20 conversations · 3.2 MB",
-              path: "ai/",
-            },
-            { k: "Snapshots", v: "84 snapshots · 412 MB", path: "snapshots/" },
-            { k: "Cached schemas", v: "12 dbs · 8.4 MB", path: "cache/" },
-          ].map((x, i, arr) => (
-            <div
-              key={x.k}
-              className={
-                "grid grid-cols-[160px_1fr_auto_22px] items-center gap-2.5 bg-bg-2 px-2.5 py-1.5 text-[11px] hover:bg-bg-3 " +
-                (i !== arr.length - 1
-                  ? "border-b border-border-divider"
-                  : "")
-              }
-            >
-              <span className="font-medium text-fg-0">{x.k}</span>
-              <span className="text-fg-2">{x.v}</span>
-              <span className="font-mono text-[10.5px] text-fg-3">
-                ~/.cellar/{x.path}
-              </span>
-              <button className="icon-btn" title="open">
-                <Icon.chevronRight size={10} />
-              </button>
-            </div>
-          ))}
-        </div>
-      </Section>
-    </div>
-  );
-}
-
-function SettingsUpdates() {
-  return (
-    <div className="flex-1 overflow-y-auto pb-6 pt-1">
-      <Section title="Updates">
-        <div className="mb-2 flex items-center justify-between rounded-[5px] border border-border-default bg-bg-inset px-3 py-2.5">
-          <div className="flex items-center gap-2.5">
-            <span className="font-mono text-[13px] font-semibold text-fg-0">
-              v0.4.2
-            </span>
-            <span className="inline-flex items-center gap-1 text-[11px]">
-              <Icon.check size={11} stroke="var(--insert)" />
-              <span className="text-insert">You're up to date</span>
-            </span>
-            <span className="text-[11px] text-fg-3">last checked 2 minutes ago</span>
-          </div>
-          <button className="inline-flex h-[26px] items-center gap-1 rounded-[4px] border border-border-default bg-bg-2 px-2 text-[11px] text-fg-1 hover:bg-bg-3">
-            <Icon.power size={11} />
-            <span>Check now</span>
-          </button>
-        </div>
-        <Row label="Channel">
-          <StaticSegment values={["stable", "beta", "nightly"]} activeIdx={0} />
-        </Row>
-        <Row label="Auto-install on quit">
-          <Toggle on={true} />
-        </Row>
-      </Section>
-    </div>
-  );
-}
-
-function SettingsAbout() {
-  return (
-    <div className="flex-1 overflow-y-auto pb-6 pt-1">
-      <Section title="About">
-        <div className="flex items-start gap-4">
-          <span
-            className="relative h-12 w-12 shrink-0 rounded-[10px]"
-            style={{
-              background:
-                "linear-gradient(135deg, var(--accent), color-mix(in oklab, var(--accent) 50%, var(--syn-kw)))",
-              boxShadow: "0 0 24px var(--accent-soft)",
-            }}
-          >
-            <span
-              className="absolute inset-2 rounded-[4px] bg-bg-1"
-              style={{
-                clipPath:
-                  "polygon(0 0, 100% 0, 100% 35%, 35% 35%, 35% 65%, 100% 65%, 100% 100%, 0 100%)",
-              }}
-            />
-          </span>
-          <div>
-            <div className="text-[18px] font-semibold tracking-[-0.01em] text-fg-0">
-              Cellar
-            </div>
-            <div className="mb-2 text-[12px] text-fg-2">
-              A fast, native database client with AI built in.
-            </div>
-            <div className="mb-2.5 flex gap-1.5 font-mono text-[10.5px] text-fg-2">
-              <span>v0.4.2 · darwin-arm64</span>
-              <span className="text-fg-3">·</span>
-              <span>MIT licensed</span>
-              <span className="text-fg-3">·</span>
-              <span>commit 8e4f2a1</span>
-            </div>
-            <div className="flex gap-1.5 text-[11px]">
-              <button className="text-accent underline underline-offset-2">
-                docs
-              </button>
-              <span className="text-fg-3">·</span>
-              <button className="text-accent underline underline-offset-2">
-                github
-              </button>
-              <span className="text-fg-3">·</span>
-              <button className="text-accent underline underline-offset-2">
-                changelog
-              </button>
-              <span className="text-fg-3">·</span>
-              <button className="text-accent underline underline-offset-2">
-                acknowledgements
-              </button>
-            </div>
-          </div>
-        </div>
-      </Section>
-    </div>
   );
 }

--- a/apps/desktop/src/components/modals/settingsAIPanel.tsx
+++ b/apps/desktop/src/components/modals/settingsAIPanel.tsx
@@ -1,0 +1,286 @@
+import { useState } from "react";
+import { Icon } from "../icons";
+import { CD_INPUT, ED_RUN_DANGER, Row, Section } from "./settingsPrimitives";
+
+type AiProviderId = "anthropic" | "openai" | "google" | "local" | "custom";
+type AiModelTag = "balanced" | "max" | "fast" | "local";
+
+type AiModel = {
+  id: string;
+  ctx: string;
+  tag: AiModelTag;
+  def?: boolean;
+};
+
+const PROVIDERS: Record<
+  AiProviderId,
+  {
+    label: string;
+    sub: string;
+    keyPrefix: string;
+    endpoint: string;
+    models: [AiModel, ...AiModel[]];
+  }
+> = {
+  anthropic: {
+    label: "Anthropic",
+    sub: "claude-* family",
+    keyPrefix: "sk-ant-",
+    endpoint: "https://api.anthropic.com/v1",
+    models: [
+      { id: "claude-sonnet-4.5", ctx: "200k", tag: "balanced", def: true },
+      { id: "claude-opus-4", ctx: "200k", tag: "max" },
+      { id: "claude-haiku-4.5", ctx: "200k", tag: "fast" },
+    ],
+  },
+  openai: {
+    label: "OpenAI",
+    sub: "gpt-* family",
+    keyPrefix: "sk-",
+    endpoint: "https://api.openai.com/v1",
+    models: [
+      { id: "gpt-5.1", ctx: "256k", tag: "balanced", def: true },
+      { id: "gpt-5.1-mini", ctx: "256k", tag: "fast" },
+    ],
+  },
+  google: {
+    label: "Google",
+    sub: "gemini-* family",
+    keyPrefix: "key",
+    endpoint: "https://generativelanguage.googleapis.com/v1beta",
+    models: [
+      { id: "gemini-2.5-pro", ctx: "1m", tag: "max", def: true },
+      { id: "gemini-2.5-flash", ctx: "1m", tag: "fast" },
+    ],
+  },
+  local: {
+    label: "Local",
+    sub: "Ollama, LM Studio",
+    keyPrefix: "none",
+    endpoint: "http://localhost:11434/v1",
+    models: [
+      { id: "local-default", ctx: "model", tag: "local", def: true },
+    ],
+  },
+  custom: {
+    label: "Custom",
+    sub: "OpenAI-compatible URL",
+    keyPrefix: "key",
+    endpoint: "https://example.invalid/v1",
+    models: [
+      { id: "custom-model", ctx: "provider", tag: "balanced", def: true },
+    ],
+  },
+};
+
+const TAG_CLASS: Record<AiModelTag, string> = {
+  balanced: "text-accent bg-accent-soft",
+  max: "text-update bg-update-bg",
+  fast: "text-insert bg-insert-bg",
+  local: "text-fg-1 bg-bg-3",
+};
+
+export function SettingsAI() {
+  const [provider, setProvider] = useState<AiProviderId>("anthropic");
+  const [model, setModel] = useState(PROVIDERS.anthropic.models[0].id);
+  const [reveal, setReveal] = useState(false);
+  const current = PROVIDERS[provider];
+
+  const selectProvider = (id: AiProviderId) => {
+    setProvider(id);
+    setModel(PROVIDERS[id].models[0].id);
+  };
+
+  return (
+    <div className="flex-1 overflow-y-auto pb-6 pt-1">
+      <Section
+        title="AI Assistant"
+        sub="Cellar's AI runs entirely on your key. Your queries, schemas and results never touch our servers."
+      >
+        <div className="flex gap-2.5 rounded-[6px] border border-accent-line bg-accent-soft px-3.5 py-3">
+          <span className="inline-flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-[5px] border border-accent-line bg-bg-1">
+            <Icon.sparkles size={12} stroke="var(--accent)" />
+          </span>
+          <div className="text-pretty">
+            <div className="mb-0.5 text-[12px] font-semibold text-fg-0">
+              Bring-your-own-key, by design
+            </div>
+            <div className="text-[11.5px] leading-[1.45] text-fg-1">
+              All AI requests go directly from your machine to the provider. We
+              see nothing. Cellar is open-source; verify the network path in the
+              AI package before enabling providers.
+            </div>
+          </div>
+        </div>
+      </Section>
+
+      <Section title="Provider">
+        <Row label="Provider">
+          <div className="grid w-full grid-cols-5 gap-1.5">
+            {Object.entries(PROVIDERS).map(([id, p]) => {
+              const providerId = id as AiProviderId;
+              const active = provider === providerId;
+              return (
+                <button
+                  type="button"
+                  key={id}
+                  onClick={() => selectProvider(providerId)}
+                  className={
+                    "relative flex flex-col items-start gap-0.5 rounded-[5px] border px-[9px] py-2 text-left " +
+                    (active
+                      ? "border-accent bg-accent-soft shadow-[inset_0_0_0_1px_var(--accent)]"
+                      : "border-border-default bg-bg-2 hover:border-border-strong")
+                  }
+                >
+                  <span className="text-[11.5px] font-medium text-fg-0">
+                    {p.label}
+                  </span>
+                  <span
+                    className={
+                      "font-mono text-[9.5px] " +
+                      (active ? "text-accent opacity-85" : "text-fg-3")
+                    }
+                  >
+                    {p.sub}
+                  </span>
+                  {active && (
+                    <span className="absolute right-[5px] top-[5px] inline-flex h-3 w-3 items-center justify-center rounded-full bg-accent text-accent-fg">
+                      <Icon.check size={9} />
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </Row>
+
+        <Row label="Model" hint="used for chat, generation, ghost text">
+          <div className="flex w-full flex-col gap-[3px]">
+            {current.models.map((m) => {
+              const active = model === m.id;
+              return (
+                <label
+                  key={m.id}
+                  className={
+                    "grid cursor-pointer grid-cols-[14px_1fr_auto_auto_auto] items-center gap-2.5 rounded-[4px] border px-2.5 py-1.5 " +
+                    (active
+                      ? "border-accent-line bg-accent-soft"
+                      : "border-border-default bg-bg-2 hover:border-border-strong")
+                  }
+                >
+                  <span
+                    className={
+                      "relative inline-block h-3 w-3 rounded-full border " +
+                      (active ? "border-accent" : "border-border-strong")
+                    }
+                  >
+                    {active && (
+                      <span
+                        className="absolute inset-[2px] rounded-full"
+                        style={{ background: "var(--accent)" }}
+                      />
+                    )}
+                  </span>
+                  <input
+                    type="radio"
+                    className="hidden"
+                    checked={active}
+                    onChange={() => setModel(m.id)}
+                  />
+                  <span className="font-mono text-[11.5px] text-fg-0">
+                    {m.id}
+                  </span>
+                  <span className="font-mono text-[10px] text-fg-3">
+                    {m.ctx} ctx
+                  </span>
+                  <span
+                    className={
+                      "rounded-[3px] px-1.5 py-px font-mono text-[9.5px] uppercase tracking-[0.04em] " +
+                      TAG_CLASS[m.tag]
+                    }
+                  >
+                    {m.tag}
+                  </span>
+                  {m.def && (
+                    <span className="text-[9.5px] italic text-fg-2">
+                      recommended
+                    </span>
+                  )}
+                </label>
+              );
+            })}
+          </div>
+        </Row>
+
+        <Row label="API key" hint="stored in OS keychain, never written to disk">
+          <div className="inline-flex min-w-0 flex-1 items-center gap-1">
+            <span className="inline-flex h-[26px] items-center rounded-l-[4px] border border-r-0 border-border-default bg-bg-inset px-1.5 font-mono text-[11px] text-fg-2">
+              {current.keyPrefix}
+            </span>
+            <input
+              className="-ml-px h-[26px] min-w-0 flex-1 border border-border-default bg-bg-inset px-2 font-mono text-[11.5px] text-fg-0 outline-none focus:border-accent-line focus:bg-bg-2"
+              type={reveal ? "text" : "password"}
+              value=""
+              placeholder={reveal ? "No key configured" : "stored in keychain"}
+              readOnly
+              spellCheck={false}
+            />
+            <button
+              type="button"
+              onClick={() => setReveal(!reveal)}
+              className="inline-flex h-[26px] items-center gap-1 rounded-[4px] border border-border-default bg-bg-2 px-2 text-[10.5px] text-fg-1 hover:bg-bg-3"
+            >
+              {reveal ? "hide" : "reveal"}
+            </button>
+            <button
+              type="button"
+              disabled
+              title="Keychain editing is not wired yet"
+              className="inline-flex h-[26px] cursor-not-allowed items-center gap-1 rounded-[4px] border border-border-default bg-bg-2 px-2 text-[11px] text-fg-2 opacity-70"
+            >
+              <Icon.edit size={11} />
+              <span>change</span>
+            </button>
+          </div>
+        </Row>
+
+        <Row label="Endpoint" hint="override for proxies, custom routers">
+          <input
+            className={CD_INPUT + " cursor-not-allowed font-mono opacity-80"}
+            value={current.endpoint}
+            readOnly
+            style={{ flex: 1 }}
+          />
+        </Row>
+      </Section>
+
+      <Section title="Danger zone">
+        <Row
+          label="Clear AI conversation history"
+          hint="20 conversations, 3.2 MB locally"
+        >
+          <button
+            type="button"
+            disabled
+            title="AI history deletion is not wired yet"
+            className={ED_RUN_DANGER + " cursor-not-allowed opacity-60"}
+          >
+            <Icon.trash size={11} />
+            <span>Clear all</span>
+          </button>
+        </Row>
+        <Row label="Revoke API key" hint="remove from keychain — does not affect provider">
+          <button
+            type="button"
+            disabled
+            title="Key revocation is not wired yet"
+            className={ED_RUN_DANGER + " cursor-not-allowed opacity-60"}
+          >
+            <Icon.close size={11} />
+            <span>Revoke</span>
+          </button>
+        </Row>
+      </Section>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/modals/settingsDataPanels.tsx
+++ b/apps/desktop/src/components/modals/settingsDataPanels.tsx
@@ -1,0 +1,155 @@
+import { Icon } from "../icons";
+import {
+  CD_INPUT,
+  Row,
+  Section,
+  StaticSegment,
+  StubBanner,
+  Toggle,
+} from "./settingsPrimitives";
+
+export function SettingsConnections() {
+  return (
+    <div className="flex-1 overflow-y-auto pb-6 pt-1">
+      <Section
+        title="Defaults for new connections"
+        sub="Applied when you create a connection. Per-connection overrides win."
+      >
+        <Row label="Read-only by default">
+          <Toggle on={true} ariaLabel="Read-only by default" />
+        </Row>
+        <Row label="Connection timeout">
+          <input
+            readOnly
+            className={CD_INPUT + " cursor-not-allowed font-mono opacity-80"}
+            defaultValue="10"
+            style={{ width: 70, flex: "none" }}
+          />
+          <span className="text-[11px] text-fg-2">seconds</span>
+        </Row>
+        <Row label="Keep-alive interval">
+          <input
+            readOnly
+            className={CD_INPUT + " cursor-not-allowed font-mono opacity-80"}
+            defaultValue="30"
+            style={{ width: 70, flex: "none" }}
+          />
+          <span className="text-[11px] text-fg-2">seconds</span>
+        </Row>
+        <Row label="Application name">
+          <input
+            readOnly
+            className={CD_INPUT + " cursor-not-allowed font-mono opacity-80"}
+            defaultValue="cellar (alice@laptop)"
+            style={{ flex: 1 }}
+          />
+        </Row>
+      </Section>
+      <Section
+        title="Production safety"
+        sub="Cellar will require you to type the connection name before running these against any 'prod' connection."
+      >
+        <Row label="Confirm DML on prod">
+          <Toggle on={true} locked ariaLabel="Confirm DML on prod" />
+        </Row>
+        <Row label="Confirm DROP / TRUNCATE on prod">
+          <Toggle on={true} locked ariaLabel="Confirm DROP or TRUNCATE on prod" />
+        </Row>
+        <Row label="Block UPDATE without WHERE">
+          <Toggle on={true} ariaLabel="Block UPDATE without WHERE" />
+        </Row>
+        <Row label="Block DELETE without WHERE">
+          <Toggle on={true} ariaLabel="Block DELETE without WHERE" />
+        </Row>
+        <Row label="Max rows affected before warn">
+          <input
+            readOnly
+            className={CD_INPUT + " cursor-not-allowed font-mono opacity-80"}
+            defaultValue="100"
+            style={{ width: 70, flex: "none" }}
+          />
+          <span className="text-[11px] text-fg-2">rows</span>
+        </Row>
+      </Section>
+    </div>
+  );
+}
+
+export function SettingsHistory() {
+  return (
+    <div className="flex-1 overflow-y-auto pb-6 pt-1">
+      <Section title="Query history">
+        <Row label="Retain history for">
+          <StaticSegment
+            values={["7 days", "30 days", "90 days", "forever"]}
+            activeIdx={2}
+          />
+        </Row>
+        <Row label="Store query results">
+          <Toggle on={false} ariaLabel="Store query results" />
+        </Row>
+      </Section>
+      <StubBanner>23,418 queries · 14.2 MB · last cleared 12 days ago</StubBanner>
+    </div>
+  );
+}
+
+export function SettingsBackups() {
+  return (
+    <div className="flex-1 overflow-y-auto pb-6 pt-1">
+      <Section title="Backups">
+        <Row
+          label="Auto-snapshot before commits"
+          hint="pg_dump --schema-only + affected rows"
+        >
+          <Toggle on={true} ariaLabel="Auto-snapshot before commits" />
+        </Row>
+        <Row label="Snapshot location">
+          <input
+            readOnly
+            className={CD_INPUT + " cursor-not-allowed font-mono opacity-80"}
+            defaultValue="~/.cellar/snapshots"
+            style={{ flex: 1 }}
+          />
+          <button
+            type="button"
+            disabled
+            title="Snapshot location browsing is not wired yet"
+            className="inline-flex h-[26px] cursor-not-allowed items-center gap-1 rounded-[4px] border border-border-default bg-bg-2 px-2 text-[11px] text-fg-2 opacity-70"
+          >
+            <Icon.fileText size={11} />
+            <span>Browse</span>
+          </button>
+        </Row>
+        <Row label="Retain snapshots for">
+          <input
+            readOnly
+            className={CD_INPUT + " cursor-not-allowed font-mono opacity-80"}
+            defaultValue="30"
+            style={{ width: 70, flex: "none" }}
+          />
+          <span className="text-[11px] text-fg-2">days</span>
+        </Row>
+      </Section>
+      <Section title="Export defaults">
+        <Row label="Format">
+          <StaticSegment
+            values={["CSV", "JSON", "Parquet", "SQL INSERT"]}
+            activeIdx={0}
+          />
+        </Row>
+        <Row label="NULL as">
+          <input
+            readOnly
+            className={CD_INPUT + " cursor-not-allowed font-mono opacity-80"}
+            defaultValue="\\N"
+            style={{ width: 120, flex: "none" }}
+          />
+        </Row>
+        <Row label="Include headers">
+          <Toggle on={true} ariaLabel="Include headers" />
+        </Row>
+      </Section>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/modals/settingsPrimitives.tsx
+++ b/apps/desktop/src/components/modals/settingsPrimitives.tsx
@@ -1,0 +1,187 @@
+import type { ReactNode } from "react";
+import { Icon } from "../icons";
+
+export const ED_RUN_BASE =
+  "inline-flex h-[26px] items-center gap-[5px] whitespace-nowrap rounded-[4px] border border-transparent px-2.5 text-[11.5px] font-medium text-fg-1 transition-[background,color,border-color,filter] duration-[120ms]";
+export const ED_RUN_SUBTLE =
+  ED_RUN_BASE +
+  " bg-transparent border-border-default hover:bg-bg-3 hover:border-border-strong hover:text-fg-0";
+export const ED_RUN_PRIMARY =
+  ED_RUN_BASE + " bg-accent text-accent-fg hover:brightness-[1.07]";
+export const ED_RUN_DANGER =
+  ED_RUN_BASE +
+  " bg-transparent border-[color-mix(in_oklab,var(--delete)_30%,var(--border-default))] text-delete hover:bg-delete-bg hover:border-delete";
+
+export const CD_INPUT =
+  "h-[26px] min-w-0 flex-1 rounded-[4px] border border-border-default bg-bg-inset px-2 text-[11.5px] text-fg-0 outline-none focus:border-accent-line focus:bg-bg-2";
+
+export function Section({
+  title,
+  sub,
+  children,
+}: {
+  title: string;
+  sub?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="px-6 pb-1 pt-[18px] [&+section]:mt-1.5 [&+section]:border-t [&+section]:border-border-divider">
+      <header className="mb-3">
+        <h2 className="m-0 text-[13px] font-semibold tracking-[-0.005em] text-fg-0">
+          {title}
+        </h2>
+        {sub && (
+          <p className="m-0 mt-px max-w-[60ch] text-[11.5px] text-fg-2 text-pretty">
+            {sub}
+          </p>
+        )}
+      </header>
+      <div className="flex flex-col gap-2">{children}</div>
+    </section>
+  );
+}
+
+export function Row({
+  label,
+  hint,
+  children,
+  stack,
+}: {
+  label: string;
+  hint?: string;
+  children: ReactNode;
+  stack?: boolean;
+}) {
+  return (
+    <div
+      className={
+        "grid min-h-[24px] grid-cols-[180px_1fr] gap-[14px] py-1 " +
+        (stack ? "items-start" : "items-center")
+      }
+    >
+      <div className="flex flex-col gap-[2px] text-[11.5px] font-medium text-fg-1">
+        <span>{label}</span>
+        {hint && (
+          <span className="text-[10.5px] font-normal text-fg-3 text-pretty">
+            {hint}
+          </span>
+        )}
+      </div>
+      <div
+        className={
+          "min-w-0 text-[11.5px] " +
+          (stack ? "block" : "flex flex-wrap items-center gap-2")
+        }
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export function Toggle({
+  on,
+  onChange,
+  locked,
+  ariaLabel = "Setting toggle",
+}: {
+  on: boolean;
+  onChange?: (v: boolean) => void;
+  locked?: boolean;
+  ariaLabel?: string;
+}) {
+  const interactive = Boolean(onChange) && !locked;
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={on}
+      aria-label={ariaLabel}
+      onClick={() => interactive && onChange?.(!on)}
+      disabled={!interactive}
+      title={locked ? "Forced on for prod connections" : undefined}
+      className={
+        "relative h-4 w-7 shrink-0 rounded-[10px] transition-colors duration-150 " +
+        (on ? (locked ? "bg-warn" : "bg-accent") : "bg-bg-3") +
+        (!interactive ? " cursor-not-allowed opacity-85" : "")
+      }
+    >
+      <span
+        className={
+          "absolute top-[2px] h-3 w-3 rounded-full bg-white transition-[left] duration-150 " +
+          (on ? "left-[14px]" : "left-[2px]")
+        }
+      />
+    </button>
+  );
+}
+
+export function Segment<T extends string>({
+  options,
+  value,
+  onChange,
+}: {
+  options: { value: T; label: string }[];
+  value: T;
+  onChange?: (v: T) => void;
+}) {
+  return (
+    <div className="inline-flex gap-px rounded-[4px] border border-border-default bg-bg-inset p-[2px]">
+      {options.map((o) => (
+        <button
+          type="button"
+          key={o.value}
+          disabled={!onChange}
+          aria-pressed={value === o.value}
+          onClick={() => onChange?.(o.value)}
+          className={
+            "h-5 rounded-[3px] px-2.5 text-[11px] " +
+            (value === o.value
+              ? "bg-bg-3 font-medium text-fg-0"
+              : "text-fg-2 " + (onChange ? "hover:text-fg-0" : ""))
+          }
+        >
+          {o.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function StaticSegment({
+  values,
+  activeIdx,
+}: {
+  values: string[];
+  activeIdx: number;
+}) {
+  return (
+    <div className="inline-flex gap-px rounded-[4px] border border-border-default bg-bg-inset p-[2px]">
+      {values.map((v, i) => (
+        <button
+          type="button"
+          key={v}
+          disabled
+          aria-pressed={i === activeIdx}
+          className={
+            "h-5 cursor-not-allowed rounded-[3px] px-2.5 text-[11px] " +
+            (i === activeIdx
+              ? "bg-bg-3 font-medium text-fg-0"
+              : "text-fg-2")
+          }
+        >
+          {v}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function StubBanner({ children }: { children: ReactNode }) {
+  return (
+    <div className="mx-6 my-2 flex items-center gap-1.5 rounded-[4px] border border-dashed border-border-default bg-bg-inset px-3 py-2 text-[11px] text-fg-2">
+      <Icon.info size={12} stroke="var(--fg-3)" />
+      <span>{children}</span>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/modals/settingsSystemPanels.tsx
+++ b/apps/desktop/src/components/modals/settingsSystemPanels.tsx
@@ -1,0 +1,159 @@
+import { Icon } from "../icons";
+import { Row, Section, StaticSegment, Toggle } from "./settingsPrimitives";
+
+export function SettingsPrivacy() {
+  return (
+    <div className="flex-1 overflow-y-auto pb-6 pt-1">
+      <Section title="Telemetry">
+        <Row
+          label="Send anonymous usage stats"
+          hint="counts of feature use, no query content"
+        >
+          <Toggle on={false} ariaLabel="Send anonymous usage stats" />
+        </Row>
+        <Row label="Send crash reports" hint="stack traces only, never DB contents">
+          <Toggle on={false} ariaLabel="Send crash reports" />
+        </Row>
+      </Section>
+      <Section
+        title="Stored locally only"
+        sub="Cellar never uploads any of these. Open ~/.cellar to inspect."
+      >
+        <div className="w-full overflow-hidden rounded-[5px] border border-border-default">
+          {[
+            { k: "Connections", v: "12 connections", path: "connections.toml" },
+            {
+              k: "Query history",
+              v: "23,418 queries · 14.2 MB",
+              path: "history.sqlite",
+            },
+            {
+              k: "AI conversations",
+              v: "20 conversations · 3.2 MB",
+              path: "ai/",
+            },
+            { k: "Snapshots", v: "84 snapshots · 412 MB", path: "snapshots/" },
+            { k: "Cached schemas", v: "12 dbs · 8.4 MB", path: "cache/" },
+          ].map((x, i, arr) => (
+            <div
+              key={x.k}
+              className={
+                "grid grid-cols-[160px_1fr_auto_22px] items-center gap-2.5 bg-bg-2 px-2.5 py-1.5 text-[11px] hover:bg-bg-3 " +
+                (i !== arr.length - 1 ? "border-b border-border-divider" : "")
+              }
+            >
+              <span className="font-medium text-fg-0">{x.k}</span>
+              <span className="text-fg-2">{x.v}</span>
+              <span className="font-mono text-[10.5px] text-fg-3">
+                ~/.cellar/{x.path}
+              </span>
+              <button
+                type="button"
+                disabled
+                className="icon-btn cursor-not-allowed opacity-60"
+                title="Local file browsing is not wired yet"
+              >
+                <Icon.chevronRight size={10} />
+              </button>
+            </div>
+          ))}
+        </div>
+      </Section>
+    </div>
+  );
+}
+
+export function SettingsUpdates() {
+  return (
+    <div className="flex-1 overflow-y-auto pb-6 pt-1">
+      <Section title="Updates">
+        <div className="mb-2 flex items-center justify-between rounded-[5px] border border-border-default bg-bg-inset px-3 py-2.5">
+          <div className="flex items-center gap-2.5">
+            <span className="font-mono text-[13px] font-semibold text-fg-0">
+              v0.1.0-alpha
+            </span>
+            <span className="inline-flex items-center gap-1 text-[11px]">
+              <Icon.info size={11} stroke="var(--fg-2)" />
+              <span className="text-fg-2">Updater not configured</span>
+            </span>
+            <span className="text-[11px] text-fg-3">last checked never</span>
+          </div>
+          <button
+            type="button"
+            disabled
+            title="Updater checks are not wired yet"
+            className="inline-flex h-[26px] cursor-not-allowed items-center gap-1 rounded-[4px] border border-border-default bg-bg-2 px-2 text-[11px] text-fg-2 opacity-70"
+          >
+            <Icon.power size={11} />
+            <span>Check now</span>
+          </button>
+        </div>
+        <Row label="Channel">
+          <StaticSegment values={["stable", "beta", "nightly"]} activeIdx={0} />
+        </Row>
+        <Row label="Auto-install on quit">
+          <Toggle on={false} ariaLabel="Auto-install on quit" />
+        </Row>
+      </Section>
+    </div>
+  );
+}
+
+export function SettingsAbout() {
+  return (
+    <div className="flex-1 overflow-y-auto pb-6 pt-1">
+      <Section title="About">
+        <div className="flex items-start gap-4">
+          <span
+            className="relative h-12 w-12 shrink-0 rounded-[10px]"
+            style={{
+              background:
+                "linear-gradient(135deg, var(--accent), color-mix(in oklab, var(--accent) 50%, var(--syn-kw)))",
+              boxShadow: "0 0 24px var(--accent-soft)",
+            }}
+          >
+            <span
+              className="absolute inset-2 rounded-[4px] bg-bg-1"
+              style={{
+                clipPath:
+                  "polygon(0 0, 100% 0, 100% 35%, 35% 35%, 35% 65%, 100% 65%, 100% 100%, 0 100%)",
+              }}
+            />
+          </span>
+          <div>
+            <div className="text-[18px] font-semibold tracking-[-0.01em] text-fg-0">
+              Cellar
+            </div>
+            <div className="mb-2 text-[12px] text-fg-2">
+              A fast, native database client with AI built in.
+            </div>
+            <div className="mb-2.5 flex gap-1.5 font-mono text-[10.5px] text-fg-2">
+              <span>v0.1.0-alpha · development build</span>
+              <span className="text-fg-3">·</span>
+              <span>MIT licensed</span>
+              <span className="text-fg-3">·</span>
+              <span>commit unavailable</span>
+            </div>
+            <div className="flex gap-1.5 text-[11px]">
+              <button type="button" className="text-accent underline underline-offset-2">
+                docs
+              </button>
+              <span className="text-fg-3">·</span>
+              <button type="button" className="text-accent underline underline-offset-2">
+                github
+              </button>
+              <span className="text-fg-3">·</span>
+              <button type="button" className="text-accent underline underline-offset-2">
+                changelog
+              </button>
+              <span className="text-fg-3">·</span>
+              <button type="button" className="text-accent underline underline-offset-2">
+                acknowledgements
+              </button>
+            </div>
+          </div>
+        </div>
+      </Section>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/modals/settingsWorkspacePanels.tsx
+++ b/apps/desktop/src/components/modals/settingsWorkspacePanels.tsx
@@ -1,0 +1,343 @@
+import { Icon } from "../icons";
+import {
+  ACCENT_SWATCHES,
+  FONT_SIZE_MAX,
+  FONT_SIZE_MIN,
+  useSettings,
+  type Density,
+  type Theme,
+} from "../../lib/settings";
+import {
+  CD_INPUT,
+  Row,
+  Section,
+  Segment,
+  StaticSegment,
+  Toggle,
+} from "./settingsPrimitives";
+
+export function SettingsAppearance() {
+  const { settings, set } = useSettings();
+
+  return (
+    <div className="flex-1 overflow-y-auto pb-6 pt-1">
+      <Section title="Theme">
+        <Row label="Theme">
+          <Segment<Theme>
+            value={settings.theme}
+            onChange={(v) => set("theme", v)}
+            options={[
+              { value: "system", label: "system" },
+              { value: "dark", label: "dark" },
+              { value: "light", label: "light" },
+            ]}
+          />
+        </Row>
+        <Row label="Accent">
+          <div className="flex flex-wrap gap-1">
+            {ACCENT_SWATCHES.map((c) => {
+              const active = settings.accent.toLowerCase() === c.toLowerCase();
+              return (
+                <button
+                  type="button"
+                  key={c}
+                  onClick={() => set("accent", c)}
+                  className={
+                    "h-[18px] w-[18px] rounded-[4px] border border-white/10 transition-transform hover:scale-110 " +
+                    (active
+                      ? "shadow-[0_0_0_2px_var(--bg-1),0_0_0_3px_var(--fg-0)]"
+                      : "")
+                  }
+                  style={{ background: c }}
+                  title={c}
+                />
+              );
+            })}
+          </div>
+        </Row>
+        <Row label="Density">
+          <Segment<Density>
+            value={settings.density}
+            onChange={(v) => set("density", v)}
+            options={[
+              { value: "compact", label: "compact" },
+              { value: "comfortable", label: "comfortable" },
+            ]}
+          />
+        </Row>
+      </Section>
+
+      <Section title="Type">
+        <Row label="Interface font">
+          <input
+            className={CD_INPUT + " font-sans"}
+            value={settings.interfaceFont}
+            onChange={(e) => set("interfaceFont", e.target.value)}
+            style={{ flex: 1 }}
+          />
+        </Row>
+        <Row label="Editor / mono font">
+          <input
+            className={CD_INPUT + " font-mono"}
+            value={settings.monoFont}
+            onChange={(e) => set("monoFont", e.target.value)}
+            style={{ flex: 1 }}
+          />
+        </Row>
+        <Row
+          label="Font size"
+          hint="Scales the entire interface. Default is 12.5 px."
+        >
+          <input
+            className={CD_INPUT + " font-mono"}
+            style={{ width: 70, flex: "none" }}
+            type="number"
+            min={FONT_SIZE_MIN}
+            max={FONT_SIZE_MAX}
+            step={0.5}
+            value={settings.fontSizePx}
+            onChange={(e) => {
+              const v = parseFloat(e.target.value);
+              if (Number.isFinite(v)) {
+                set("fontSizePx", Math.min(Math.max(v, FONT_SIZE_MIN), FONT_SIZE_MAX));
+              }
+            }}
+          />
+          <span className="text-[11px] text-fg-2">px</span>
+          <div className="relative ml-2 w-[220px] pt-[14px]">
+            <span className="absolute top-0 left-0 -translate-x-1/2 whitespace-nowrap text-[9.5px] text-fg-3">
+              {FONT_SIZE_MIN}
+            </span>
+            <span className="absolute top-0 left-1/2 -translate-x-1/2 whitespace-nowrap text-[9.5px] text-fg-3">
+              12.5
+            </span>
+            <span className="absolute top-0 right-0 translate-x-1/2 whitespace-nowrap text-[9.5px] text-fg-3">
+              {FONT_SIZE_MAX}
+            </span>
+            <input
+              type="range"
+              min={FONT_SIZE_MIN}
+              max={FONT_SIZE_MAX}
+              step={0.5}
+              value={settings.fontSizePx}
+              onChange={(e) => set("fontSizePx", parseFloat(e.target.value))}
+              className="m-0 h-[18px] w-full"
+              style={{ accentColor: "var(--accent)" }}
+            />
+          </div>
+        </Row>
+      </Section>
+
+      <Section title="Window">
+        <Row label="Show traffic lights">
+          <Toggle on={true} ariaLabel="Show traffic lights" />
+        </Row>
+        <Row label="Native window controls">
+          <Toggle on={false} ariaLabel="Native window controls" />
+        </Row>
+      </Section>
+    </div>
+  );
+}
+
+export function SettingsGeneral() {
+  return (
+    <div className="flex-1 overflow-y-auto pb-6 pt-1">
+      <Section title="General">
+        <Row label="Startup">
+          <StaticSegment
+            values={["Restore last session", "Empty workspace", "Show welcome"]}
+            activeIdx={0}
+          />
+        </Row>
+        <Row label="Default schema search path">
+          <input
+            readOnly
+            className={CD_INPUT + " cursor-not-allowed font-mono opacity-80"}
+            defaultValue="public, audit, analytics"
+            style={{ flex: 1 }}
+          />
+        </Row>
+        <Row label="Confirm before quitting">
+          <Toggle on={true} ariaLabel="Confirm before quitting" />
+        </Row>
+        <Row label="Allow background queries">
+          <Toggle on={true} ariaLabel="Allow background queries" />
+        </Row>
+      </Section>
+      <Section title="Updates">
+        <Row label="Channel">
+          <StaticSegment values={["stable", "beta", "nightly"]} activeIdx={0} />
+        </Row>
+        <Row label="Auto-install on quit">
+          <Toggle on={true} ariaLabel="Auto-install on quit" />
+        </Row>
+      </Section>
+    </div>
+  );
+}
+
+export function SettingsEditor() {
+  return (
+    <div className="flex-1 overflow-y-auto pb-6 pt-1">
+      <Section title="SQL editor">
+        <Row label="Tab size">
+          <StaticSegment values={["2", "4", "8"]} activeIdx={1} />
+        </Row>
+        <Row label="Indent with">
+          <StaticSegment values={["spaces", "tabs"]} activeIdx={0} />
+        </Row>
+        <Row label="Auto-format on save">
+          <Toggle on={true} ariaLabel="Auto-format on save" />
+        </Row>
+        <Row label="Keyword case">
+          <StaticSegment values={["UPPER", "lower", "Preserve"]} activeIdx={0} />
+        </Row>
+        <Row label="Show line numbers">
+          <Toggle on={true} ariaLabel="Show line numbers" />
+        </Row>
+        <Row label="Soft wrap">
+          <Toggle on={false} ariaLabel="Soft wrap" />
+        </Row>
+        <Row label="Bracket matching">
+          <Toggle on={true} ariaLabel="Bracket matching" />
+        </Row>
+      </Section>
+      <Section title="Execution">
+        <Row label="Statement at cursor runs">
+          <StaticSegment
+            values={["current statement", "selection", "whole file"]}
+            activeIdx={0}
+          />
+        </Row>
+        <Row label="LIMIT applied to SELECT *">
+          <input
+            readOnly
+            className={CD_INPUT + " cursor-not-allowed font-mono opacity-80"}
+            defaultValue="500"
+            style={{ width: 70, flex: "none" }}
+          />
+        </Row>
+      </Section>
+    </div>
+  );
+}
+
+export function SettingsGrid() {
+  return (
+    <div className="flex-1 overflow-y-auto pb-6 pt-1">
+      <Section title="Data grid">
+        <Row label="Row height">
+          <StaticSegment values={["20px", "22px", "28px", "36px"]} activeIdx={1} />
+        </Row>
+        <Row label="NULL display">
+          <input
+            readOnly
+            className={CD_INPUT + " cursor-not-allowed font-mono opacity-80"}
+            defaultValue="NULL"
+            style={{ width: 120, flex: "none" }}
+          />
+          <StaticSegment values={["dim italic", "strong"]} activeIdx={0} />
+        </Row>
+        <Row label="Number alignment">
+          <StaticSegment values={["left", "right"]} activeIdx={1} />
+        </Row>
+        <Row label="Stripe alternating rows">
+          <Toggle on={false} ariaLabel="Stripe alternating rows" />
+        </Row>
+        <Row label="Sticky pkey column">
+          <Toggle on={true} ariaLabel="Sticky pkey column" />
+        </Row>
+        <Row label="Truncate cells over">
+          <input
+            readOnly
+            className={CD_INPUT + " cursor-not-allowed font-mono opacity-80"}
+            defaultValue="200"
+            style={{ width: 70, flex: "none" }}
+          />
+          <span className="text-[11px] text-fg-2">chars</span>
+        </Row>
+      </Section>
+    </div>
+  );
+}
+
+export function SettingsKeymap() {
+  const shortcuts = [
+    {
+      grp: "Workspace",
+      items: [
+        { k: "Command palette", kbd: "⌘K" },
+        { k: "New connection", kbd: "⌘N" },
+        { k: "New SQL tab", kbd: "⌘T" },
+        { k: "Close tab", kbd: "⌘W" },
+        { k: "Settings", kbd: "⌘," },
+        { k: "Toggle sidebar", kbd: "⌘B" },
+        { k: "Toggle AI panel", kbd: "⌘J" },
+        { k: "Toggle results panel", kbd: "⌘↓" },
+      ],
+    },
+    {
+      grp: "Editor",
+      items: [
+        { k: "Run statement", kbd: "⌘⏎" },
+        { k: "Run selection", kbd: "⌥⏎" },
+        { k: "Format", kbd: "⌥⇧F" },
+        { k: "Accept ghost text", kbd: "Tab" },
+        { k: "Show schema for symbol", kbd: "F12" },
+      ],
+    },
+    {
+      grp: "Grid",
+      items: [
+        { k: "Edit cell", kbd: "⏎" },
+        { k: "Revert cell", kbd: "Esc" },
+        { k: "Commit changes", kbd: "⌘S" },
+        { k: "Revert all pending", kbd: "⌘⇧Z" },
+        { k: "Set NULL", kbd: "⌘⌫" },
+      ],
+    },
+  ];
+
+  return (
+    <div className="flex-1 overflow-y-auto pb-6 pt-1">
+      <Section title="Keymap" sub="Pick a preset or rebind any individual shortcut.">
+        <Row label="Preset">
+          <StaticSegment
+            values={["Cellar", "DataGrip", "VS Code", "Linear"]}
+            activeIdx={0}
+          />
+        </Row>
+      </Section>
+      {shortcuts.map((g) => (
+        <Section key={g.grp} title={g.grp}>
+          <div className="flex flex-col">
+            {g.items.map((s) => (
+              <div
+                key={s.k}
+                className="grid grid-cols-[1fr_auto_auto] items-center gap-3 border-b border-dashed border-border-divider py-1.5 last:border-b-0"
+              >
+                <span className="text-[11.5px] text-fg-1">{s.k}</span>
+                <span className="inline-flex gap-0.5">
+                  {[...s.kbd].map((k, i) => (
+                    <kbd key={i} className="kbd">
+                      {k}
+                    </kbd>
+                  ))}
+                </span>
+                <button
+                  type="button"
+                  disabled
+                  className="icon-btn cursor-not-allowed opacity-60"
+                  title="Key rebinding is not wired yet"
+                >
+                  <Icon.edit size={10} />
+                </button>
+              </div>
+            ))}
+          </div>
+        </Section>
+      ))}
+    </div>
+  );
+}

--- a/apps/desktop/src/lib/settings.tsx
+++ b/apps/desktop/src/lib/settings.tsx
@@ -56,10 +56,17 @@ function load(): Settings {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return DEFAULTS;
     const parsed = JSON.parse(raw) as Partial<Settings>;
-    return { ...DEFAULTS, ...parsed };
+    return sanitize({ ...DEFAULTS, ...parsed });
   } catch {
     return DEFAULTS;
   }
+}
+
+function sanitize(s: Settings): Settings {
+  return {
+    ...s,
+    fontSizePx: clamp(s.fontSizePx, FONT_SIZE_MIN, FONT_SIZE_MAX),
+  };
 }
 
 function applySideEffects(s: Settings) {
@@ -78,11 +85,11 @@ function applySideEffects(s: Settings) {
   html.style.setProperty("--accent", s.accent);
   html.style.setProperty(
     "--accent-soft",
-    hexToRgba(s.accent, s.theme === "light" ? 0.1 : 0.14),
+    hexToRgba(s.accent, resolvedTheme === "light" ? 0.1 : 0.14),
   );
   html.style.setProperty(
     "--accent-line",
-    hexToRgba(s.accent, s.theme === "light" ? 0.28 : 0.32),
+    hexToRgba(s.accent, resolvedTheme === "light" ? 0.28 : 0.32),
   );
 
   const scale = clamp(s.fontSizePx, FONT_SIZE_MIN, FONT_SIZE_MAX) / FONT_SIZE_BASELINE;
@@ -125,7 +132,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
 
   const set = useCallback(<K extends keyof Settings>(key: K, value: Settings[K]) => {
     setSettings((prev) => {
-      const next = { ...prev, [key]: value };
+      const next = sanitize({ ...prev, [key]: value });
       localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
       applySideEffects(next);
       return next;

--- a/apps/desktop/src/lib/sqlTokens.tsx
+++ b/apps/desktop/src/lib/sqlTokens.tsx
@@ -61,8 +61,18 @@ export function tokenizeSql(sql: string): Token[] {
     }
     if (ch === "'") {
       let j = i + 1;
-      while (j < sql.length && sql.charAt(j) !== "'") j++;
-      j++;
+      while (j < sql.length) {
+        if (sql.charAt(j) !== "'") {
+          j++;
+          continue;
+        }
+        if (sql.charAt(j + 1) === "'") {
+          j += 2;
+          continue;
+        }
+        j++;
+        break;
+      }
       out.push({ kind: "str", text: sql.slice(i, j) });
       i = j;
       continue;


### PR DESCRIPTION
## Summary
- refresh AGENTS.md to match the current Postgres vertical slice and project guardrails
- split the oversized settings modal into focused submodules to satisfy the 800-line rule
- address audit findings around SQL preview escaping, stub settings controls, AI settings copy, privacy defaults, and SQL tokenization

## Validation
- pnpm typecheck
- pnpm lint
- pnpm build
- pnpm test
- cargo check --workspace
- 800-line source scan
- clawpatch doctor
- clawpatch review --include-dirty
