### PR TITLE
fix(postgres): cap query results while streaming

### DIFF
--- a/crates/cellar-drivers/postgres/src/query.rs
+++ b/crates/cellar-drivers/postgres/src/query.rs
@@ -3,6 +3,7 @@ use std::time::Instant;
 use cellar_core::error::{CellarError, CellarResult};
 use cellar_core::query::{Query, QueryResult};
 use cellar_core::value::{ColumnMeta, Row};
+use futures::TryStreamExt;
 use sqlx::{Column as _, Row as _, TypeInfo as _};
 
 use crate::connect::PgConnection;
@@ -21,44 +22,51 @@ pub async fn execute_query(conn: &PgConnection, query: &Query) -> CellarResult<Q
     let pool = &pool;
 
     let max_rows = query.max_rows.unwrap_or(DEFAULT_MAX_ROWS);
+    let max_rows_usize = max_rows as usize;
+    let capacity = max_rows.min(10_000) as usize;
+
     // SQL passes through verbatim. Driving LIMIT into user-supplied SQL would
-    // need a parser; we cap on the host side instead and signal truncation.
+    // need a parser; we cap while reading the stream instead of materializing
+    // the full server result first.
     let started = Instant::now();
-    let rows = sqlx::query(&query.sql)
-        .fetch_all(pool)
+    let mut stream = sqlx::query(&query.sql).fetch(pool);
+    let mut columns: Option<Vec<ColumnMeta>> = None;
+    let mut materialized: Vec<Row> = Vec::with_capacity(capacity);
+    let mut truncated = false;
+
+    while let Some(r) = stream
+        .try_next()
         .await
-        .map_err(|e| CellarError::query(e.to_string()))?;
-    let duration_ms = started.elapsed().as_millis() as u64;
+        .map_err(|e| CellarError::query(e.to_string()))?
+    {
+        if columns.is_none() {
+            columns = Some(
+                r.columns()
+                    .iter()
+                    .map(|c| ColumnMeta {
+                        name: c.name().to_string(),
+                        data_type: c.type_info().name().to_string().to_lowercase(),
+                        nullable: true,
+                    })
+                    .collect(),
+            );
+        }
 
-    let total = rows.len();
-    let capped = total.min(max_rows as usize);
-    let truncated = total > capped;
+        if materialized.len() >= max_rows_usize {
+            truncated = true;
+            break;
+        }
 
-    let columns = if let Some(first) = rows.first() {
-        first
-            .columns()
-            .iter()
-            .map(|c| ColumnMeta {
-                name: c.name().to_string(),
-                data_type: c.type_info().name().to_string().to_lowercase(),
-                nullable: true,
-            })
-            .collect()
-    } else {
-        Vec::new()
-    };
-
-    let mut materialized: Vec<Row> = Vec::with_capacity(capped);
-    for r in rows.iter().take(capped) {
         let mut cells: Row = Vec::with_capacity(r.columns().len());
         for i in 0..r.columns().len() {
-            cells.push(decode_cell(r, i)?);
+            cells.push(decode_cell(&r, i)?);
         }
         materialized.push(cells);
     }
+    let duration_ms = started.elapsed().as_millis() as u64;
 
     Ok(QueryResult {
-        columns,
+        columns: columns.unwrap_or_default(),
         rows: materialized,
         rows_affected: None,
         duration_ms,


### PR DESCRIPTION
## Summary

Stop Postgres query execution from materializing the entire server result before applying Cellar's row cap. The driver now reads from the SQLx row stream, records column metadata from the first row, and stops once max_rows has been filled while marking the result as truncated.

## Why

The previous fetch_all path meant a query like SELECT * FROM huge_table could still load every row into memory before the host-side cap was applied. This made the row limit look safer than it actually was.

## Validation

- cargo check -p cellar-driver-postgres
