### PR TITLE
feat: commit grid edits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,6 +396,7 @@ version = "0.1.0-alpha"
 dependencies = [
  "async-trait",
  "cellar-core",
+ "cellar-diff",
  "cellar-driver-postgres",
  "cellar-secrets",
  "dirs 5.0.1",
@@ -413,6 +414,11 @@ dependencies = [
 [[package]]
 name = "cellar-diff"
 version = "0.1.0-alpha"
+dependencies = [
+ "serde",
+ "specta",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "cellar-driver-postgres"
@@ -420,6 +426,7 @@ version = "0.1.0-alpha"
 dependencies = [
  "async-trait",
  "cellar-core",
+ "cellar-diff",
  "chrono",
  "futures",
  "serde",

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ pnpm install
 pnpm dev
 ```
 
-That's it. `pnpm dev` runs `tauri dev` inside `apps/desktop`, which spawns the Vite dev server on `localhost:1430` and a Cargo build of the Rust shell, then opens the app window.
+That's it. `pnpm dev` runs `tauri dev` inside `apps/desktop`, which spawns the Vite dev server starting at `localhost:1430` and falls forward to the next free port if needed, then opens the app window.
 
 Other useful scripts (all from the repo root):
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tauri dev",
+    "dev": "node scripts/dev.mjs",
     "dev:web": "vite",
     "build": "tsc --noEmit && vite build",
     "build:tauri": "tauri build",

--- a/apps/desktop/scripts/dev.mjs
+++ b/apps/desktop/scripts/dev.mjs
@@ -1,0 +1,72 @@
+import net from "node:net";
+import { spawn } from "node:child_process";
+
+const DEFAULT_PORT = 1430;
+const requestedPort = Number(process.env.CELLAR_DEV_PORT ?? DEFAULT_PORT);
+const devPort = await findAvailablePort(requestedPort);
+
+if (devPort !== requestedPort) {
+  console.log(
+    `Port ${requestedPort} is in use; starting Cellar dev server on ${devPort}.`,
+  );
+}
+
+const config = JSON.stringify({
+  build: {
+    devUrl: `http://localhost:${devPort}`,
+  },
+});
+
+const child = spawn("pnpm", ["exec", "tauri", "dev", "--config", config], {
+  cwd: new URL("..", import.meta.url),
+  env: {
+    ...process.env,
+    CELLAR_DEV_PORT: String(devPort),
+  },
+  stdio: "inherit",
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 0);
+});
+
+async function findAvailablePort(start) {
+  let port = start;
+  while (!(await canUsePort(port))) {
+    port += 1;
+  }
+  return port;
+}
+
+async function canUsePort(port) {
+  const results = await Promise.all([
+    canListen(port, "127.0.0.1"),
+    canListen(port, "::1"),
+  ]);
+  return results.every(Boolean);
+}
+
+function canListen(port, host) {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.once("error", (error) => {
+      if (error.code === "EADDRINUSE" || error.code === "EACCES") {
+        resolve(false);
+        return;
+      }
+      if (host === "::1" && error.code === "EADDRNOTAVAIL") {
+        resolve(true);
+        return;
+      }
+      reject(error);
+    });
+    server.listen({ host, port }, () => {
+      server.close(() => resolve(true));
+    });
+  });
+}

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -33,4 +33,5 @@ specta-typescript = "=0.0.9"
 tauri-specta = { version = "=2.0.0-rc.21", features = ["derive", "typescript"] }
 cellar-core = { path = "../../../crates/cellar-core" }
 cellar-driver-postgres = { path = "../../../crates/cellar-drivers/postgres" }
+cellar-diff = { path = "../../../crates/cellar-diff" }
 cellar-secrets = { path = "../../../crates/cellar-secrets" }

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -8,6 +8,7 @@
 pub mod connection;
 pub mod query;
 pub mod schema;
+pub mod transaction;
 
 use specta_typescript::{BigIntExportBehavior, Typescript};
 use tauri_specta::{collect_commands, Builder};
@@ -25,6 +26,8 @@ pub fn builder() -> Builder<tauri::Wry> {
         connection::disconnect,
         schema::introspect,
         query::run_query,
+        transaction::preview_table_changes,
+        transaction::commit_table_changes,
     ])
 }
 

