### PR TITLE
feat: make bottom results query-scoped

### DIFF
--- a/apps/desktop/src/components/BottomPanel.tsx
+++ b/apps/desktop/src/components/BottomPanel.tsx
@@ -5,6 +5,7 @@ import {
   type NoticeSeverity,
   type QueryHistoryRecord,
 } from "@cellar/ipc";
+import { DataGrid, useGridState } from "@cellar/data-grid";
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 
 import {
@@ -23,6 +24,13 @@ import {
 } from "../state/notices";
 import { useStatus } from "../state/status";
 import { useTabs, type TableTab } from "../state/tabs";
+import {
+  maxRowsLabel,
+  resultContextLabel,
+  rowCountLabel,
+  useTabResults,
+  type TabResult,
+} from "../state/tabResults";
 import { Icon } from "./icons";
 
 type BottomTabId = "results" | "messages" | "plan" | "history" | "notices";
@@ -32,14 +40,15 @@ type BPTab = {
   label: string;
   count: number | null;
   icon: ReactNode;
+  enabled: boolean;
 };
 
 const BASE_TABS: Omit<BPTab, "count">[] = [
-  { id: "results", label: "Results", icon: <Icon.table size={11} /> },
-  { id: "messages", label: "Messages", icon: <Icon.info size={11} /> },
-  { id: "plan", label: "Plan", icon: <Icon.tree size={11} /> },
-  { id: "history", label: "History", icon: <Icon.history size={11} /> },
-  { id: "notices", label: "Notices", icon: <Icon.warn size={11} /> },
+  { id: "results", label: "Results", icon: <Icon.table size={11} />, enabled: true },
+  { id: "messages", label: "Messages", icon: <Icon.info size={11} />, enabled: false },
+  { id: "plan", label: "Plan", icon: <Icon.tree size={11} />, enabled: false },
+  { id: "history", label: "History", icon: <Icon.history size={11} />, enabled: true },
+  { id: "notices", label: "Notices", icon: <Icon.warn size={11} />, enabled: true },
 ];
 
 export function BottomPanel({ onClose }: { onClose: () => void }) {
@@ -49,6 +58,13 @@ export function BottomPanel({ onClose }: { onClose: () => void }) {
   const tabs = useTabs((s) => s.tabs);
   const connections = useConnections((s) => s.connections);
   const activeTab = tabs.find((t) => t.id === activeTabId) ?? null;
+  const result = useTabResults((s) =>
+    activeTabId ? s.byTabId[activeTabId] ?? null : null,
+  );
+  const resultCount =
+    result?.status === "ready" && result.source.kind === "query"
+      ? result.rowCount
+      : null;
   const activeConnection = activeTab
     ? connections.find((c) => c.id === activeTab.connectionId) ?? null
     : null;
@@ -72,7 +88,9 @@ export function BottomPanel({ onClose }: { onClose: () => void }) {
         ? noticeEntry.notices.length
         : tab.id === "history"
           ? historyCount
-          : null,
+          : tab.id === "results"
+            ? resultCount
+            : null,
   }));
 
   return (
@@ -84,12 +102,16 @@ export function BottomPanel({ onClose }: { onClose: () => void }) {
             return (
               <button
                 key={t.id}
-                onClick={() => setActive(t.id)}
+                onClick={() => {
+                  if (t.enabled) setActive(t.id);
+                }}
+                disabled={!t.enabled}
+                title={t.enabled ? t.label : `${t.label} is not wired yet`}
                 className={
-                  "mt-[3px] inline-flex h-[22px] items-center gap-1.5 rounded-[4px] px-2 text-[11px] " +
+                  "mt-[3px] inline-flex h-[22px] items-center gap-1.5 rounded-[4px] px-2 text-[11px] disabled:cursor-default disabled:opacity-45 " +
                   (isActive
                     ? "bg-accent-soft text-accent"
-                    : "text-fg-2 hover:bg-bg-2 hover:text-fg-0")
+                    : "text-fg-2 hover:bg-bg-2 hover:text-fg-0 disabled:hover:bg-transparent disabled:hover:text-fg-2")
                 }
               >
                 <span className={"inline-flex " + (isActive ? "text-accent" : "text-fg-3")}>
@@ -110,13 +132,7 @@ export function BottomPanel({ onClose }: { onClose: () => void }) {
             );
           })}
           <div className="mx-1.5 h-[18px] w-px self-center bg-border-divider" />
