### PR TITLE
feat: wire bottom panel messages

### DIFF
--- a/apps/desktop/src/components/BottomMessagesPanel.tsx
+++ b/apps/desktop/src/components/BottomMessagesPanel.tsx
@@ -1,0 +1,163 @@
+import { useState } from "react";
+
+import {
+  formatMessageTime,
+  QUERY_MESSAGE_SEVERITIES,
+  severityCounts,
+  type QueryMessage,
+  type QueryMessageSeverity,
+} from "../lib/queryMessages";
+
+export function MessagesView({
+  messages,
+  hasActiveTab = true,
+}: {
+  messages: QueryMessage[];
+  hasActiveTab?: boolean;
+}) {
+  const [filter, setFilter] = useState<QueryMessageSeverity | "all">("all");
+  const counts = severityCounts(messages);
+  const visible =
+    filter === "all" ? messages : messages.filter((m) => m.severity === filter);
+
+  if (!hasActiveTab) {
+    return (
+      <EmptyMessagePanel
+        title="No active tab"
+        detail="Open a table or query tab to see execution feedback."
+      />
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-bg-inset">
+      <div className="flex h-8 shrink-0 items-center justify-between border-b border-border-divider px-2">
+        <div className="flex items-center gap-1">
+          <SeverityFilter
+            label="all"
+            active={filter === "all"}
+            count={messages.length}
+            onClick={() => setFilter("all")}
+          />
+          {QUERY_MESSAGE_SEVERITIES.map((severity) => (
+            <SeverityFilter
+              key={severity}
+              label={severity}
+              active={filter === severity}
+              count={counts[severity]}
+              onClick={() => setFilter(severity)}
+            />
+          ))}
+        </div>
+        <div className="font-mono text-[10px] text-fg-3">
+          {messages.length === 0 ? "no messages" : `${messages.length} total`}
+        </div>
+      </div>
+      {messages.length === 0 ? (
+        <EmptyMessagePanel
+          title="No execution messages"
+          detail="Run or refresh the active tab to populate status, warnings, and errors."
+        />
+      ) : visible.length === 0 ? (
+        <EmptyMessagePanel
+          title="No matching messages"
+          detail="Adjust the severity filter to inspect the current execution feedback."
+        />
+      ) : (
+        <div className="min-h-0 flex-1 overflow-auto">
+          <div className="grid min-w-[720px] grid-cols-[92px_74px_86px_minmax(220px,1fr)_160px] border-b border-border-divider px-2 py-1 font-mono text-[10px] uppercase text-fg-3">
+            <span>time</span>
+            <span>level</span>
+            <span>source</span>
+            <span>message</span>
+            <span>metrics</span>
+          </div>
+          {visible.map((message) => (
+            <MessageRow key={message.id} message={message} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SeverityFilter({
+  label,
+  count,
+  active,
+  onClick,
+}: {
+  label: string;
+  count: number;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={
+        "inline-flex h-[22px] items-center gap-1 rounded-[4px] px-2 font-mono text-[10.5px] " +
+        (active
+          ? "bg-accent-soft text-accent"
+          : "text-fg-2 hover:bg-bg-2 hover:text-fg-0")
+      }
+    >
+      <span>{label}</span>
+      <span className={active ? "text-accent" : "text-fg-3"}>{count}</span>
+    </button>
+  );
+}
+
+function MessageRow({ message }: { message: QueryMessage }) {
+  return (
+    <div className="grid min-w-[720px] grid-cols-[92px_74px_86px_minmax(220px,1fr)_160px] items-start border-b border-border-subtle px-2 py-1.5 font-mono text-[10.5px] leading-[1.45] hover:bg-bg-1">
+      <span className="text-fg-3">{formatMessageTime(message.timestamp)}</span>
+      <span className={severityClass(message.severity)}>{message.severity}</span>
+      <span className="text-fg-2">{message.source}</span>
+      <span className="min-w-0 whitespace-pre-wrap break-words pr-3 text-fg-1">
+        {message.text}
+      </span>
+      <span className="text-fg-3">{metricsText(message)}</span>
+    </div>
+  );
+}
+
+function EmptyMessagePanel({
+  title,
+  detail,
+}: {
+  title: string;
+  detail: string;
+}) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-1.5 bg-bg-inset p-6 text-center text-[11.5px] text-fg-3">
+      <div className="text-[12px] font-medium text-fg-1">{title}</div>
+      <div className="max-w-[460px] text-[10.5px] leading-[1.5] text-fg-3">
+        {detail}
+      </div>
+    </div>
+  );
+}
+
+function metricsText(message: QueryMessage): string {
+  const parts: string[] = [];
+  if (message.durationMs != null) parts.push(`${message.durationMs} ms`);
+  if (message.rowCount != null) {
+    parts.push(`${message.rowCount.toLocaleString()} row${message.rowCount === 1 ? "" : "s"}`);
+  }
+  if (message.statementIndex != null) parts.push(`stmt ${message.statementIndex + 1}`);
+  return parts.length ? parts.join(" | ") : "-";
+}
+
+function severityClass(severity: QueryMessageSeverity): string {
+  switch (severity) {
+    case "success":
+      return "text-insert";
+    case "warning":
+      return "text-warn";
+    case "error":
+      return "text-delete";
+    case "info":
+      return "text-info";
+  }
+}

--- a/apps/desktop/src/components/BottomPanel.test.tsx
+++ b/apps/desktop/src/components/BottomPanel.test.tsx
@@ -1,0 +1,50 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { MessagesView } from "./BottomMessagesPanel";
+import type { QueryMessage } from "../lib/queryMessages";
+
+describe("MessagesView", () => {
+  it("renders an honest empty state without an active tab", () => {
+    const html = renderToStaticMarkup(
+      <MessagesView messages={[]} hasActiveTab={false} />,
+    );
+
+    expect(html).toContain("No active tab");
+    expect(html).toContain("Open a table or query tab");
+  });
+
+  it("renders execution feedback with severity filters and metrics", () => {
+    const html = renderToStaticMarkup(
+      <MessagesView
+        messages={[
+          message("msg-1", "success", "Loaded public.orders: 2 rows in 12 ms."),
+          message("msg-2", "warning", "Result hit row limit 500."),
+        ]}
+      />,
+    );
+
+    expect(html).toContain("success");
+    expect(html).toContain("warning");
+    expect(html).toContain("Loaded public.orders");
+    expect(html).toContain("12 ms");
+    expect(html).toContain("2 rows");
+  });
+});
+
+function message(
+  id: string,
+  severity: QueryMessage["severity"],
+  text: string,
+): QueryMessage {
+  return {
+    id,
+    tabId: "tab-1",
+    connectionId: "conn-1",
+    severity,
+    source: "execution",
+    text,
+    timestamp: "2026-05-30T00:00:00.000Z",
+    durationMs: 12,
+    rowCount: 2,
+  };
+}

--- a/apps/desktop/src/components/BottomPanel.tsx
+++ b/apps/desktop/src/components/BottomPanel.tsx
@@ -31,6 +31,8 @@ import {
   useTabResults,
   type TabResult,
 } from "../state/tabResults";
+import { useQueryMessages } from "../state/queryMessages";
+import { MessagesView } from "./BottomMessagesPanel";
 import { Icon } from "./icons";
 
 type BottomTabId = "results" | "messages" | "plan" | "history" | "notices";
@@ -45,7 +47,7 @@ type BPTab = {
 
 const BASE_TABS: Omit<BPTab, "count">[] = [
   { id: "results", label: "Results", icon: <Icon.table size={11} />, enabled: true },
-  { id: "messages", label: "Messages", icon: <Icon.info size={11} />, enabled: false },
+  { id: "messages", label: "Messages", icon: <Icon.info size={11} />, enabled: true },
   { id: "plan", label: "Plan", icon: <Icon.tree size={11} />, enabled: false },
   { id: "history", label: "History", icon: <Icon.history size={11} />, enabled: true },
   { id: "notices", label: "Notices", icon: <Icon.warn size={11} />, enabled: true },
@@ -57,7 +59,12 @@ export function BottomPanel({ onClose }: { onClose: () => void }) {
   const activeTabId = useTabs((s) => s.activeId);
   const tabs = useTabs((s) => s.tabs);
   const connections = useConnections((s) => s.connections);
+  const messages = useQueryMessages((s) => s.messages);
   const activeTab = tabs.find((t) => t.id === activeTabId) ?? null;
+  const activeMessages = useMemo(
+    () => messages.filter((m) => m.tabId === activeTabId),
+    [activeTabId, messages],
+  );
   const result = useTabResults((s) =>
     activeTabId ? s.byTabId[activeTabId] ?? null : null,
   );
@@ -86,6 +93,8 @@ export function BottomPanel({ onClose }: { onClose: () => void }) {
     count:
       tab.id === "notices"
         ? noticeEntry.notices.length
+        : tab.id === "messages"
+          ? activeMessages.length || null
         : tab.id === "history"
           ? historyCount
           : tab.id === "results"
@@ -150,6 +159,11 @@ export function BottomPanel({ onClose }: { onClose: () => void }) {
       <div className="min-h-0 flex-1 overflow-hidden">
         {active === "results" ? (
           <ResultsBody activeTab={activeTab} result={result} />
+        ) : active === "messages" ? (
+          <MessagesView
+            messages={activeMessages}
+            hasActiveTab={activeTabId != null}
+          />
         ) : active === "history" ? (
           <HistoryPanel activeTab={activeTab} onCountChange={setHistoryCount} />
         ) : active === "notices" ? (
@@ -719,7 +733,7 @@ function labelFor(id: BottomTabId) {
     case "results":
       return "Run a query to see results here";
     case "messages":
-      return "No messages yet";
+      return "No execution messages";
     case "plan":
       return "Execution plans appear here";
     case "history":
@@ -736,7 +750,7 @@ function subFor(id: BottomTabId) {
     case "results":
       return "Open a query tab, ⌘⏎ to run the statement under the cursor.";
     case "messages":
-      return "Query truncation, validation, and app-side execution status land here as this panel grows.";
+      return "Execution status, row-limit warnings, and failures appear here.";
     case "plan":
       return "EXPLAIN ANALYZE renders as a tree with a cost heatmap.";
     case "history":

--- a/apps/desktop/src/components/Workspace.tsx
+++ b/apps/desktop/src/components/Workspace.tsx
@@ -54,7 +54,7 @@ function TableTabPane({
   if (data.error) {
     return (
       <PaneMessage>
-        <span className="text-warn">{data.error}</span>
+        <span className="text-warn">Table load failed. See Messages for details.</span>
       </PaneMessage>
     );
   }

--- a/apps/desktop/src/hooks/useTableData.ts
+++ b/apps/desktop/src/hooks/useTableData.ts
@@ -5,8 +5,15 @@ import { useEffect, useState } from "react";
 
 import { useConnections } from "../state/connections";
 import { useNotices } from "../state/notices";
+import { useQueryMessages } from "../state/queryMessages";
 import { useStatus } from "../state/status";
 import { useTabResults } from "../state/tabResults";
+import {
+  buildQueryErrorMessage,
+  buildQueryResultMessages,
+  buildTableLoadStartedMessage,
+  type TableQueryContext,
+} from "../lib/queryMessages";
 
 interface TableData {
   columns: GridColumn[];
@@ -49,9 +56,22 @@ export function useTableData(
     setState((s) => ({ ...s, loading: s.rows.length === 0, error: null }));
     const primaryKey = tablePrimaryKey(connectionId, database, schema, table);
     const sql = tableSelectSql(schema, table, primaryKey);
+    const messageTabId = tabId ?? tableTabId(connectionId, database, schema, table);
+    const queryContext: TableQueryContext = {
+      tabId: messageTabId,
+      connectionId,
+      database,
+      schema,
+      table,
+      sql,
+      maxRows: DEFAULT_LIMIT,
+    };
     if (tabId) {
       useTabResults.getState().clearTab(tabId);
     }
+    useQueryMessages
+      .getState()
+      .replaceForTab(messageTabId, [buildTableLoadStartedMessage(queryContext)]);
     void (async () => {
       try {
         const result = await loadTableQuery(
@@ -82,6 +102,9 @@ export function useTableData(
           { tabId: tableTabId(connectionId, database, schema, table), connectionId, database },
           result,
         );
+        useQueryMessages
+          .getState()
+          .addMessages(buildQueryResultMessages(queryContext, result));
         useStatus.getState().setLastQuery({
           connectionId,
           tabId: tabId ?? null,
@@ -100,6 +123,9 @@ export function useTableData(
           error: message,
           durationMs: 0,
         });
+        useQueryMessages
+          .getState()
+          .addMessage(buildQueryErrorMessage(queryContext, err));
       }
     })();
     return () => {

--- a/apps/desktop/src/lib/queryMessages.test.ts
+++ b/apps/desktop/src/lib/queryMessages.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import type { QueryResult } from "@cellar/ipc";
+import {
+  buildQueryErrorMessage,
+  buildQueryResultMessages,
+  buildTableLoadStartedMessage,
+  formatDuration,
+  severityCounts,
+  type QueryMessage,
+  type TableQueryContext,
+} from "./queryMessages";
+
+const context: TableQueryContext = {
+  tabId: "tab-1",
+  connectionId: "conn-1",
+  database: "app",
+  schema: "public",
+  table: "orders",
+  sql: 'SELECT * FROM "public"."orders" LIMIT 500',
+  maxRows: 500,
+};
+
+const result: QueryResult = {
+  columns: [],
+  rows: [[], []],
+  notices: [],
+  notice_capture: { supported: false, reason: null },
+  rows_affected: null,
+  duration_ms: 12,
+  truncated: false,
+};
+
+describe("query message builders", () => {
+  it("builds an honest table loading message", () => {
+    const message = buildTableLoadStartedMessage(context);
+
+    expect(message.severity).toBe("info");
+    expect(message.source).toBe("client");
+    expect(message.text).toContain("public.orders");
+    expect(message.sql).toBe(context.sql);
+  });
+
+  it("builds success and truncation messages from QueryResult", () => {
+    const messages = buildQueryResultMessages(context, {
+      ...result,
+      truncated: true,
+    });
+
+    expect(messages).toHaveLength(2);
+    expect(messages[0]?.severity).toBe("success");
+    expect(messages[0]?.durationMs).toBe(12);
+    expect(messages[0]?.rowCount).toBe(2);
+    expect(messages[1]?.severity).toBe("warning");
+    expect(messages[1]?.text).toContain("row limit 500");
+  });
+
+  it("uses affected rows for non-row results", () => {
+    const messages = buildQueryResultMessages(context, {
+      ...result,
+      rows: [],
+      rows_affected: 3,
+    });
+
+    expect(messages[0]?.rowCount).toBe(3);
+    expect(messages[0]?.text).toContain("3 rows affected");
+  });
+
+  it("formats driver errors without creating notices", () => {
+    const message = buildQueryErrorMessage(context, new Error("permission denied"));
+
+    expect(message.severity).toBe("error");
+    expect(message.source).toBe("driver");
+    expect(message.text).toContain("permission denied");
+  });
+
+  it("counts severities for rendering filters", () => {
+    const messages: QueryMessage[] = [
+      fullMessage("1", "info"),
+      fullMessage("2", "success"),
+      fullMessage("3", "warning"),
+      fullMessage("4", "warning"),
+    ];
+
+    expect(severityCounts(messages)).toEqual({
+      info: 1,
+      success: 1,
+      warning: 2,
+      error: 0,
+    });
+  });
+
+  it("formats short and long durations", () => {
+    expect(formatDuration(999)).toBe("999 ms");
+    expect(formatDuration(1200)).toBe("1.20 s");
+  });
+});
+
+function fullMessage(
+  id: string,
+  severity: QueryMessage["severity"],
+): QueryMessage {
+  return {
+    id,
+    tabId: "tab-1",
+    connectionId: "conn-1",
+    severity,
+    source: "execution",
+    text: id,
+    timestamp: "2026-05-30T00:00:00.000Z",
+  };
+}

--- a/apps/desktop/src/lib/queryMessages.ts
+++ b/apps/desktop/src/lib/queryMessages.ts
@@ -1,0 +1,155 @@
+import type { QueryResult } from "@cellar/ipc";
+
+export type QueryMessageSeverity = "info" | "success" | "warning" | "error";
+export type QueryMessageSource = "client" | "execution" | "driver";
+
+export interface SqlRange {
+  startLine: number;
+  startColumn: number;
+  endLine: number;
+  endColumn: number;
+}
+
+export interface QueryMessage {
+  id: string;
+  tabId: string;
+  connectionId: string;
+  database?: string;
+  severity: QueryMessageSeverity;
+  source: QueryMessageSource;
+  text: string;
+  timestamp: string;
+  sql?: string;
+  sqlRange?: SqlRange;
+  statementIndex?: number;
+  durationMs?: number;
+  rowCount?: number;
+}
+
+export type PendingQueryMessage = Omit<QueryMessage, "id" | "timestamp"> &
+  Partial<Pick<QueryMessage, "id" | "timestamp">>;
+
+export const QUERY_MESSAGE_SEVERITIES: QueryMessageSeverity[] = [
+  "info",
+  "success",
+  "warning",
+  "error",
+];
+
+export interface TableQueryContext {
+  tabId: string;
+  connectionId: string;
+  database: string;
+  schema: string;
+  table: string;
+  sql: string;
+  maxRows: number;
+}
+
+export function buildTableLoadStartedMessage(
+  context: TableQueryContext,
+): PendingQueryMessage {
+  return {
+    tabId: context.tabId,
+    connectionId: context.connectionId,
+    database: context.database,
+    severity: "info",
+    source: "client",
+    text: `Loading ${formatQualifiedName(context.schema, context.table)} with row limit ${context.maxRows}.`,
+    sql: context.sql,
+    statementIndex: 0,
+  };
+}
+
+export function buildQueryResultMessages(
+  context: TableQueryContext,
+  result: QueryResult,
+): PendingQueryMessage[] {
+  const rowCount = result.rows_affected ?? result.rows.length;
+  const messages: PendingQueryMessage[] = [
+    {
+      tabId: context.tabId,
+      connectionId: context.connectionId,
+      database: context.database,
+      severity: "success",
+      source: "execution",
+      text: result.rows_affected == null
+        ? `Loaded ${formatQualifiedName(context.schema, context.table)}: ${formatCount(result.rows.length, "row")} in ${formatDuration(result.duration_ms)}.`
+        : `Query OK: ${formatCount(result.rows_affected, "row")} affected in ${formatDuration(result.duration_ms)}.`,
+      sql: context.sql,
+      statementIndex: 0,
+      durationMs: result.duration_ms,
+      rowCount,
+    },
+  ];
+
+  if (result.truncated) {
+    messages.push({
+      tabId: context.tabId,
+      connectionId: context.connectionId,
+      database: context.database,
+      severity: "warning",
+      source: "execution",
+      text: `Result hit row limit ${context.maxRows}; showing first ${formatCount(result.rows.length, "row")}.`,
+      sql: context.sql,
+      statementIndex: 0,
+      durationMs: result.duration_ms,
+      rowCount: result.rows.length,
+    });
+  }
+
+  return messages;
+}
+
+export function buildQueryErrorMessage(
+  context: TableQueryContext,
+  error: unknown,
+): PendingQueryMessage {
+  return {
+    tabId: context.tabId,
+    connectionId: context.connectionId,
+    database: context.database,
+    severity: "error",
+    source: "driver",
+    text: `Failed to load ${formatQualifiedName(context.schema, context.table)}: ${errorMessage(error)}`,
+    sql: context.sql,
+    statementIndex: 0,
+  };
+}
+
+export function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms} ms`;
+  return `${(ms / 1000).toFixed(ms < 10_000 ? 2 : 1)} s`;
+}
+
+export function formatMessageTime(timestamp: string): string {
+  const d = new Date(timestamp);
+  if (Number.isNaN(d.getTime())) return "--:--:--.---";
+  const h = String(d.getHours()).padStart(2, "0");
+  const m = String(d.getMinutes()).padStart(2, "0");
+  const s = String(d.getSeconds()).padStart(2, "0");
+  const ms = String(d.getMilliseconds()).padStart(3, "0");
+  return `${h}:${m}:${s}.${ms}`;
+}
+
+export function severityCounts(messages: QueryMessage[]): Record<QueryMessageSeverity, number> {
+  return {
+    info: messages.filter((m) => m.severity === "info").length,
+    success: messages.filter((m) => m.severity === "success").length,
+    warning: messages.filter((m) => m.severity === "warning").length,
+    error: messages.filter((m) => m.severity === "error").length,
+  };
+}
+
+function formatQualifiedName(schema: string, table: string): string {
+  return `${schema}.${table}`;
+}
+
+function formatCount(count: number, noun: string): string {
+  return `${count.toLocaleString()} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}

--- a/apps/desktop/src/state/queryMessages.test.ts
+++ b/apps/desktop/src/state/queryMessages.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useQueryMessages } from "./queryMessages";
+
+describe("useQueryMessages", () => {
+  beforeEach(() => {
+    useQueryMessages.getState().clear();
+  });
+
+  it("normalizes and appends pending messages", () => {
+    useQueryMessages.getState().addMessage({
+      id: "msg-1",
+      tabId: "tab-1",
+      connectionId: "conn-1",
+      severity: "info",
+      source: "client",
+      text: "Loading",
+      timestamp: "2026-05-30T00:00:00.000Z",
+    });
+
+    expect(useQueryMessages.getState().messages).toEqual([
+      {
+        id: "msg-1",
+        tabId: "tab-1",
+        connectionId: "conn-1",
+        severity: "info",
+        source: "client",
+        text: "Loading",
+        timestamp: "2026-05-30T00:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("replaces only messages for the target tab", () => {
+    const store = useQueryMessages.getState();
+    store.addMessages([
+      fixedMessage("old-1", "tab-1"),
+      fixedMessage("keep-1", "tab-2"),
+    ]);
+
+    store.replaceForTab("tab-1", [fixedMessage("new-1", "tab-1")]);
+
+    expect(useQueryMessages.getState().messages.map((m) => m.id)).toEqual([
+      "keep-1",
+      "new-1",
+    ]);
+  });
+});
+
+function fixedMessage(id: string, tabId: string) {
+  return {
+    id,
+    tabId,
+    connectionId: "conn-1",
+    severity: "info" as const,
+    source: "client" as const,
+    text: id,
+    timestamp: "2026-05-30T00:00:00.000Z",
+  };
+}

--- a/apps/desktop/src/state/queryMessages.ts
+++ b/apps/desktop/src/state/queryMessages.ts
@@ -1,0 +1,65 @@
+import { create } from "zustand";
+import type { PendingQueryMessage, QueryMessage } from "../lib/queryMessages";
+
+const MAX_MESSAGES = 300;
+let sequence = 0;
+
+interface QueryMessagesStore {
+  messages: QueryMessage[];
+  addMessage: (message: PendingQueryMessage) => void;
+  addMessages: (messages: PendingQueryMessage[]) => void;
+  replaceForTab: (tabId: string, messages: PendingQueryMessage[]) => void;
+  clearForTab: (tabId: string) => void;
+  clear: () => void;
+}
+
+export const useQueryMessages = create<QueryMessagesStore>((set) => ({
+  messages: [],
+
+  addMessage(message) {
+    set((s) => ({
+      messages: trimMessages([...s.messages, normalizeMessage(message)]),
+    }));
+  },
+
+  addMessages(messages) {
+    if (messages.length === 0) return;
+    set((s) => ({
+      messages: trimMessages([
+        ...s.messages,
+        ...messages.map((m) => normalizeMessage(m)),
+      ]),
+    }));
+  },
+
+  replaceForTab(tabId, messages) {
+    set((s) => ({
+      messages: trimMessages([
+        ...s.messages.filter((m) => m.tabId !== tabId),
+        ...messages.map((m) => normalizeMessage(m)),
+      ]),
+    }));
+  },
+
+  clearForTab(tabId) {
+    set((s) => ({ messages: s.messages.filter((m) => m.tabId !== tabId) }));
+  },
+
+  clear() {
+    set({ messages: [] });
+  },
+}));
+
+function normalizeMessage(message: PendingQueryMessage): QueryMessage {
+  const timestamp = message.timestamp ?? new Date().toISOString();
+  return {
+    ...message,
+    id: message.id ?? `query-message-${Date.now()}-${++sequence}`,
+    timestamp,
+  };
+}
+
+function trimMessages(messages: QueryMessage[]): QueryMessage[] {
+  if (messages.length <= MAX_MESSAGES) return messages;
+  return messages.slice(messages.length - MAX_MESSAGES);
+}


### PR DESCRIPTION
## Summary

- add a typed frontend query-message model and scoped Zustand message store
- render the bottom-panel Messages tab as a real execution feedback surface with severity filters, timestamps, sources, text, and metrics
- wire table loading to emit start, success, row-limit warning, and error messages while leaving database-emitted notices in the Notices tab
- keep workspace load failures concise so detailed errors live in Messages

## Validation

- `pnpm typecheck`
- `pnpm --filter @cellar/desktop test`
- `git diff --check`
- browser smoke test on `localhost:1432` for the Messages tab