--- a/apps/desktop/src-tauri/src/commands/transaction.rs
+++ b/apps/desktop/src-tauri/src/commands/transaction.rs
@@ -1,0 +1,25 @@
+use cellar_core::error::CellarError;
+use cellar_diff::{build_postgres_plan, TableChangeRequest, TableCommitPreview, TableCommitResult};
+use tauri::State;
+
+use crate::state::ConnectionRegistry;
+
+#[tauri::command]
+#[specta::specta]
+pub fn preview_table_changes(
+    request: TableChangeRequest,
+) -> Result<TableCommitPreview, CellarError> {
+    build_postgres_plan(&request)
+        .map(|plan| plan.preview)
+        .map_err(|e| CellarError::query(e.to_string()))
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn commit_table_changes(
+    registry: State<'_, ConnectionRegistry>,
+    connection_id: String,
+    request: TableChangeRequest,
+) -> Result<TableCommitResult, CellarError> {
+    registry.commit_table_changes(&connection_id, request).await
+}

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -5,6 +5,7 @@ use cellar_core::driver::{Connection, ConnectionConfig, Driver, DriverInfo, Engi
 use cellar_core::error::{CellarError, CellarResult};
 use cellar_core::query::{Query, QueryResult};
 use cellar_core::schema::Database;
+use cellar_diff::{TableChangeRequest, TableCommitResult};
 use cellar_driver_postgres::PostgresDriver;
 use tokio::fs;
 use tokio::sync::RwLock;
@@ -169,6 +170,28 @@ impl ConnectionRegistry {
             .ok_or_else(|| CellarError::NotConnected(format!("no open connection for {id}")))?;
         let driver = driver_for(open.config.engine)?;
         driver.execute_query(open.connection.as_ref(), &query).await
+    }
+
+    pub async fn commit_table_changes(
+        &self,
+        id: &str,
+        request: TableChangeRequest,
+    ) -> CellarResult<TableCommitResult> {
+        let inner = self.inner.read().await;
+        let open = inner
+            .open
+            .get(id)
+            .ok_or_else(|| CellarError::NotConnected(format!("no open connection for {id}")))?;
+        match open.config.engine {
+            Engine::Postgres => {
+                cellar_driver_postgres::commit_table_changes(open.connection.as_ref(), &request)
+                    .await
+            }
+            other => Err(CellarError::invalid_config(format!(
+                "engine {} does not support grid commits yet",
+                other.as_str()
+            ))),
+        }
     }
 
     async fn config_for(&self, id: &str) -> CellarResult<ConnectionConfig> {

--- a/apps/desktop/src/components/Workspace.tsx
+++ b/apps/desktop/src/components/Workspace.tsx
@@ -1,8 +1,14 @@
-import { DataGrid, useGridState } from "@cellar/data-grid";
+import {
+  DataGrid,
+  useGridState,
+  type PendingChanges,
+} from "@cellar/data-grid";
 
 import { Icon } from "./icons";
 import { useTabs, type TableTab } from "../state/tabs";
 import { useTableData } from "../hooks/useTableData";
+
+const EMPTY_CHANGES: PendingChanges = {};
 
 export function Workspace({ onCommit }: { onCommit?: () => void } = {}) {
   const tabs = useTabs((s) => s.tabs);
@@ -24,7 +30,17 @@ function TableTabPane({
   tab: TableTab;
   onCommit?: () => void;
 }) {
-  const data = useTableData(tab.connectionId, tab.database, tab.schema, tab.table);
+  const refreshKey = useTabs((s) => s.refreshKeys[tab.id] ?? 0);
+  const changes = useTabs((s) => s.tableChanges[tab.id] ?? EMPTY_CHANGES);
+  const setTableChanges = useTabs((s) => s.setTableChanges);
+  const clearTableChanges = useTabs((s) => s.clearTableChanges);
+  const data = useTableData(
+    tab.connectionId,
+    tab.database,
+    tab.schema,
+    tab.table,
+    refreshKey,
+  );
   const grid = useGridState();
 
   if (data.loading) {
@@ -48,8 +64,8 @@ function TableTabPane({
         columns={data.columns}
         rows={data.rows}
         totalRows={data.truncated ? undefined : data.rows.length}
-        changes={grid.changes}
-        onChange={grid.setChanges}
+        changes={changes}
+        onChange={(next) => setTableChanges(tab.id, next)}
         selection={grid.selection}
         onSelect={grid.setSelection}
         editing={grid.editing}
@@ -57,7 +73,7 @@ function TableTabPane({
         filters={grid.filters}
         onFiltersChange={grid.setFilters}
         onCommit={onCommit}
-        onRevert={grid.revert}
+        onRevert={() => clearTableChanges(tab.id)}
       />
     </div>
   );

--- a/apps/desktop/src/components/modals/CommitModal.tsx
+++ b/apps/desktop/src/components/modals/CommitModal.tsx
@@ -1,69 +1,27 @@
+import { useEffect, useMemo, useState } from "react";
+import type { PendingChange, PendingChanges } from "@cellar/data-grid";
+import {
+  commands,
+  unwrap,
+  type CellAssignment,
+  type Table,
+  type TableChangeRequest,
+  type TableCommitPreview,
+} from "@cellar/ipc";
+
 import { Icon } from "../icons";
 import { Modal } from "./Modal";
 import { tokenizeSql, tokensToLines, renderTokens } from "../../lib/sqlTokens";
+import { useConnections } from "../../state/connections";
+import { useStatus } from "../../state/status";
+import { useTabs, type TableTab } from "../../state/tabs";
 
-type Edit = { from: string | number | null; to: string | number | null };
-type UpdateChange = {
-  kind: "update";
-  row: { order_number: string };
-  edits: Record<string, Edit>;
-};
-type InsertChange = { kind: "insert"; row: Record<string, unknown> };
-type DeleteChange = { kind: "delete"; row: { order_number: string } };
-export type Change = UpdateChange | InsertChange | DeleteChange;
+type PreviewState =
+  | { kind: "idle" | "loading"; preview: null; error: null }
+  | { kind: "ready"; preview: TableCommitPreview; error: null }
+  | { kind: "error"; preview: null; error: string };
 
-export type ChangeSet = Record<string, Change>;
-
-export const SAMPLE_CHANGES: ChangeSet = {
-  "0a14b9b2-7f6c-4f2d-8a17-3e9f30caa101": {
-    kind: "update",
-    row: { order_number: "EU-0184237" },
-    edits: {
-      status: { from: "paid", to: "fulfilled" },
-      shipping_method: { from: "standard", to: "express" },
-    },
-  },
-  "2c4dd1a3-9914-4d12-9f8b-1c0e0a3bbf24": {
-    kind: "update",
-    row: { order_number: "EU-0184244" },
-    edits: {
-      status: { from: "paid", to: "cancelled" },
-      notes: { from: null, to: "customer requested cancel" },
-    },
-  },
-  "9f1c2c50-22d0-43a8-9d12-aa3f6e5210ef": {
-    kind: "insert",
-    row: {
-      id: "9f1c2c50-22d0-43a8-9d12-aa3f6e5210ef",
-      order_number: "EU-0184902",
-      customer_id: "1d4e2-...",
-      status: "pending",
-      total_eur: 84.5,
-      currency: "EUR",
-      channel: "web",
-      country: "DE",
-    },
-  },
-  "ba27e1f8-1d61-4b09-bc44-9e102239f48a": {
-    kind: "delete",
-    row: { order_number: "EU-0184121" },
-  },
-};
-
-function formatVal(v: unknown): string {
-  if (v === null || v === undefined) return "NULL";
-  if (typeof v === "number") return String(v);
-  if (typeof v === "boolean") return v ? "TRUE" : "FALSE";
-  return "'" + String(v).replaceAll("'", "''") + "'";
-}
-
-function quoteIdent(value: string): string {
-  return `"${value.replaceAll('"', '""')}"`;
-}
-
-function sqlComment(value: string): string {
-  return value.replaceAll("\n", " ").replaceAll("\r", " ");
-}
+const EMPTY_CHANGES: PendingChanges = {};
 
 const ED_RUN_BASE =
   "inline-flex h-[26px] items-center gap-[5px] whitespace-nowrap rounded-[4px] border border-transparent px-2.5 text-[11.5px] font-medium text-fg-1 transition-[background,color,border-color,filter] duration-[120ms]";
@@ -74,74 +32,132 @@ const ED_RUN_SUBTLE =
 
 const ED_RUN_DANGER =
   ED_RUN_BASE +
-  " bg-delete text-white hover:brightness-[1.07]";
+  " bg-delete text-white hover:brightness-[1.07] disabled:cursor-not-allowed disabled:opacity-60";
 
-export function CommitModal({
-  onClose,
-  changes = SAMPLE_CHANGES,
-  table = "orders",
-}: {
-  onClose: () => void;
-  changes?: ChangeSet;
-  table?: string;
-}) {
+export function CommitModal({ onClose }: { onClose: () => void }) {
+  const activeId = useTabs((s) => s.activeId);
+  const tabs = useTabs((s) => s.tabs);
+  const tableChanges = useTabs((s) => s.tableChanges);
+  const clearTableChanges = useTabs((s) => s.clearTableChanges);
+  const refreshTable = useTabs((s) => s.refreshTable);
+  const connections = useConnections((s) => s.connections);
+  const byId = useConnections((s) => s.byId);
+
+  const active = tabs.find((t) => t.id === activeId) ?? null;
+  const changes = active ? tableChanges[active.id] ?? EMPTY_CHANGES : EMPTY_CHANGES;
   const entries = Object.entries(changes);
-  const updates = entries.filter(([, c]) => c.kind === "update") as [
-    string,
-    UpdateChange,
-  ][];
-  const inserts = entries.filter(([, c]) => c.kind === "insert") as [
-    string,
-    InsertChange,
-  ][];
-  const deletes = entries.filter(([, c]) => c.kind === "delete") as [
-    string,
-    DeleteChange,
-  ][];
+  const activeConn = active
+    ? connections.find((c) => c.id === active.connectionId) ?? null
+    : null;
+  const tableMeta = active ? findTableMeta(active) : null;
 
-  const sqlLines: string[] = ["BEGIN;", ""];
-  const tableIdent = `public.${quoteIdent(table)}`;
-  updates.forEach(([id, c]) => {
-    sqlLines.push(`-- ${sqlComment(c.row.order_number)} · updated by alice@laptop`);
-    sqlLines.push(`UPDATE ${tableIdent}`);
-    const sets = Object.entries(c.edits).map(
-      ([col, e]) => `  ${quoteIdent(col)} = ${formatVal(e.to)}`,
-    );
-    sqlLines.push("SET");
-    sqlLines.push(sets.join(",\n"));
-    sqlLines.push(`WHERE ${quoteIdent("id")} = ${formatVal(id)};`);
-    sqlLines.push("");
+  const blockers = useMemo(
+    () => blockersFor(active, tableMeta, entries.length),
+    [active, tableMeta, entries.length],
+  );
+  const request = useMemo(
+    () =>
+      active && tableMeta && blockers.length === 0
+        ? buildRequest(active, tableMeta, changes)
+        : null,
+    [active, tableMeta, blockers.length, changes],
+  );
+  const [previewState, setPreviewState] = useState<PreviewState>({
+    kind: "idle",
+    preview: null,
+    error: null,
   });
-  inserts.forEach(([id, c]) => {
-    const cols = Object.keys(c.row);
-    const vals = cols.map((k) => formatVal(c.row[k]));
-    sqlLines.push(`INSERT INTO ${tableIdent} (${cols.map(quoteIdent).join(", ")})`);
-    sqlLines.push(`VALUES (${vals.join(", ")});`);
-    sqlLines.push("");
-    void id;
-  });
-  deletes.forEach(([id, c]) => {
-    sqlLines.push(`-- ${sqlComment(c.row.order_number)} · marked for deletion`);
-    sqlLines.push(`DELETE FROM ${tableIdent} WHERE ${quoteIdent("id")} = ${formatVal(id)};`);
-    sqlLines.push("");
-  });
-  sqlLines.push("COMMIT;");
-  const sqlText = sqlLines.join("\n");
-  const lines = tokensToLines(tokenizeSql(sqlText));
+  const [commitError, setCommitError] = useState<string | null>(null);
+  const [committing, setCommitting] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setCommitError(null);
+    if (!request) {
+      setPreviewState({ kind: "idle", preview: null, error: null });
+      return;
+    }
+    setPreviewState({ kind: "loading", preview: null, error: null });
+    void (async () => {
+      try {
+        const preview = await unwrap(commands.previewTableChanges(request));
+        if (!cancelled) setPreviewState({ kind: "ready", preview, error: null });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (!cancelled) {
+          setPreviewState({ kind: "error", preview: null, error: message });
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [request]);
+
+  const preview = previewState.preview;
+  const sqlText = preview?.sql ?? "";
+  const lines = preview ? tokensToLines(tokenizeSql(sqlText)) : [];
+  const updates = entries.filter(([, c]) => c.kind === "update");
+  const inserts = entries.filter(([, c]) => c.kind === "insert");
+  const deletes = entries.filter(([, c]) => c.kind === "delete");
+  const canCommit = !!active && !!request && !!preview && !committing;
+
+  useEffect(() => {
+    if (!canCommit) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Enter" || event.metaKey || event.ctrlKey || event.altKey) {
+        return;
+      }
+      const target = event.target;
+      if (target instanceof HTMLElement && isTextInput(target)) {
+        return;
+      }
+      event.preventDefault();
+      void handleCommit();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [canCommit, active, request, preview]);
+
+  async function handleCommit() {
+    if (!active || !request || !preview) return;
+    setCommitting(true);
+    setCommitError(null);
+    try {
+      const result = await unwrap(
+        commands.commitTableChanges(active.connectionId, request),
+      );
+      useStatus.getState().setLastQuery({
+        connectionId: active.connectionId,
+        rowCount: result.rows_affected,
+        truncated: false,
+        durationMs: result.duration_ms,
+      });
+      clearTableChanges(active.id);
+      refreshTable(active.id);
+      onClose();
+    } catch (err) {
+      setCommitError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setCommitting(false);
+    }
+  }
 
   return (
     <Modal onClose={onClose} width={880}>
       <div className="flex h-[38px] shrink-0 items-center justify-between border-b border-border-default pl-3.5 pr-2">
-        <div className="flex items-center gap-2">
+        <div className="flex min-w-0 items-center gap-2">
           <span className="inline-flex text-accent">
             <Icon.commit size={14} />
           </span>
           <span className="whitespace-nowrap text-[12.5px] font-semibold text-fg-0">
             Review &amp; commit
           </span>
-          <span className="ml-1 border-l border-border-divider pl-1.5 font-mono text-[11px] text-fg-2">
-            public.{table} <span style={{ color: "var(--fg-3)" }}>·</span>{" "}
-            shop-eu (prod)
+          <span className="ml-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap border-l border-border-divider pl-1.5 font-mono text-[11px] text-fg-2">
+            {active ? `${active.schema}.${active.table}` : "no table"}{" "}
+            <span style={{ color: "var(--fg-3)" }}>·</span>{" "}
+            {activeConn?.name ?? "no connection"}
+            {activeConn?.env_tag ? ` (${activeConn.env_tag})` : ""}
           </span>
         </div>
         <button type="button" className="icon-btn" onClick={onClose} title="Close">
@@ -150,31 +166,13 @@ export function CommitModal({
       </div>
 
       <div className="flex shrink-0 items-center gap-4 border-b border-border-default bg-bg-2 px-4 py-2.5">
-        <SummaryItem
-          icon={<Icon.plus size={11} />}
-          bg="var(--insert-bg)"
-          color="var(--insert)"
-          n={inserts.length}
-          label={`insert${inserts.length === 1 ? "" : "s"}`}
-        />
-        <SummaryItem
-          icon={<Icon.diff size={11} />}
-          bg="var(--update-bg)"
-          color="var(--update)"
-          n={updates.length}
-          label={`update${updates.length === 1 ? "" : "s"}`}
-        />
-        <SummaryItem
-          icon={<Icon.close size={11} />}
-          bg="var(--delete-bg)"
-          color="var(--delete)"
-          n={deletes.length}
-          label={`delete${deletes.length === 1 ? "" : "s"}`}
-        />
+        <SummaryItem icon={<Icon.plus size={11} />} bg="var(--insert-bg)" color="var(--insert)" n={inserts.length} label={`insert${inserts.length === 1 ? "" : "s"}`} />
+        <SummaryItem icon={<Icon.diff size={11} />} bg="var(--update-bg)" color="var(--update)" n={updates.length} label={`update${updates.length === 1 ? "" : "s"}`} />
+        <SummaryItem icon={<Icon.close size={11} />} bg="var(--delete-bg)" color="var(--delete)" n={deletes.length} label={`delete${deletes.length === 1 ? "" : "s"}`} />
         <div className="flex-1" />
         <span className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-[4px] bg-bg-inset px-2 py-1 font-mono text-[10.5px] text-fg-2">
           <Icon.bracket size={10} />
-          <span>BEGIN … COMMIT — atomic</span>
+          <span>BEGIN ... COMMIT - atomic</span>
         </span>
       </div>
 
@@ -187,141 +185,63 @@ export function CommitModal({
             </span>
           </div>
           <div className="flex-1 overflow-y-auto py-1.5">
-            {updates.map(([id, c]) => (
-              <ChangeRow key={id} tag="UPDATE" tagBg="var(--update-bg)" tagColor="var(--update)">
-                <div className="flex items-center gap-1.5 text-[11px]">
-                  <span className="font-mono font-medium text-fg-0">
-                    {c.row.order_number}
-                  </span>
-                  <span style={{ color: "var(--fg-3)" }}>·</span>
-                  <span className="font-mono" style={{ color: "var(--fg-3)", fontSize: 10 }}>
-                    {id.slice(0, 8)}
-                  </span>
-                </div>
-                {Object.entries(c.edits).map(([col, e]) => (
-                  <div
-                    key={col}
-                    className="grid items-center gap-[5px] pl-1 font-mono text-[10.5px] grid-cols-[90px_auto_auto_auto]"
-                  >
-                    <span className="overflow-hidden text-ellipsis text-fg-2">
-                      {col}
-                    </span>
-                    <span
-                      className="overflow-hidden text-ellipsis rounded-[3px] px-1.5 py-px text-delete line-through"
-                      style={{
-                        background: "var(--delete-bg)",
-                        textDecorationColor: "rgba(255, 255, 255, 0.2)",
-                      }}
-                    >
-                      {formatVal(e.from)}
-                    </span>
-                    <Icon.chevronRight size={10} stroke="var(--fg-3)" />
-                    <span className="overflow-hidden text-ellipsis rounded-[3px] bg-accent-soft px-1.5 py-px text-accent">
-                      {formatVal(e.to)}
-                    </span>
-                  </div>
-                ))}
-              </ChangeRow>
-            ))}
-            {inserts.map(([id, c]) => (
-              <ChangeRow key={id} tag="INSERT" tagBg="var(--insert-bg)" tagColor="var(--insert)">
-                <div className="flex items-center gap-1.5 text-[11px]">
-                  <span className="font-mono font-medium text-fg-0">
-                    {String((c.row as { order_number?: string }).order_number ?? "new")}
-                  </span>
-                  <span style={{ color: "var(--fg-3)" }}>·</span>
-                  <span className="font-mono" style={{ color: "var(--fg-3)", fontSize: 10 }}>
-                    new
-                  </span>
-                </div>
-                <div
-                  className="pl-1 font-mono text-[10.5px] text-fg-2"
-                  style={{ display: "grid", gridTemplateColumns: "1fr", gap: 5 }}
-                >
-                  new row · {Object.keys(c.row).length} columns set
-                </div>
-              </ChangeRow>
-            ))}
-            {deletes.map(([id, c]) => (
-              <ChangeRow key={id} tag="DELETE" tagBg="var(--delete-bg)" tagColor="var(--delete)">
-                <div className="flex items-center gap-1.5 text-[11px]">
-                  <span className="font-mono font-medium text-fg-0 line-through">
-                    {c.row.order_number}
-                  </span>
-                  <span style={{ color: "var(--fg-3)" }}>·</span>
-                  <span className="font-mono" style={{ color: "var(--fg-3)", fontSize: 10 }}>
-                    {id.slice(0, 8)}
-                  </span>
-                </div>
-              </ChangeRow>
-            ))}
+            {entries.length === 0 ? (
+              <div className="px-3 py-3 text-[11px] text-fg-3">
+                No pending changes on the active table.
+              </div>
+            ) : (
+              entries.map(([rowId, change]) => (
+                <ChangePreview key={rowId} rowId={rowId} change={change} />
+              ))
+            )}
           </div>
         </div>
 
         <div className="flex min-h-0 flex-col bg-bg-inset">
           <div className="flex h-[26px] shrink-0 items-center justify-between border-b border-border-divider bg-bg-1 px-3 text-[10px] font-semibold uppercase tracking-[0.05em] text-fg-3">
             <span>Generated SQL</span>
-            <div className="flex gap-1">
-              <button
-                type="button"
-                disabled
-                title="SQL editing is not wired yet"
-                className="inline-flex h-[26px] cursor-not-allowed items-center gap-1 rounded-[4px] border border-border-default bg-bg-2 px-2 text-[11px] text-fg-2 opacity-70"
-              >
-                <Icon.edit size={11} />
-                <span>Edit</span>
-              </button>
-              <button
-                type="button"
-                onClick={() => void navigator.clipboard?.writeText(sqlText)}
-                className="inline-flex h-[26px] items-center gap-1 rounded-[4px] border border-border-default bg-bg-2 px-2 text-[11px] text-fg-1 hover:bg-bg-3"
-              >
-                <Icon.copy size={11} />
-                <span>Copy</span>
-              </button>
-            </div>
+            <button
+              type="button"
+              disabled={!preview}
+              onClick={() => void navigator.clipboard?.writeText(sqlText)}
+              className="inline-flex h-[26px] items-center gap-1 rounded-[4px] border border-border-default bg-bg-2 px-2 text-[11px] text-fg-1 hover:bg-bg-3 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <Icon.copy size={11} />
+              <span>Copy</span>
+            </button>
           </div>
           <div className="flex-1 overflow-auto py-2 font-mono text-[11.5px] leading-[1.55]">
-            {lines.map((toks, i) => (
-              <div key={i} className="flex px-3">
-                <span className="inline-flex w-7 shrink-0 select-none items-center justify-end pr-2.5 font-variant-numeric-tabular text-[10px] text-fg-3 font-mono">
-                  {i + 1}
-                </span>
-                <span className="whitespace-pre font-mono">
-                  {renderTokens(toks)}
-                </span>
-              </div>
-            ))}
+            {blockers.length > 0 ? (
+              <MessageList messages={blockers} tone="warn" />
+            ) : previewState.kind === "loading" ? (
+              <div className="px-3 text-[11px] text-fg-3">Generating preview...</div>
+            ) : previewState.kind === "error" ? (
+              <MessageList messages={[previewState.error]} tone="warn" />
+            ) : (
+              lines.map((toks, i) => (
+                <div key={i} className="flex px-3">
+                  <span className="inline-flex w-7 shrink-0 select-none items-center justify-end pr-2.5 font-variant-numeric-tabular text-[10px] text-fg-3 font-mono">
+                    {i + 1}
+                  </span>
+                  <span className="whitespace-pre font-mono">
+                    {renderTokens(toks)}
+                  </span>
+                </div>
+              ))
+            )}
           </div>
         </div>
       </div>
 
-      <div className="flex h-11 shrink-0 items-center justify-between gap-3 border-t border-border-default bg-bg-2 px-3">
-        <div className="flex items-center gap-2">
-          <label className="inline-flex cursor-pointer items-center gap-1 text-[11px] text-fg-2">
-            <input
-              type="checkbox"
-              defaultChecked
-              className="h-3 w-3"
-              style={{ accentColor: "var(--accent)" }}
-            />
-            Rollback on error
-          </label>
-          <label className="inline-flex cursor-pointer items-center gap-1 text-[11px] text-fg-2">
-            <input
-              type="checkbox"
-              defaultChecked
-              className="h-3 w-3"
-              style={{ accentColor: "var(--accent)" }}
-            />
-            Confirm if rows affected &gt; 100
-          </label>
-          <span className="ml-2 inline-flex items-center gap-1.5 text-[10.5px]">
-            <Icon.warn size={10} stroke="var(--warn)" />
-            <span style={{ color: "var(--warn)" }}>prod</span>
-            <span style={{ color: "var(--fg-2)" }}>
-              · you'll be asked to type the connection name
-            </span>
+      <div className="flex min-h-11 shrink-0 items-center justify-between gap-3 border-t border-border-default bg-bg-2 px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2 text-[10.5px]">
+          <Icon.warn size={10} stroke={activeConn?.env_tag === "prod" ? "var(--warn)" : "var(--fg-3)"} />
+          <span className={activeConn?.env_tag === "prod" ? "text-warn" : "text-fg-2"}>
+            {activeConn?.env_tag === "prod" ? "prod" : "transaction"}
+          </span>
+          <span className="min-w-0 text-fg-2">
+            {commitError ??
+              "commits rollback on error and require the expected row count"}
           </span>
         </div>
         <div className="flex items-center gap-2">
@@ -339,19 +259,206 @@ export function CommitModal({
           </button>
           <button
             type="button"
-            disabled
-            title="Committing pending edits is not wired yet"
-            className={ED_RUN_DANGER + " cursor-not-allowed opacity-60"}
+            disabled={!canCommit}
+            onClick={() => void handleCommit()}
+            className={ED_RUN_DANGER}
             style={{
               borderColor: "color-mix(in oklab, var(--delete) 40%, black)",
             }}
           >
             <Icon.commit size={11} />
-            <span>Commit transaction</span>
+            <span>{committing ? "Committing..." : "Commit transaction"}</span>
+            <kbd className="kbd ml-1">Return</kbd>
           </button>
         </div>
       </div>
     </Modal>
+  );
+
+  function findTableMeta(tab: TableTab): Table | null {
+    return (
+      byId[tab.connectionId]?.databases
+        .find((d) => d.name === tab.database)
+        ?.schemas.find((s) => s.name === tab.schema)
+        ?.tables.find((t) => t.name === tab.table) ?? null
+    );
+  }
+}
+
+function ChangePreview({
+  rowId,
+  change,
+}: {
+  rowId: string;
+  change: PendingChange;
+}) {
+  const tag = change.kind.toUpperCase();
+  const tagBg =
+    change.kind === "insert"
+      ? "var(--insert-bg)"
+      : change.kind === "delete"
+        ? "var(--delete-bg)"
+        : "var(--update-bg)";
+  const tagColor =
+    change.kind === "insert"
+      ? "var(--insert)"
+      : change.kind === "delete"
+        ? "var(--delete)"
+        : "var(--update)";
+  const label = rowLabel(rowId);
+
+  return (
+    <ChangeRow tag={tag} tagBg={tagBg} tagColor={tagColor}>
+      <div className="flex items-center gap-1.5 text-[11px]">
+        <span className="font-mono font-medium text-fg-0">{label}</span>
+      </div>
+      {Object.entries(change.edits).map(([col, e]) => (
+        <div
+          key={col}
+          className="grid items-center gap-[5px] pl-1 font-mono text-[10.5px] grid-cols-[90px_auto_auto_auto]"
+        >
+          <span className="overflow-hidden text-ellipsis text-fg-2">{col}</span>
+          <span
+            className="overflow-hidden text-ellipsis rounded-[3px] px-1.5 py-px text-delete line-through"
+            style={{
+              background: "var(--delete-bg)",
+              textDecorationColor: "rgba(255, 255, 255, 0.2)",
+            }}
+          >
+            {formatVal(e.from)}
+          </span>
+          <Icon.chevronRight size={10} stroke="var(--fg-3)" />
+          <span className="overflow-hidden text-ellipsis rounded-[3px] bg-accent-soft px-1.5 py-px text-accent">
+            {formatVal(e.to)}
+          </span>
+        </div>
+      ))}
+    </ChangeRow>
+  );
+}
+
+function buildRequest(
+  tab: TableTab,
+  table: Table,
+  changes: PendingChanges,
+): TableChangeRequest {
+  return {
+    database: tab.database,
+    schema: tab.schema,
+    table: tab.table,
+    primary_key: table.primary_key,
+    columns: table.columns.map((c) => ({
+      name: c.name,
+      data_type: c.data_type,
+      nullable: c.nullable,
+    })),
+    changes: Object.entries(changes).map(([rowId, change]) => {
+      if (change.kind === "insert") {
+        return {
+          kind: "insert",
+          row_id: rowId,
+          values: editsToAssignments(change),
+        };
+      }
+      if (change.kind === "delete") {
+        return {
+          kind: "delete",
+          row_id: rowId,
+          keys: decodeRowKeys(rowId),
+        };
+      }
+      return {
+        kind: "update",
+        row_id: rowId,
+        keys: decodeRowKeys(rowId),
+        edits: editsToAssignments(change),
+      };
+    }),
+  };
+}
+
+function blockersFor(
+  active: TableTab | null,
+  table: Table | null,
+  changeCount: number,
+): string[] {
+  if (!active) return ["Open a table before reviewing changes."];
+  if (changeCount === 0) return ["There are no pending changes to commit."];
+  if (!table) return ["Schema metadata is still unavailable for this table."];
+  if (table.primary_key.length === 0) {
+    return ["Cellar needs a primary key before it can safely commit grid edits."];
+  }
+  return [];
+}
+
+function editsToAssignments(change: PendingChange): CellAssignment[] {
+  return Object.entries(change.edits).map(([column, edit]) => ({
+    column,
+    value: { value: primitiveToString(edit.to) },
+  }));
+}
+
+function decodeRowKeys(rowId: string): CellAssignment[] {
+  try {
+    const parsed = JSON.parse(rowId) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .map((entry) => {
+        if (!entry || typeof entry !== "object") return null;
+        const item = entry as { column?: unknown; value?: unknown };
+        if (typeof item.column !== "string") return null;
+        return {
+          column: item.column,
+          value: { value: primitiveToString(item.value) },
+        };
+      })
+      .filter((v): v is CellAssignment => v !== null);
+  } catch {
+    return [];
+  }
+}
+
+function rowLabel(rowId: string): string {
+  const keys = decodeRowKeys(rowId);
+  if (keys.length === 0) return rowId;
+  return keys
+    .map((k) => `${k.column}=${k.value.value ?? "NULL"}`)
+    .join(", ");
+}
+
+function primitiveToString(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  return String(value);
+}
+
+function isTextInput(target: HTMLElement): boolean {
+  return (
+    target.tagName === "INPUT" ||
+    target.tagName === "TEXTAREA" ||
+    target.isContentEditable
+  );
+}
+
+function formatVal(v: unknown): string {
+  if (v === null || v === undefined) return "NULL";
+  if (typeof v === "number") return String(v);
+  if (typeof v === "boolean") return v ? "TRUE" : "FALSE";
+  return "'" + String(v).replaceAll("'", "''") + "'";
+}
+
+function MessageList({
+  messages,
+  tone,
+}: {
+  messages: string[];
+  tone: "warn" | "muted";
+}) {
+  return (
+    <div className={tone === "warn" ? "px-3 text-[11px] text-warn" : "px-3 text-[11px] text-fg-3"}>
+      {messages.map((message) => (
+        <div key={message}>{message}</div>
+      ))}
+    </div>
   );
 }
 

--- a/apps/desktop/src/hooks/useTableData.ts
+++ b/apps/desktop/src/hooks/useTableData.ts
@@ -28,6 +28,7 @@ export function useTableData(
   database: string,
   schema: string,
   table: string,
+  refreshKey = 0,
 ): TableData {
   const [state, setState] = useState<TableData>({
     columns: [],
@@ -40,8 +41,9 @@ export function useTableData(
 
   useEffect(() => {
     let cancelled = false;
-    setState((s) => ({ ...s, loading: true, error: null }));
-    const sql = `SELECT * FROM ${quoteIdent(schema)}.${quoteIdent(table)} LIMIT ${DEFAULT_LIMIT}`;
+    setState((s) => ({ ...s, loading: s.rows.length === 0, error: null }));
+    const primaryKey = tablePrimaryKey(connectionId, database, schema, table);
+    const sql = tableSelectSql(schema, table, primaryKey);
     void (async () => {
       try {
         const result = await unwrap(
@@ -49,7 +51,11 @@ export function useTableData(
         );
         if (cancelled) return;
         const columns = columnsFor(connectionId, database, schema, table, result);
-        const rows = rowsFor(columns, result);
+        const rows = rowsFor(
+          columns,
+          result,
+          primaryKey,
+        );
         setState({
           columns,
           rows,
@@ -80,9 +86,22 @@ export function useTableData(
     return () => {
       cancelled = true;
     };
-  }, [connectionId, database, schema, table]);
+  }, [connectionId, database, schema, table, refreshKey]);
 
   return state;
+}
+
+function tableSelectSql(
+  schema: string,
+  table: string,
+  primaryKey: string[],
+): string {
+  const tableIdent = `${quoteIdent(schema)}.${quoteIdent(table)}`;
+  const orderBy =
+    primaryKey.length > 0
+      ? ` ORDER BY ${primaryKey.map(quoteIdent).join(", ")}`
+      : "";
+  return `SELECT * FROM ${tableIdent}${orderBy} LIMIT ${DEFAULT_LIMIT}`;
 }
 
 function columnsFor(
@@ -118,6 +137,22 @@ function columnsFor(
   });
 }
 
+function tablePrimaryKey(
+  connectionId: string,
+  database: string,
+  schema: string,
+  table: string,
+): string[] {
+  const cache = useConnections.getState().byId[connectionId];
+  return (
+    cache?.databases
+      .filter((d) => d.name === database)
+      .flatMap((d) => d.schemas)
+      .find((s) => s.name === schema)
+      ?.tables.find((t) => t.name === table)?.primary_key ?? []
+  );
+}
+
 function findForeignKey(
   fks: {
     columns: string[];
@@ -134,15 +169,30 @@ function findForeignKey(
   return undefined;
 }
 
-function rowsFor(columns: GridColumn[], result: QueryResult): GridRow[] {
+function rowsFor(
+  columns: GridColumn[],
+  result: QueryResult,
+  primaryKey: string[],
+): GridRow[] {
   return result.rows.map((cells, i) => {
     const row: GridRow = { id: String(i) };
     cells.forEach((cell, ci) => {
       const col = columns[ci];
       if (col) row[col.key] = cellValueToGrid(cell);
     });
+    row.id = rowIdFor(row, primaryKey, i);
     return row;
   });
+}
+
+function rowIdFor(row: GridRow, primaryKey: string[], index: number): string {
+  if (primaryKey.length === 0) return `row:${index}`;
+  return JSON.stringify(
+    primaryKey.map((column) => ({
+      column,
+      value: gridValueToString(row[column] ?? null),
+    })),
+  );
 }
 
 function cellValueToGrid(value: CellValue): string | number | null {
@@ -170,6 +220,13 @@ function cellValueToGrid(value: CellValue): string | number | null {
     case "TimestampTz":
       return value.value;
   }
+}
+
+function gridValueToString(
+  value: string | number | null | undefined,
+): string | null {
+  if (value === null || value === undefined) return null;
+  return String(value);
 }
 
 function isNumeric(type: string): boolean {

--- a/apps/desktop/src/state/tabs.ts
+++ b/apps/desktop/src/state/tabs.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import type { PendingChanges } from "@cellar/data-grid";
 
 export interface TableTab {
   id: string;
@@ -12,6 +13,8 @@ export interface TableTab {
 interface TabsStore {
   tabs: TableTab[];
   activeId: string | null;
+  tableChanges: Record<string, PendingChanges>;
+  refreshKeys: Record<string, number>;
   openTable: (
     connectionId: string,
     database: string,
@@ -20,6 +23,9 @@ interface TabsStore {
   ) => void;
   closeTab: (id: string) => void;
   setActive: (id: string) => void;
+  setTableChanges: (id: string, changes: PendingChanges) => void;
+  clearTableChanges: (id: string) => void;
+  refreshTable: (id: string) => void;
 }
 
 function tableKey(
@@ -34,6 +40,8 @@ function tableKey(
 export const useTabs = create<TabsStore>((set, get) => ({
   tabs: [],
   activeId: null,
+  tableChanges: {},
+  refreshKeys: {},
 
   openTable(connectionId, database, schema, table) {
     const id = tableKey(connectionId, database, schema, table);
@@ -56,11 +64,30 @@ export const useTabs = create<TabsStore>((set, get) => ({
       const tabs = s.tabs.filter((t) => t.id !== id);
       const activeId =
         s.activeId === id ? tabs[tabs.length - 1]?.id ?? null : s.activeId;
-      return { tabs, activeId };
+      const { [id]: _changes, ...tableChanges } = s.tableChanges;
+      const { [id]: _refresh, ...refreshKeys } = s.refreshKeys;
+      return { tabs, activeId, tableChanges, refreshKeys };
     });
   },
 
   setActive(id) {
     set({ activeId: id });
+  },
+
+  setTableChanges(id, changes) {
+    set((s) => ({ tableChanges: { ...s.tableChanges, [id]: changes } }));
+  },
+
+  clearTableChanges(id) {
+    set((s) => {
+      const { [id]: _changes, ...tableChanges } = s.tableChanges;
+      return { tableChanges };
+    });
+  },
+
+  refreshTable(id) {
+    set((s) => ({
+      refreshKeys: { ...s.refreshKeys, [id]: (s.refreshKeys[id] ?? 0) + 1 },
+    }));
   },
 }));

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -2,19 +2,20 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
-// Tauri expects a fixed port and to know if it's iOS/Android.
+// Tauri expects a known port and to know if it's iOS/Android.
 // See https://v2.tauri.app/start/frontend/vite/
 const host = process.env.TAURI_DEV_HOST;
+const devPort = Number(process.env.CELLAR_DEV_PORT ?? 1430);
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   clearScreen: false,
   server: {
-    port: 1430,
-    strictPort: true,
+    port: devPort,
+    strictPort: !!process.env.CELLAR_DEV_PORT,
     host: host || false,
     hmr: host
-      ? { protocol: "ws", host, port: 1431 }
+      ? { protocol: "ws", host, port: devPort + 1 }
       : undefined,
     watch: {
       ignored: ["**/src-tauri/**"],

--- a/crates/cellar-diff/Cargo.toml
+++ b/crates/cellar-diff/Cargo.toml
@@ -5,3 +5,8 @@ edition.workspace = true
 license.workspace = true
 description = "Cellar — pending row-level edits → transactional SQL"
 publish = false
+
+[dependencies]
+serde = { workspace = true }
+specta = { version = "=2.0.0-rc.22", features = ["derive"] }
+thiserror = { workspace = true }

--- a/crates/cellar-diff/src/lib.rs
+++ b/crates/cellar-diff/src/lib.rs
@@ -1,1 +1,264 @@
-// Placeholder. Grid-edit diff engine lands here.
+//! Build reviewable, transactional SQL from grid pending changes.
+
+use serde::{Deserialize, Serialize};
+use specta::Type;
+use thiserror::Error;
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum DiffError {
+    #[error("table name is empty")]
+    EmptyTable,
+    #[error("schema name is empty")]
+    EmptySchema,
+    #[error("primary key metadata is required to commit row edits")]
+    MissingPrimaryKey,
+    #[error("change {0} does not include primary key values")]
+    MissingRowKey(String),
+    #[error("change {0} does not edit any columns")]
+    EmptyEdit(String),
+    #[error("insert change {0} does not include any values")]
+    EmptyInsert(String),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
+pub struct TableChangeRequest {
+    pub database: Option<String>,
+    pub schema: String,
+    pub table: String,
+    pub primary_key: Vec<String>,
+    pub columns: Vec<DiffColumn>,
+    pub changes: Vec<RowChange>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
+pub struct DiffColumn {
+    pub name: String,
+    pub data_type: String,
+    pub nullable: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum RowChange {
+    Update {
+        row_id: String,
+        keys: Vec<CellAssignment>,
+        edits: Vec<CellAssignment>,
+    },
+    Insert {
+        row_id: String,
+        values: Vec<CellAssignment>,
+    },
+    Delete {
+        row_id: String,
+        keys: Vec<CellAssignment>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
+pub struct CellAssignment {
+    pub column: String,
+    pub value: DiffValue,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
+pub struct DiffValue {
+    pub value: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
+pub struct TableCommitPreview {
+    pub sql: String,
+    pub expected_rows: u64,
+    pub statement_count: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
+pub struct TableCommitResult {
+    pub sql: String,
+    pub rows_affected: u64,
+    pub duration_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommitPlan {
+    pub preview: TableCommitPreview,
+    pub statements: Vec<String>,
+}
+
+pub fn build_postgres_plan(request: &TableChangeRequest) -> Result<CommitPlan, DiffError> {
+    validate_request(request)?;
+
+    let table = qualified_table(&request.schema, &request.table);
+    let mut statements = Vec::with_capacity(request.changes.len());
+    for change in &request.changes {
+        statements.push(statement_for(change, &table)?);
+    }
+
+    let mut lines = Vec::with_capacity(statements.len() * 3 + 2);
+    lines.push("BEGIN;".to_string());
+    for statement in &statements {
+        lines.push(String::new());
+        lines.push(statement.clone());
+    }
+    lines.push(String::new());
+    lines.push("COMMIT;".to_string());
+
+    Ok(CommitPlan {
+        preview: TableCommitPreview {
+            sql: lines.join("\n"),
+            expected_rows: request.changes.len() as u64,
+            statement_count: statements.len() as u32,
+        },
+        statements,
+    })
+}
+
+fn validate_request(request: &TableChangeRequest) -> Result<(), DiffError> {
+    if request.schema.trim().is_empty() {
+        return Err(DiffError::EmptySchema);
+    }
+    if request.table.trim().is_empty() {
+        return Err(DiffError::EmptyTable);
+    }
+    if request.primary_key.is_empty() && !request.changes.is_empty() {
+        return Err(DiffError::MissingPrimaryKey);
+    }
+    Ok(())
+}
+
+fn statement_for(change: &RowChange, table: &str) -> Result<String, DiffError> {
+    match change {
+        RowChange::Update {
+            row_id,
+            keys,
+            edits,
+        } => {
+            if keys.is_empty() {
+                return Err(DiffError::MissingRowKey(row_id.clone()));
+            }
+            if edits.is_empty() {
+                return Err(DiffError::EmptyEdit(row_id.clone()));
+            }
+            let set = edits
+                .iter()
+                .map(|e| format!("  {} = {}", quote_ident(&e.column), literal(&e.value)))
+                .collect::<Vec<_>>()
+                .join(",\n");
+            Ok(format!(
+                "UPDATE {table}\nSET\n{set}\nWHERE {};",
+                where_clause(keys)
+            ))
+        }
+        RowChange::Insert { row_id, values } => {
+            if values.is_empty() {
+                return Err(DiffError::EmptyInsert(row_id.clone()));
+            }
+            let cols = values
+                .iter()
+                .map(|v| quote_ident(&v.column))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let vals = values
+                .iter()
+                .map(|v| literal(&v.value))
+                .collect::<Vec<_>>()
+                .join(", ");
+            Ok(format!("INSERT INTO {table} ({cols})\nVALUES ({vals});"))
+        }
+        RowChange::Delete { row_id, keys } => {
+            if keys.is_empty() {
+                return Err(DiffError::MissingRowKey(row_id.clone()));
+            }
+            Ok(format!(
+                "DELETE FROM {table}\nWHERE {};",
+                where_clause(keys)
+            ))
+        }
+    }
+}
+
+fn where_clause(keys: &[CellAssignment]) -> String {
+    keys.iter()
+        .map(|k| {
+            format!(
+                "{} IS NOT DISTINCT FROM {}",
+                quote_ident(&k.column),
+                literal(&k.value)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(" AND ")
+}
+
+fn qualified_table(schema: &str, table: &str) -> String {
+    format!("{}.{}", quote_ident(schema), quote_ident(table))
+}
+
+fn quote_ident(value: &str) -> String {
+    format!("\"{}\"", value.replace('"', "\"\""))
+}
+
+fn literal(value: &DiffValue) -> String {
+    match &value.value {
+        None => "NULL".to_string(),
+        Some(v) => format!("'{}'", v.replace('\'', "''")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_postgres_update_transaction() {
+        let plan = build_postgres_plan(&TableChangeRequest {
+            database: Some("shop".into()),
+            schema: "public".into(),
+            table: "orders".into(),
+            primary_key: vec!["id".into()],
+            columns: vec![],
+            changes: vec![RowChange::Update {
+                row_id: "1".into(),
+                keys: vec![assign("id", Some("1"))],
+                edits: vec![assign("status", Some("paid's")), assign("note", None)],
+            }],
+        })
+        .expect("plan");
+
+        assert_eq!(plan.preview.expected_rows, 1);
+        assert_eq!(plan.statements.len(), 1);
+        assert!(plan.preview.sql.contains("BEGIN;"));
+        assert!(plan.preview.sql.contains("\"status\" = 'paid''s'"));
+        assert!(plan.preview.sql.contains("\"note\" = NULL"));
+        assert!(plan.preview.sql.contains("\"id\" IS NOT DISTINCT FROM '1'"));
+    }
+
+    #[test]
+    fn rejects_keyless_updates() {
+        let err = build_postgres_plan(&TableChangeRequest {
+            database: None,
+            schema: "public".into(),
+            table: "orders".into(),
+            primary_key: vec![],
+            columns: vec![],
+            changes: vec![RowChange::Update {
+                row_id: "row:1".into(),
+                keys: vec![],
+                edits: vec![assign("status", Some("paid"))],
+            }],
+        })
+        .expect_err("keyless update should fail");
+
+        assert_eq!(err, DiffError::MissingPrimaryKey);
+    }
+
+    fn assign(column: &str, value: Option<&str>) -> CellAssignment {
+        CellAssignment {
+            column: column.into(),
+            value: DiffValue {
+                value: value.map(str::to_string),
+            },
+        }
+    }
+}

--- a/crates/cellar-drivers/postgres/Cargo.toml
+++ b/crates/cellar-drivers/postgres/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [dependencies]
 cellar-core = { path = "../../cellar-core" }
+cellar-diff = { path = "../../cellar-diff" }
 async-trait = "0.1"
 futures = "0.3"
 serde = { workspace = true }

--- a/crates/cellar-drivers/postgres/src/lib.rs
+++ b/crates/cellar-drivers/postgres/src/lib.rs
@@ -7,6 +7,7 @@ use cellar_core::driver::{Connection, ConnectionConfig, Driver, Engine};
 use cellar_core::error::CellarResult;
 use cellar_core::query::{Query, QueryResult};
 use cellar_core::schema::Database;
+use cellar_diff::{TableChangeRequest, TableCommitResult};
 
 mod connect;
 mod decode;
@@ -24,6 +25,14 @@ impl PostgresDriver {
     pub fn new() -> Self {
         Self
     }
+}
+
+pub async fn commit_table_changes(
+    conn: &dyn Connection,
+    request: &TableChangeRequest,
+) -> CellarResult<TableCommitResult> {
+    let pg = connect::as_pg(conn)?;
+    query::commit_table_changes(pg, request).await
 }
 
 #[async_trait]

--- a/crates/cellar-drivers/postgres/src/query.rs
+++ b/crates/cellar-drivers/postgres/src/query.rs
@@ -3,6 +3,7 @@ use std::time::Instant;
 use cellar_core::error::{CellarError, CellarResult};
 use cellar_core::query::{Query, QueryResult};
 use cellar_core::value::{ColumnMeta, Row};
+use cellar_diff::{build_postgres_plan, TableChangeRequest, TableCommitResult};
 use sqlx::{Column as _, Row as _, TypeInfo as _};
 
 use crate::connect::PgConnection;
@@ -63,5 +64,52 @@ pub async fn execute_query(conn: &PgConnection, query: &Query) -> CellarResult<Q
         rows_affected: None,
         duration_ms,
         truncated,
+    })
+}
+
+pub async fn commit_table_changes(
+    conn: &PgConnection,
+    request: &TableChangeRequest,
+) -> CellarResult<TableCommitResult> {
+    let database = request
+        .database
+        .as_deref()
+        .unwrap_or(conn.config().database.as_str());
+    let pool = conn.pool_for_database(database).await?;
+    let plan = build_postgres_plan(request).map_err(|e| CellarError::query(e.to_string()))?;
+
+    let started = Instant::now();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| CellarError::query(e.to_string()))?;
+    let mut rows_affected = 0u64;
+
+    for statement in &plan.statements {
+        let result = sqlx::query(statement)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| CellarError::query(e.to_string()))?;
+        rows_affected += result.rows_affected();
+    }
+
+    if rows_affected != plan.preview.expected_rows {
+        tx.rollback()
+            .await
+            .map_err(|e| CellarError::query(e.to_string()))?;
+        return Err(CellarError::query(format!(
+            "expected {} affected rows but database reported {}; the table may have changed since it was loaded",
+            plan.preview.expected_rows, rows_affected
+        )));
+    }
+
+    tx.commit()
+        .await
+        .map_err(|e| CellarError::query(e.to_string()))?;
+
+    Ok(TableCommitResult {
+        sql: plan.preview.sql,
+        rows_affected,
+        duration_ms: started.elapsed().as_millis() as u64,
     })
 }

--- a/packages/ipc/src/generated.ts
+++ b/packages/ipc/src/generated.ts
@@ -68,6 +68,22 @@ async runQuery(connectionId: string, sql: string, maxRows: number | null, databa
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
+},
+async previewTableChanges(request: TableChangeRequest) : Promise<Result<TableCommitPreview, CellarError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("preview_table_changes", { request }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async commitTableChanges(connectionId: string, request: TableChangeRequest) : Promise<Result<TableCommitResult, CellarError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("commit_table_changes", { connectionId, request }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
 }
 }
 
@@ -81,6 +97,7 @@ async runQuery(connectionId: string, sql: string, maxRows: number | null, databa
 
 /** user-defined types **/
 
+export type CellAssignment = { column: string; value: DiffValue }
 /**
  * One cell value, tagged so the frontend can render the right editor and
  * preserve type fidelity through the IPC boundary.
@@ -155,6 +172,8 @@ color: string | null }
  * `pg_database` row, for MySQL to a single catalog, for SQLite the file.
  */
 export type Database = { name: string; is_default: boolean; schemas: Schema[] }
+export type DiffColumn = { name: string; data_type: string; nullable: boolean }
+export type DiffValue = { value: string | null }
 export type DriverInfo = { engine: Engine; 
 /**
  * Server version as reported by the engine, e.g. `PostgreSQL 16.2 on
@@ -189,6 +208,7 @@ duration_ms: number;
  * [`Query::max_rows`]. The grid uses this to show a "+ more" badge.
  */
 truncated: boolean }
+export type RowChange = { kind: "update"; row_id: string; keys: CellAssignment[]; edits: CellAssignment[] } | { kind: "insert"; row_id: string; values: CellAssignment[] } | { kind: "delete"; row_id: string; keys: CellAssignment[] }
 export type Schema = { name: string; tables: Table[]; views: View[] }
 export type SslMode = "disable" | "prefer" | "require" | "verify-ca" | "verify-full"
 export type Table = { name: string; schema: string; 
@@ -196,6 +216,9 @@ export type Table = { name: string; schema: string;
  * `None` until lazy row-count introspection has run.
  */
 row_count: number | null; columns: Column[]; primary_key: string[]; foreign_keys: ForeignKey[]; indexes: Index[] }
+export type TableChangeRequest = { database: string | null; schema: string; table: string; primary_key: string[]; columns: DiffColumn[]; changes: RowChange[] }
+export type TableCommitPreview = { sql: string; expected_rows: number; statement_count: number }
+export type TableCommitResult = { sql: string; rows_affected: number; duration_ms: number }
 export type View = { name: string; schema: string; columns: Column[]; definition: string | null }
 
 /** tauri-specta globals **/

--- a/packages/ipc/src/mock.ts
+++ b/packages/ipc/src/mock.ts
@@ -11,6 +11,9 @@ import type {
   DriverInfo,
   QueryResult,
   Result,
+  TableChangeRequest,
+  TableCommitPreview,
+  TableCommitResult,
 } from "./generated";
 
 function ok<T>(data: T): Result<T, CellarError> {
@@ -58,5 +61,24 @@ export const mockCommands = {
       rows_affected: null,
       duration_ms: 0,
       truncated: false,
+    }),
+
+  previewTableChanges: async (
+    _request: TableChangeRequest,
+  ): Promise<Result<TableCommitPreview, CellarError>> =>
+    ok({
+      sql: "BEGIN;\n\n-- preview unavailable in web mode\n\nCOMMIT;",
+      expected_rows: 0,
+      statement_count: 0,
+    }),
+
+  commitTableChanges: async (
+    _connectionId: string,
+    _request: TableChangeRequest,
+  ): Promise<Result<TableCommitResult, CellarError>> =>
+    ok({
+      sql: "BEGIN;\n\nCOMMIT;",
+      rows_affected: 0,
+      duration_ms: 0,
     }),
 };


### PR DESCRIPTION
## Summary

Adds the first real review-and-commit path for editable grid cells. Pending edits now flow from the data grid into the active tab state, the review modal renders backend-generated SQL, and Postgres commits execute inside a transaction with affected-row verification.

Also improves the local dev loop by letting `pnpm dev` fall forward to the next free Vite port when `1430` is already occupied.

## Details

- Adds `cellar-diff` planning for transactional Postgres table changes.
- Adds typed Tauri IPC commands for previewing and committing table changes.
- Wires the Postgres driver to execute generated statements inside a transaction and rollback on mismatch/error.
- Updates the commit modal to use actual pending table edits, supports `Cmd+S` then `Return`, and keeps post-commit table reloads stable.
- Orders table loads by primary key when available so refreshed data does not appear to jump around.
- Adds a dev launcher that chooses a free Vite port and passes it to Tauri.

## Validation

- `pnpm typecheck`
- `cargo check --workspace`
- `node --check apps/desktop/scripts/dev.mjs`
- Earlier in the branch: `pnpm lint`, `pnpm --filter @cellar/desktop build`, `cargo test --workspace`