-          <div className="inline-flex min-w-0 items-center gap-1.5 font-mono text-[10.5px]">
-            <span className="truncate text-fg-3">
-              {activeTab
-                ? `${activeTab.database}.${activeTab.schema}.${activeTab.table}`
-                : "no active tab"}
-            </span>
-          </div>
+          <HeaderMeta activeTab={activeTab} result={result} />
         </div>
         <div className="flex items-center gap-px">
           <button className="icon-btn opacity-45" disabled title="Export not implemented yet">
@@ -132,7 +148,9 @@ export function BottomPanel({ onClose }: { onClose: () => void }) {
       </div>
 
       <div className="min-h-0 flex-1 overflow-hidden">
-        {active === "history" ? (
+        {active === "results" ? (
+          <ResultsBody activeTab={activeTab} result={result} />
+        ) : active === "history" ? (
           <HistoryPanel activeTab={activeTab} onCountChange={setHistoryCount} />
         ) : active === "notices" ? (
           <NoticesPanel
@@ -153,6 +171,174 @@ export function BottomPanel({ onClose }: { onClose: () => void }) {
       </div>
     </div>
   );
+}
+
+function HeaderMeta({
+  activeTab,
+  result,
+}: {
+  activeTab: TableTab | null;
+  result: TabResult | null;
+}) {
+  const items = headerItems(activeTab, result);
+
+  return (
+    <div className="inline-flex min-w-0 items-center gap-1.5 overflow-hidden font-mono text-[10.5px]">
+      {items.map((item, i) => (
+        <span
+          key={`${item}-${i}`}
+          className={i === 0 ? "truncate text-fg-2" : "shrink-0 text-fg-3"}
+        >
+          {i > 0 && <span className="text-fg-4">· </span>}
+          {item}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function headerItems(activeTab: TableTab | null, result: TabResult | null): string[] {
+  if (!activeTab) return ["no active tab"];
+  if (!result) return [tableLabel(activeTab), "table rows shown above"];
+
+  const context = resultContextLabel(result.source);
+  if (result.source.kind === "table") {
+    return [context, "table rows shown above"];
+  }
+  if (result.status === "loading") {
+    return [context, "loading", maxRowsLabel(result.source.maxRows, false)];
+  }
+  if (result.status === "error") {
+    return [context, "failed"];
+  }
+  return [
+    context,
+    rowCountLabel(result.rowCount, result.truncated),
+    maxRowsLabel(result.source.maxRows, result.truncated),
+    `${result.durationMs} ms`,
+  ];
+}
+
+function ResultsBody({
+  activeTab,
+  result,
+}: {
+  activeTab: TableTab | null;
+  result: TabResult | null;
+}) {
+  if (!activeTab) {
+    return (
+      <EmptyPanel
+        title="No active tab"
+        detail="Open a table from the sidebar to load rows. SQL query-tab results will use this panel when the editor slice lands."
+      />
+    );
+  }
+
+  if (!result) {
+    return (
+      <EmptyPanel
+        title="Table rows are already shown"
+        detail={`${tableLabel(activeTab)} is a table-browsing tab. The Results grid is reserved for SQL query output, so it will light up when SQL editor tabs land.`}
+      />
+    );
+  }
+
+  if (result.source.kind === "table") {
+    return (
+      <EmptyPanel
+        title="Table rows are already shown"
+        detail="This tab's table data lives in the main grid. The bottom Results grid is reserved for SQL query output."
+      />
+    );
+  }
+
+  if (result.status === "loading") {
+    return (
+      <EmptyPanel
+        title="Loading rows"
+        detail={`Running ${result.source.statement}`}
+      />
+    );
+  }
+
+  if (result.status === "error") {
+    return (
+      <EmptyPanel
+        title="Could not load results"
+        detail={result.message}
+        tone="warn"
+      />
+    );
+  }
+
+  if (result.columns.length === 0) {
+    return (
+      <EmptyPanel
+        title="Statement returned no columns"
+        detail="Rows-affected messages are not surfaced in the bottom panel yet."
+      />
+    );
+  }
+
+  return <ReadOnlyResultGrid key={result.tabId} result={result} />;
+}
+
+function ReadOnlyResultGrid({
+  result,
+}: {
+  result: Extract<TabResult, { status: "ready" }>;
+}) {
+  const grid = useGridState();
+
+  return (
+    <div className="flex h-full min-h-0 overflow-hidden">
+      <DataGrid
+        columns={result.columns}
+        rows={result.rows}
+        totalRows={result.truncated ? undefined : result.rows.length}
+        changes={grid.changes}
+        onChange={grid.setChanges}
+        selection={grid.selection}
+        onSelect={grid.setSelection}
+        editing={grid.editing}
+        onEdit={grid.setEditing}
+        filters={grid.filters}
+        onFiltersChange={grid.setFilters}
+        readOnly
+      />
+    </div>
+  );
+}
+
+function EmptyPanel({
+  title,
+  detail,
+  tone = "muted",
+}: {
+  title: string;
+  detail: string;
+  tone?: "muted" | "warn";
+}) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-1.5 bg-bg-inset p-6 text-center text-[11.5px] text-fg-3">
+      <div
+        className={
+          "text-[12px] font-medium " +
+          (tone === "warn" ? "text-warn" : "text-fg-1")
+        }
+      >
+        {title}
+      </div>
+      <div className="max-w-[460px] text-[10.5px] leading-[1.5] text-fg-3">
+        {detail}
+      </div>
+    </div>
+  );
+}
+
+function tableLabel(tab: TableTab): string {
+  return `${tab.database}.${tab.schema}.${tab.table}`;
 }
 
 function HistoryPanel({

--- a/apps/desktop/src/hooks/useTableData.ts
+++ b/apps/desktop/src/hooks/useTableData.ts
@@ -6,6 +6,7 @@ import { useEffect, useState } from "react";
 import { useConnections } from "../state/connections";
 import { useNotices } from "../state/notices";
 import { useStatus } from "../state/status";
+import { useTabResults } from "../state/tabResults";
 
 interface TableData {
   columns: GridColumn[];
@@ -48,6 +49,9 @@ export function useTableData(
     setState((s) => ({ ...s, loading: s.rows.length === 0, error: null }));
     const primaryKey = tablePrimaryKey(connectionId, database, schema, table);
     const sql = tableSelectSql(schema, table, primaryKey);
+    if (tabId) {
+      useTabResults.getState().clearTab(tabId);
+    }
     void (async () => {
       try {
         const result = await loadTableQuery(

--- a/apps/desktop/src/state/tabResults.test.ts
+++ b/apps/desktop/src/state/tabResults.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { GridColumn, GridRow } from "@cellar/data-grid";
+
+import {
+  maxRowsLabel,
+  queryResultSource,
+  resultContextLabel,
+  rowCountLabel,
+  useTabResults,
+} from "./tabResults";
+
+const source = queryResultSource(
+  "conn-1",
+  "app",
+  "sql-tab-1",
+  "Query 1",
+  "SELECT * FROM orders LIMIT 500",
+  500,
+);
+
+const columns: GridColumn[] = [
+  { key: "order_id", name: "order_id", type: "int8", width: 110 },
+];
+const rows: GridRow[] = [{ id: "0", order_id: 1 }];
+
+describe("tab result state", () => {
+  beforeEach(() => {
+    useTabResults.setState({ byTabId: {} });
+  });
+
+  it("keeps result data scoped to the producing tab", () => {
+    useTabResults.getState().setLoading("tab-a", source);
+    useTabResults.getState().setReady("tab-a", {
+      source,
+      columns,
+      rows,
+      rowCount: rows.length,
+      truncated: false,
+      durationMs: 12,
+    });
+
+    expect(useTabResults.getState().byTabId["tab-a"]).toMatchObject({
+      status: "ready",
+      rowCount: 1,
+      durationMs: 12,
+    });
+    expect(useTabResults.getState().byTabId["tab-b"]).toBeUndefined();
+  });
+
+  it("clears only the closed tab result", () => {
+    useTabResults.getState().setLoading("tab-a", source);
+    useTabResults.getState().setLoading("tab-b", source);
+    useTabResults.getState().clearTab("tab-a");
+
+    expect(useTabResults.getState().byTabId["tab-a"]).toBeUndefined();
+    expect(useTabResults.getState().byTabId["tab-b"]?.status).toBe("loading");
+  });
+});
+
+describe("tab result labels", () => {
+  it("formats query context and row limits honestly", () => {
+    expect(resultContextLabel(source)).toBe("app.Query 1");
+    expect(rowCountLabel(1, false)).toBe("1 row");
+    expect(rowCountLabel(500, true)).toBe("500+ rows");
+    expect(maxRowsLabel(500, false)).toBe("max 500");
+    expect(maxRowsLabel(500, true)).toBe("capped at 500");
+  });
+});

--- a/apps/desktop/src/state/tabResults.ts
+++ b/apps/desktop/src/state/tabResults.ts
@@ -1,0 +1,151 @@
+import type { GridColumn, GridRow } from "@cellar/data-grid";
+import { create } from "zustand";
+
+export type ResultSource =
+  | {
+      kind: "table";
+      connectionId: string;
+      database: string;
+      schema: string;
+      table: string;
+      statement: string;
+      maxRows: number;
+    }
+  | {
+      kind: "query";
+      connectionId: string;
+      database: string | null;
+      tabId: string;
+      label: string;
+      statement: string;
+      maxRows: number;
+    };
+
+export type TabResult =
+  | {
+      status: "loading";
+      tabId: string;
+      source: ResultSource;
+    }
+  | {
+      status: "ready";
+      tabId: string;
+      source: ResultSource;
+      columns: GridColumn[];
+      rows: GridRow[];
+      rowCount: number;
+      truncated: boolean;
+      durationMs: number;
+    }
+  | {
+      status: "error";
+      tabId: string;
+      source: ResultSource;
+      message: string;
+    };
+
+interface TabResultsStore {
+  byTabId: Record<string, TabResult>;
+  setLoading: (tabId: string, source: ResultSource) => void;
+  setReady: (
+    tabId: string,
+    result: Omit<Extract<TabResult, { status: "ready" }>, "status" | "tabId">,
+  ) => void;
+  setError: (tabId: string, source: ResultSource, message: string) => void;
+  clearTab: (tabId: string) => void;
+}
+
+export const useTabResults = create<TabResultsStore>((set) => ({
+  byTabId: {},
+
+  setLoading: (tabId, source) =>
+    set((s) => ({
+      byTabId: {
+        ...s.byTabId,
+        [tabId]: { status: "loading", tabId, source },
+      },
+    })),
+
+  setReady: (tabId, result) =>
+    set((s) => ({
+      byTabId: {
+        ...s.byTabId,
+        [tabId]: { status: "ready", tabId, ...result },
+      },
+    })),
+
+  setError: (tabId, source, message) =>
+    set((s) => ({
+      byTabId: {
+        ...s.byTabId,
+        [tabId]: { status: "error", tabId, source, message },
+      },
+    })),
+
+  clearTab: (tabId) =>
+    set((s) => {
+      const next = { ...s.byTabId };
+      delete next[tabId];
+      return { byTabId: next };
+    }),
+}));
+
+export function tableResultSource(
+  connectionId: string,
+  database: string,
+  schema: string,
+  table: string,
+  statement: string,
+  maxRows: number,
+): ResultSource {
+  return {
+    kind: "table",
+    connectionId,
+    database,
+    schema,
+    table,
+    statement,
+    maxRows,
+  };
+}
+
+export function queryResultSource(
+  connectionId: string,
+  database: string | null,
+  tabId: string,
+  label: string,
+  statement: string,
+  maxRows: number,
+): ResultSource {
+  return {
+    kind: "query",
+    connectionId,
+    database,
+    tabId,
+    label,
+    statement,
+    maxRows,
+  };
+}
+
+export function resultContextLabel(source: ResultSource): string {
+  switch (source.kind) {
+    case "table":
+      return `${source.database}.${source.schema}.${source.table}`;
+    case "query":
+      return source.database ? `${source.database}.${source.label}` : source.label;
+  }
+}
+
+export function rowCountLabel(rowCount: number, truncated: boolean): string {
+  const suffix = truncated ? "+" : "";
+  return `${formatCount(rowCount)}${suffix} ${rowCount === 1 && !truncated ? "row" : "rows"}`;
+}
+
+export function maxRowsLabel(maxRows: number, truncated: boolean): string {
+  return truncated ? `capped at ${formatCount(maxRows)}` : `max ${formatCount(maxRows)}`;
+}
+
+function formatCount(value: number): string {
+  return new Intl.NumberFormat("en-US").format(value);
+}

--- a/apps/desktop/src/state/tabs.ts
+++ b/apps/desktop/src/state/tabs.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import type { PendingChanges } from "@cellar/data-grid";
+import { useTabResults } from "./tabResults";
 
 export interface TableTab {
   id: string;
@@ -68,6 +69,7 @@ export const useTabs = create<TabsStore>((set, get) => ({
       const { [id]: _refresh, ...refreshKeys } = s.refreshKeys;
       return { tabs, activeId, tableChanges, refreshKeys };
     });
+    useTabResults.getState().clearTab(id);
   },
 
   setActive(id) {

--- a/packages/data-grid/src/DataGrid.tsx
+++ b/packages/data-grid/src/DataGrid.tsx
@@ -44,6 +44,9 @@ export type DataGridProps = {
 
   onCommit?: () => void;
   onRevert?: () => void;
+
+  /** Read-only result grids can still select/filter, but do not expose edits. */
+  readOnly?: boolean;
 };
 
 /**
@@ -68,6 +71,7 @@ export function DataGrid({
   totalRows,
   onCommit,
   onRevert,
+  readOnly = false,
 }: DataGridProps) {
   // Local search across visible page. Server-side filtering happens upstream
   // for large tables; the chips drive both.
@@ -197,7 +201,8 @@ export function DataGrid({
                 {columns.map((c, ci) => {
                   const isSel =
                     selection?.row === ri && selection?.col === ci;
-                  const isEdit = editing?.row === ri && editing?.col === ci;
+                  const isEdit =
+                    !readOnly && editing?.row === ri && editing?.col === ci;
                   const cellChange = change?.edits?.[c.key];
                   const displayed = cellChange ? cellChange.to : row[c.key];
                   const original = row[c.key] ?? null;
@@ -214,7 +219,9 @@ export function DataGrid({
                       }
                       style={{ width: c.width, flexBasis: c.width }}
                       onClick={() => onSelect({ row: ri, col: ci })}
-                      onDoubleClick={() => onEdit({ row: ri, col: ci })}
+                      onDoubleClick={() => {
+                        if (!readOnly) onEdit({ row: ri, col: ci });
+                      }}
                     >
                       {isEdit ? (
                         <CellEditor
@@ -250,10 +257,22 @@ export function DataGrid({
               </div>
             );
           })}
+          {!readOnly && (
+            <div className="grid-row grid-row-add">
+              <div className="grid-cell grid-cell-rowno">
+                <GridIcon.plus size={9} stroke="var(--fg-3)" />
+              </div>
+              <div className="grid-cell" style={{ width: 600 }}>
+                <span style={{ color: "var(--fg-3)" }}>Insert new row…</span>
+              </div>
+            </div>
+          )}
         </div>
       </div>
 
-      <PendingBar changes={changes} onCommit={onCommit} onRevert={onRevert} />
+      {!readOnly && (
+        <PendingBar changes={changes} onCommit={onCommit} onRevert={onRevert} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Make the bottom Results tab useful without duplicating table-browse grids.
- Add tab-scoped query result state for future SQL editor result rendering.
- Keep table tabs focused on the main grid while preserving bottom-panel History and Notices.
- Add a read-only DataGrid mode so query results can render without edit/commit affordances.

## Why

When browsing a table, the bottom Results grid duplicated the same rows already visible in the main workspace. Results should be reserved for SQL query output, where the bottom panel is the natural place for returned rows.

## Validation

- `pnpm --filter @cellar/desktop typecheck`
- `pnpm --filter @cellar/desktop test`
- `pnpm --filter @cellar/data-grid lint`
- `pnpm typecheck`
- Browser smoke check on `http://127.0.0.1:1432/`
