### PR TITLE
feat: add typed table browse command

### DIFF
--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -28,6 +28,7 @@ pub fn builder() -> Builder<tauri::Wry> {
         schema::introspect,
         query::run_query,
         query::explain_query,
+        query::browse_table,
         transaction::preview_table_changes,
         transaction::commit_table_changes,
         history::list_query_history,

--- a/apps/desktop/src-tauri/src/commands/query.rs
+++ b/apps/desktop/src-tauri/src/commands/query.rs
@@ -1,7 +1,7 @@
 use std::time::Instant;
 
 use cellar_core::error::CellarError;
-use cellar_core::query::{PlanMode, Query, QueryPlan, QueryResult};
+use cellar_core::query::{PlanMode, Query, QueryPlan, QueryResult, TableBrowseRequest};
 use tauri::State;
 
 use crate::history::{HistoryStore, NewQueryHistoryRecord};
@@ -84,4 +84,13 @@ pub async fn explain_query(
         query = query.with_database(db);
     }
     registry.explain_query(&connection_id, query, mode).await
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn browse_table(
+    registry: State<'_, ConnectionRegistry>,
+    request: TableBrowseRequest,
+) -> Result<QueryResult, CellarError> {
+    registry.browse_table(request).await
 }

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 
 use cellar_core::driver::{Connection, ConnectionConfig, Driver, DriverInfo, Engine};
 use cellar_core::error::{CellarError, CellarResult};
-use cellar_core::query::{PlanMode, Query, QueryPlan, QueryResult};
-use cellar_core::schema::Database;
+use cellar_core::query::{PlanMode, Query, QueryPlan, QueryResult, TableBrowseRequest};
+use cellar_core::schema::{Database, Table};
 use cellar_diff::{TableChangeRequest, TableCommitResult};
 use cellar_driver_postgres::PostgresDriver;
 use tokio::fs;
@@ -118,7 +118,10 @@ impl ConnectionRegistry {
 
     pub async fn open_info(&self, id: &str) -> Option<DriverInfo> {
         let inner = self.inner.read().await;
-        inner.open.get(id).map(|open| open.connection.info().clone())
+        inner
+            .open
+            .get(id)
+            .map(|open| open.connection.info().clone())
     }
 
     pub async fn connect(&self, id: &str, password: Option<&str>) -> CellarResult<DriverInfo> {
@@ -196,6 +199,33 @@ impl ConnectionRegistry {
         driver.execute_query(connection.as_ref(), &query).await
     }
 
+    pub async fn browse_table(&self, request: TableBrowseRequest) -> CellarResult<QueryResult> {
+        let target_database = self.target_database_for(&request).await?;
+        let dbs = self.introspect(&request.connection_id, false).await?;
+        let table = find_table(&dbs, &target_database, &request.schema, &request.table)?;
+
+        let (engine, connection) = {
+            let inner = self.inner.read().await;
+            let open = inner.open.get(&request.connection_id).ok_or_else(|| {
+                CellarError::NotConnected(format!(
+                    "no open connection for {}",
+                    request.connection_id
+                ))
+            })?;
+            (open.config.engine, Arc::clone(&open.connection))
+        };
+
+        match engine {
+            Engine::Postgres => {
+                cellar_driver_postgres::browse_table(connection.as_ref(), &request, &table).await
+            }
+            other => Err(CellarError::invalid_config(format!(
+                "engine {} does not support table browsing yet",
+                other.as_str()
+            ))),
+        }
+    }
+
     pub async fn commit_table_changes(
         &self,
         id: &str,
@@ -261,6 +291,34 @@ impl ConnectionRegistry {
             .cloned()
             .ok_or_else(|| CellarError::invalid_config(format!("unknown connection {id}")))
     }
+
+    async fn target_database_for(&self, request: &TableBrowseRequest) -> CellarResult<String> {
+        if let Some(database) = &request.database {
+            if database.trim().is_empty() {
+                return Err(CellarError::invalid_config("database name is empty"));
+            }
+            return Ok(database.clone());
+        }
+
+        let inner = self.inner.read().await;
+        let open = inner.open.get(&request.connection_id).ok_or_else(|| {
+            CellarError::NotConnected(format!("no open connection for {}", request.connection_id))
+        })?;
+        Ok(open.config.database.clone())
+    }
+}
+
+fn find_table(dbs: &[Database], database: &str, schema: &str, table: &str) -> CellarResult<Table> {
+    dbs.iter()
+        .find(|db| db.name == database)
+        .and_then(|db| db.schemas.iter().find(|s| s.name == schema))
+        .and_then(|s| s.tables.iter().find(|t| t.name == table))
+        .cloned()
+        .ok_or_else(|| {
+            CellarError::invalid_config(format!(
+                "table {database}.{schema}.{table} was not found in schema metadata"
+            ))
+        })
 }
 
 fn driver_for(engine: Engine) -> CellarResult<Box<dyn Driver>> {

--- a/apps/desktop/src/hooks/useTableData.ts
+++ b/apps/desktop/src/hooks/useTableData.ts
@@ -1,5 +1,5 @@
 import { commands, unwrap } from "@cellar/ipc";
-import type { CellValue, QueryResult } from "@cellar/ipc";
+import type { CellValue, QueryResult, TableBrowseRequest } from "@cellar/ipc";
 import type { CellAlign, GridColumn, GridRow } from "@cellar/data-grid";
 import { useEffect, useState } from "react";
 
@@ -55,7 +55,16 @@ export function useTableData(
     let cancelled = false;
     setState((s) => ({ ...s, loading: s.rows.length === 0, error: null }));
     const primaryKey = tablePrimaryKey(connectionId, database, schema, table);
-    const sql = tableSelectSql(schema, table, primaryKey);
+    const request: TableBrowseRequest = {
+      connection_id: connectionId,
+      database,
+      schema,
+      table,
+      limit: DEFAULT_LIMIT,
+      sorts: [],
+      filters: [],
+      primary_key_fallback_ordering: true,
+    };
     const messageTabId = tabId ?? tableTabId(connectionId, database, schema, table);
     const queryContext: TableQueryContext = {
       tabId: messageTabId,
@@ -63,7 +72,6 @@ export function useTableData(
       database,
       schema,
       table,
-      sql,
       maxRows: DEFAULT_LIMIT,
     };
     if (tabId) {
@@ -81,7 +89,7 @@ export function useTableData(
           table,
           refreshKey,
           tabId,
-          sql,
+          request,
         );
         if (cancelled) return;
         const columns = columnsFor(connectionId, database, schema, table, result);
@@ -152,7 +160,7 @@ function loadTableQuery(
   table: string,
   refreshKey: number,
   tabId: string | undefined,
-  sql: string,
+  request: TableBrowseRequest,
 ): Promise<QueryResult> {
   const key = [
     connectionId,
@@ -161,14 +169,11 @@ function loadTableQuery(
     table,
     refreshKey,
     tabId ?? "",
-    sql,
   ].join("\u001f");
   const existing = inflightTableLoads.get(key);
   if (existing) return existing;
 
-  const promise = unwrap(
-    commands.runQuery(connectionId, sql, DEFAULT_LIMIT, database, tabId ?? null),
-  ).finally(() => {
+  const promise = unwrap(commands.browseTable(request)).finally(() => {
     if (inflightTableLoads.get(key) === promise) {
       inflightTableLoads.delete(key);
     }
@@ -176,20 +181,6 @@ function loadTableQuery(
   inflightTableLoads.set(key, promise);
   return promise;
 }
-
-function tableSelectSql(
-  schema: string,
-  table: string,
-  primaryKey: string[],
-): string {
-  const tableIdent = `${quoteIdent(schema)}.${quoteIdent(table)}`;
-  const orderBy =
-    primaryKey.length > 0
-      ? ` ORDER BY ${primaryKey.map(quoteIdent).join(", ")}`
-      : "";
-  return `SELECT * FROM ${tableIdent}${orderBy} LIMIT ${DEFAULT_LIMIT}`;
-}
-
 function columnsFor(
   connectionId: string,
   database: string,
@@ -364,8 +355,4 @@ function bytesToHex(bytes: number[]): string {
   }
   if (bytes.length > limit) out += `… (${bytes.length} bytes)`;
   return out;
-}
-
-function quoteIdent(s: string): string {
-  return `"${s.replaceAll('"', '""')}"`;
 }

--- a/apps/desktop/src/lib/queryMessages.ts
+++ b/apps/desktop/src/lib/queryMessages.ts
@@ -42,7 +42,7 @@ export interface TableQueryContext {
   database: string;
   schema: string;
   table: string;
-  sql: string;
+  sql?: string;
   maxRows: number;
 }
 

--- a/crates/cellar-core/src/query.rs
+++ b/crates/cellar-core/src/query.rs
@@ -160,3 +160,57 @@ pub struct PlanDetail {
     pub label: String,
     pub value: String,
 }
+
+/// Typed request for browsing one table through the grid. This deliberately
+/// does not carry executable SQL; each driver owns safe dialect-specific
+/// rendering and value binding.
+#[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
+pub struct TableBrowseRequest {
+    pub connection_id: String,
+    pub database: Option<String>,
+    pub schema: String,
+    pub table: String,
+    pub limit: Option<u32>,
+    pub sorts: Vec<TableSortClause>,
+    pub filters: Vec<TableFilterClause>,
+    /// When no explicit sort is requested, order by the table primary key if
+    /// metadata is available. This keeps table tabs stable without the UI
+    /// building an `ORDER BY` string.
+    pub primary_key_fallback_ordering: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
+pub struct TableSortClause {
+    pub column: String,
+    pub direction: SortDirection,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Type, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SortDirection {
+    Asc,
+    Desc,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
+pub struct TableFilterClause {
+    pub column: String,
+    pub operator: TableFilterOperator,
+    /// User-entered scalar value. Null checks intentionally use operators
+    /// instead of overloading this field.
+    pub value: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Type, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TableFilterOperator {
+    Equals,
+    NotEquals,
+    Contains,
+    IsNull,
+    IsNotNull,
+    GreaterThan,
+    GreaterThanOrEqual,
+    LessThan,
+    LessThanOrEqual,
+}

--- a/crates/cellar-drivers/postgres/src/lib.rs
+++ b/crates/cellar-drivers/postgres/src/lib.rs
@@ -5,14 +5,15 @@
 use async_trait::async_trait;
 use cellar_core::driver::{Connection, ConnectionConfig, Driver, Engine};
 use cellar_core::error::CellarResult;
-use cellar_core::query::{PlanMode, Query, QueryPlan, QueryResult};
-use cellar_core::schema::Database;
+use cellar_core::query::{PlanMode, Query, QueryPlan, QueryResult, TableBrowseRequest};
+use cellar_core::schema::{Database, Table};
 use cellar_diff::{TableChangeRequest, TableCommitResult};
 
 mod connect;
 mod decode;
 mod introspect;
 mod query;
+mod table_browse;
 
 pub use connect::{open_pool, PgConnection};
 
@@ -33,6 +34,15 @@ pub async fn commit_table_changes(
 ) -> CellarResult<TableCommitResult> {
     let pg = connect::as_pg(conn)?;
     query::commit_table_changes(pg, request).await
+}
+
+pub async fn browse_table(
+    conn: &dyn Connection,
+    request: &TableBrowseRequest,
+    table: &Table,
+) -> CellarResult<QueryResult> {
+    let pg = connect::as_pg(conn)?;
+    table_browse::browse_table(pg, request, table).await
 }
 
 #[async_trait]

--- a/crates/cellar-drivers/postgres/src/table_browse.rs
+++ b/crates/cellar-drivers/postgres/src/table_browse.rs
@@ -1,0 +1,553 @@
+use std::time::Instant;
+
+use cellar_core::error::{CellarError, CellarResult};
+use cellar_core::query::{
+    NoticeCapture, QueryResult, SortDirection, TableBrowseRequest, TableFilterClause,
+    TableFilterOperator,
+};
+use cellar_core::schema::{Column, Table};
+use cellar_core::value::{ColumnMeta, Row};
+use futures::TryStreamExt;
+use sqlx::{Column as _, Postgres, QueryBuilder, Row as _, TypeInfo as _};
+use thiserror::Error;
+
+use crate::connect::PgConnection;
+use crate::decode::decode_cell;
+
+const DEFAULT_TABLE_BROWSE_ROWS: u32 = 500;
+const MAX_TABLE_BROWSE_ROWS: u32 = 500;
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum TableBrowseError {
+    #[error("schema name is empty")]
+    EmptySchema,
+    #[error("table name is empty")]
+    EmptyTable,
+    #[error("table metadata does not match requested table")]
+    TableMetadataMismatch,
+    #[error("table browse limit must be greater than zero")]
+    EmptyLimit,
+    #[error("table browse limit cannot exceed {MAX_TABLE_BROWSE_ROWS} rows")]
+    LimitTooLarge,
+    #[error("unknown column {0}")]
+    UnknownColumn(String),
+    #[error("operator {operator:?} requires a value for column {column}")]
+    MissingValue {
+        column: String,
+        operator: TableFilterOperator,
+    },
+    #[error("operator {operator:?} does not accept a value for column {column}")]
+    UnexpectedValue {
+        column: String,
+        operator: TableFilterOperator,
+    },
+    #[error("operator {operator:?} is not supported for column {column} ({data_type})")]
+    UnsupportedOperator {
+        column: String,
+        data_type: String,
+        operator: TableFilterOperator,
+    },
+}
+
+pub async fn browse_table(
+    conn: &PgConnection,
+    request: &TableBrowseRequest,
+    table: &Table,
+) -> CellarResult<QueryResult> {
+    let max_rows = normalized_limit(request).map_err(to_query_err)?;
+    let database = request
+        .database
+        .as_deref()
+        .unwrap_or(conn.config().database.as_str());
+    let pool = conn.pool_for_database(database).await?;
+    let pool = &pool;
+
+    let mut builder = build_table_browse_query(request, table).map_err(to_query_err)?;
+    let started = Instant::now();
+    let mut stream = builder.build().fetch(pool);
+    let mut columns: Option<Vec<ColumnMeta>> = None;
+    let mut materialized: Vec<Row> = Vec::with_capacity(max_rows as usize);
+    let mut truncated = false;
+
+    while let Some(r) = stream
+        .try_next()
+        .await
+        .map_err(|e| CellarError::query(e.to_string()))?
+    {
+        if columns.is_none() {
+            columns = Some(
+                r.columns()
+                    .iter()
+                    .map(|c| ColumnMeta {
+                        name: c.name().to_string(),
+                        data_type: c.type_info().name().to_string().to_lowercase(),
+                        nullable: true,
+                    })
+                    .collect(),
+            );
+        }
+
+        if materialized.len() >= max_rows as usize {
+            truncated = true;
+            break;
+        }
+
+        let mut cells: Row = Vec::with_capacity(r.columns().len());
+        for i in 0..r.columns().len() {
+            cells.push(decode_cell(&r, i)?);
+        }
+        materialized.push(cells);
+    }
+
+    Ok(QueryResult {
+        columns: columns.unwrap_or_default(),
+        rows: materialized,
+        notices: Vec::new(),
+        notice_capture: NoticeCapture::unsupported(
+            "Postgres server notices are parsed by sqlx, but the current PgPool query path consumes NoticeResponse frames internally and exposes only log/tracing output without SQLSTATE, detail, hint, or query correlation.",
+        ),
+        rows_affected: None,
+        duration_ms: started.elapsed().as_millis() as u64,
+        truncated,
+    })
+}
+
+fn build_table_browse_query<'args>(
+    request: &TableBrowseRequest,
+    table: &Table,
+) -> Result<QueryBuilder<'args, Postgres>, TableBrowseError> {
+    validate_table_request(request, table)?;
+
+    let mut builder = QueryBuilder::<Postgres>::new("SELECT * FROM ");
+    push_qualified_table(&mut builder, &request.schema, &request.table);
+
+    if !request.filters.is_empty() {
+        builder.push(" WHERE ");
+        for (i, filter) in request.filters.iter().enumerate() {
+            if i > 0 {
+                builder.push(" AND ");
+            }
+            push_filter(&mut builder, filter, table)?;
+        }
+    }
+
+    if !request.sorts.is_empty() {
+        builder.push(" ORDER BY ");
+        for (i, sort) in request.sorts.iter().enumerate() {
+            if i > 0 {
+                builder.push(", ");
+            }
+            let column = column_for(table, &sort.column)?;
+            push_ident(&mut builder, &column.name);
+            match sort.direction {
+                SortDirection::Asc => builder.push(" ASC"),
+                SortDirection::Desc => builder.push(" DESC"),
+            };
+        }
+    } else if request.primary_key_fallback_ordering && !table.primary_key.is_empty() {
+        builder.push(" ORDER BY ");
+        for (i, column_name) in table.primary_key.iter().enumerate() {
+            if i > 0 {
+                builder.push(", ");
+            }
+            let column = column_for(table, column_name)?;
+            push_ident(&mut builder, &column.name);
+        }
+    }
+
+    let fetch_limit = normalized_limit(request)? + 1;
+    builder.push(" LIMIT ");
+    builder.push_bind(fetch_limit as i64);
+
+    Ok(builder)
+}
+
+fn validate_table_request(
+    request: &TableBrowseRequest,
+    table: &Table,
+) -> Result<(), TableBrowseError> {
+    if request.schema.trim().is_empty() {
+        return Err(TableBrowseError::EmptySchema);
+    }
+    if request.table.trim().is_empty() {
+        return Err(TableBrowseError::EmptyTable);
+    }
+    if table.schema != request.schema || table.name != request.table {
+        return Err(TableBrowseError::TableMetadataMismatch);
+    }
+    normalized_limit(request)?;
+    for sort in &request.sorts {
+        column_for(table, &sort.column)?;
+    }
+    for filter in &request.filters {
+        column_for(table, &filter.column)?;
+    }
+    Ok(())
+}
+
+fn normalized_limit(request: &TableBrowseRequest) -> Result<u32, TableBrowseError> {
+    let limit = request.limit.unwrap_or(DEFAULT_TABLE_BROWSE_ROWS);
+    if limit == 0 {
+        return Err(TableBrowseError::EmptyLimit);
+    }
+    if limit > MAX_TABLE_BROWSE_ROWS {
+        return Err(TableBrowseError::LimitTooLarge);
+    }
+    Ok(limit)
+}
+
+fn push_filter<'args>(
+    builder: &mut QueryBuilder<'args, Postgres>,
+    filter: &TableFilterClause,
+    table: &Table,
+) -> Result<(), TableBrowseError> {
+    let column = column_for(table, &filter.column)?;
+    let kind = ColumnKind::from_pg_type(&column.data_type);
+
+    match filter.operator {
+        TableFilterOperator::IsNull => {
+            reject_value(filter)?;
+            push_ident(builder, &column.name);
+            builder.push(" IS NULL");
+        }
+        TableFilterOperator::IsNotNull => {
+            reject_value(filter)?;
+            push_ident(builder, &column.name);
+            builder.push(" IS NOT NULL");
+        }
+        TableFilterOperator::Contains => {
+            let value = require_value(filter)?;
+            if !matches!(kind, ColumnKind::Text) {
+                return Err(unsupported(column, filter.operator));
+            }
+            push_ident(builder, &column.name);
+            builder.push(" ILIKE ('%' || ");
+            builder.push_bind(value);
+            builder.push(" || '%')");
+        }
+        TableFilterOperator::Equals | TableFilterOperator::NotEquals => {
+            let value = require_value(filter)?;
+            let operator = if filter.operator == TableFilterOperator::Equals {
+                " = "
+            } else {
+                " <> "
+            };
+            push_typed_comparison(builder, column, kind, operator, value, filter.operator)?;
+        }
+        TableFilterOperator::GreaterThan
+        | TableFilterOperator::GreaterThanOrEqual
+        | TableFilterOperator::LessThan
+        | TableFilterOperator::LessThanOrEqual => {
+            let value = require_value(filter)?;
+            if !kind.supports_ordering() {
+                return Err(unsupported(column, filter.operator));
+            }
+            push_typed_comparison(
+                builder,
+                column,
+                kind,
+                comparison_operator(filter.operator),
+                value,
+                filter.operator,
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
+fn push_typed_comparison<'args>(
+    builder: &mut QueryBuilder<'args, Postgres>,
+    column: &Column,
+    kind: ColumnKind,
+    operator: &str,
+    value: String,
+    filter_operator: TableFilterOperator,
+) -> Result<(), TableBrowseError> {
+    if matches!(kind, ColumnKind::Unsupported) {
+        return Err(unsupported(column, filter_operator));
+    }
+
+    push_ident(builder, &column.name);
+    builder.push(operator);
+    builder.push_bind(value);
+    if let Some(cast) = kind.parameter_cast() {
+        builder.push("::");
+        builder.push(cast);
+    }
+    Ok(())
+}
+
+fn require_value(filter: &TableFilterClause) -> Result<String, TableBrowseError> {
+    filter
+        .value
+        .clone()
+        .ok_or_else(|| TableBrowseError::MissingValue {
+            column: filter.column.clone(),
+            operator: filter.operator,
+        })
+}
+
+fn reject_value(filter: &TableFilterClause) -> Result<(), TableBrowseError> {
+    if filter.value.is_some() {
+        return Err(TableBrowseError::UnexpectedValue {
+            column: filter.column.clone(),
+            operator: filter.operator,
+        });
+    }
+    Ok(())
+}
+
+fn comparison_operator(operator: TableFilterOperator) -> &'static str {
+    match operator {
+        TableFilterOperator::GreaterThan => " > ",
+        TableFilterOperator::GreaterThanOrEqual => " >= ",
+        TableFilterOperator::LessThan => " < ",
+        TableFilterOperator::LessThanOrEqual => " <= ",
+        _ => unreachable!("comparison_operator called for non-comparison filter"),
+    }
+}
+
+fn column_for<'a>(table: &'a Table, name: &str) -> Result<&'a Column, TableBrowseError> {
+    table
+        .columns
+        .iter()
+        .find(|column| column.name == name)
+        .ok_or_else(|| TableBrowseError::UnknownColumn(name.to_string()))
+}
+
+fn unsupported(column: &Column, operator: TableFilterOperator) -> TableBrowseError {
+    TableBrowseError::UnsupportedOperator {
+        column: column.name.clone(),
+        data_type: column.data_type.clone(),
+        operator,
+    }
+}
+
+fn push_qualified_table(builder: &mut QueryBuilder<'_, Postgres>, schema: &str, table: &str) {
+    push_ident(builder, schema);
+    builder.push(".");
+    push_ident(builder, table);
+}
+
+fn push_ident(builder: &mut QueryBuilder<'_, Postgres>, ident: &str) {
+    builder.push("\"");
+    builder.push(ident.replace('"', "\"\""));
+    builder.push("\"");
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ColumnKind {
+    Text,
+    Typed(&'static str, bool),
+    Unsupported,
+}
+
+impl ColumnKind {
+    fn from_pg_type(data_type: &str) -> Self {
+        match data_type.to_ascii_lowercase().as_str() {
+            "text" | "varchar" | "bpchar" | "char" | "name" | "citext" => Self::Text,
+            "int2" => Self::Typed("int2", true),
+            "int4" => Self::Typed("int4", true),
+            "int8" => Self::Typed("int8", true),
+            "oid" => Self::Typed("oid", true),
+            "float4" => Self::Typed("float4", true),
+            "float8" => Self::Typed("float8", true),
+            "numeric" => Self::Typed("numeric", true),
+            "bool" => Self::Typed("boolean", false),
+            "uuid" => Self::Typed("uuid", false),
+            "date" => Self::Typed("date", true),
+            "time" => Self::Typed("time", true),
+            "timetz" => Self::Typed("timetz", true),
+            "timestamp" => Self::Typed("timestamp", true),
+            "timestamptz" => Self::Typed("timestamptz", true),
+            _ => Self::Unsupported,
+        }
+    }
+
+    fn parameter_cast(self) -> Option<&'static str> {
+        match self {
+            Self::Text | Self::Unsupported => None,
+            Self::Typed(cast, _) => Some(cast),
+        }
+    }
+
+    fn supports_ordering(self) -> bool {
+        match self {
+            Self::Text => true,
+            Self::Typed(_, supports_ordering) => supports_ordering,
+            Self::Unsupported => false,
+        }
+    }
+}
+
+fn to_query_err(err: TableBrowseError) -> CellarError {
+    CellarError::query(err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request() -> TableBrowseRequest {
+        TableBrowseRequest {
+            connection_id: "conn".into(),
+            database: Some("app".into()),
+            schema: "public".into(),
+            table: "users".into(),
+            limit: Some(500),
+            sorts: Vec::new(),
+            filters: Vec::new(),
+            primary_key_fallback_ordering: true,
+        }
+    }
+
+    fn table() -> Table {
+        Table {
+            name: "users".into(),
+            schema: "public".into(),
+            row_count: None,
+            primary_key: vec!["id".into()],
+            foreign_keys: Vec::new(),
+            indexes: Vec::new(),
+            columns: vec![
+                column("id", "int8", true),
+                column("email", "text", false),
+                column("age", "int4", false),
+                column("deleted_at", "timestamptz", false),
+                column("payload", "jsonb", false),
+            ],
+        }
+    }
+
+    fn column(name: &str, data_type: &str, primary: bool) -> Column {
+        Column {
+            name: name.into(),
+            data_type: data_type.into(),
+            nullable: true,
+            default: None,
+            is_primary_key: primary,
+            ordinal: 1,
+            comment: None,
+        }
+    }
+
+    fn sql_for(request: &TableBrowseRequest) -> Result<String, TableBrowseError> {
+        Ok(build_table_browse_query(request, &table())?
+            .sql()
+            .to_string())
+    }
+
+    #[test]
+    fn quotes_identifiers_and_uses_primary_key_fallback_ordering() {
+        let sql = sql_for(&request()).expect("sql");
+
+        assert_eq!(
+            sql,
+            r#"SELECT * FROM "public"."users" ORDER BY "id" LIMIT $1"#
+        );
+    }
+
+    #[test]
+    fn doubles_embedded_identifier_quotes() {
+        let mut req = request();
+        req.schema = r#"odd"schema"#.into();
+        req.table = r#"user"data"#.into();
+        let mut meta = table();
+        meta.schema = req.schema.clone();
+        meta.name = req.table.clone();
+
+        let sql = build_table_browse_query(&req, &meta)
+            .expect("sql")
+            .sql()
+            .to_string();
+
+        assert_eq!(
+            sql,
+            r#"SELECT * FROM "odd""schema"."user""data" ORDER BY "id" LIMIT $1"#
+        );
+    }
+
+    #[test]
+    fn binds_filter_values_instead_of_inlining_literals() {
+        let mut req = request();
+        req.filters.push(TableFilterClause {
+            column: "email".into(),
+            operator: TableFilterOperator::Contains,
+            value: Some("o'reilly_%".into()),
+        });
+
+        let sql = sql_for(&req).expect("sql");
+
+        assert_eq!(
+            sql,
+            r#"SELECT * FROM "public"."users" WHERE "email" ILIKE ('%' || $1 || '%') ORDER BY "id" LIMIT $2"#
+        );
+        assert!(!sql.contains("o'reilly"));
+    }
+
+    #[test]
+    fn casts_typed_values_for_safe_comparisons() {
+        let mut req = request();
+        req.filters.push(TableFilterClause {
+            column: "age".into(),
+            operator: TableFilterOperator::GreaterThanOrEqual,
+            value: Some("21".into()),
+        });
+        req.filters.push(TableFilterClause {
+            column: "deleted_at".into(),
+            operator: TableFilterOperator::IsNull,
+            value: None,
+        });
+        req.sorts.push(super::cellar_core_sort("email"));
+
+        let sql = sql_for(&req).expect("sql");
+
+        assert_eq!(
+            sql,
+            r#"SELECT * FROM "public"."users" WHERE "age" >= $1::int4 AND "deleted_at" IS NULL ORDER BY "email" ASC LIMIT $2"#
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_columns() {
+        let mut req = request();
+        req.sorts.push(super::cellar_core_sort("missing"));
+
+        assert_eq!(
+            sql_for(&req).unwrap_err(),
+            TableBrowseError::UnknownColumn("missing".into())
+        );
+    }
+
+    #[test]
+    fn rejects_unsupported_operator_for_column_type() {
+        let mut req = request();
+        req.filters.push(TableFilterClause {
+            column: "payload".into(),
+            operator: TableFilterOperator::Contains,
+            value: Some("x".into()),
+        });
+
+        assert!(matches!(
+            sql_for(&req),
+            Err(TableBrowseError::UnsupportedOperator { column, .. }) if column == "payload"
+        ));
+    }
+
+    #[test]
+    fn rejects_excessive_limits() {
+        let mut req = request();
+        req.limit = Some(MAX_TABLE_BROWSE_ROWS + 1);
+
+        assert_eq!(sql_for(&req).unwrap_err(), TableBrowseError::LimitTooLarge);
+    }
+}
+
+#[cfg(test)]
+fn cellar_core_sort(column: &str) -> cellar_core::query::TableSortClause {
+    cellar_core::query::TableSortClause {
+        column: column.into(),
+        direction: SortDirection::Asc,
+    }
+}

--- a/packages/ipc/src/generated.ts
+++ b/packages/ipc/src/generated.ts
@@ -77,6 +77,14 @@ async explainQuery(connectionId: string, sql: string, mode: PlanMode, database: 
     else return { status: "error", error: e  as any };
 }
 },
+async browseTable(request: TableBrowseRequest) : Promise<Result<QueryResult, CellarError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("browse_table", { request }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async previewTableChanges(request: TableChangeRequest) : Promise<Result<TableCommitPreview, CellarError>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("preview_table_changes", { request }) };
@@ -262,15 +270,36 @@ duration_ms: number;
 truncated: boolean }
 export type RowChange = { kind: "update"; row_id: string; keys: CellAssignment[]; edits: CellAssignment[] } | { kind: "insert"; row_id: string; values: CellAssignment[] } | { kind: "delete"; row_id: string; keys: CellAssignment[] }
 export type Schema = { name: string; tables: Table[]; views: View[] }
+export type SortDirection = "asc" | "desc"
 export type SslMode = "disable" | "prefer" | "require" | "verify-ca" | "verify-full"
 export type Table = { name: string; schema: string;
 /**
  * `None` until lazy row-count introspection has run.
  */
 row_count: number | null; columns: Column[]; primary_key: string[]; foreign_keys: ForeignKey[]; indexes: Index[] }
+/**
+ * Typed request for browsing one table through the grid. This deliberately
+ * does not carry executable SQL; each driver owns safe dialect-specific
+ * rendering and value binding.
+ */
+export type TableBrowseRequest = { connection_id: string; database: string | null; schema: string; table: string; limit: number | null; sorts: TableSortClause[]; filters: TableFilterClause[];
+/**
+ * When no explicit sort is requested, order by the table primary key if
+ * metadata is available. This keeps table tabs stable without the UI
+ * building an `ORDER BY` string.
+ */
+primary_key_fallback_ordering: boolean }
 export type TableChangeRequest = { database: string | null; schema: string; table: string; primary_key: string[]; columns: DiffColumn[]; changes: RowChange[] }
 export type TableCommitPreview = { sql: string; expected_rows: number; statement_count: number }
 export type TableCommitResult = { sql: string; rows_affected: number; duration_ms: number }
+export type TableFilterClause = { column: string; operator: TableFilterOperator;
+/**
+ * User-entered scalar value. Null checks intentionally use operators
+ * instead of overloading this field.
+ */
+value: string | null }
+export type TableFilterOperator = "equals" | "not_equals" | "contains" | "is_null" | "is_not_null" | "greater_than" | "greater_than_or_equal" | "less_than" | "less_than_or_equal"
+export type TableSortClause = { column: string; direction: SortDirection }
 export type View = { name: string; schema: string; columns: Column[]; definition: string | null }
 
 /** tauri-specta globals **/

--- a/packages/ipc/src/index.test.ts
+++ b/packages/ipc/src/index.test.ts
@@ -15,6 +15,7 @@ describe("@cellar/ipc", () => {
     // If a command name changes, this test should fail so the UI gets a heads-up.
     expect(Object.keys(commands).sort()).toEqual(
       [
+        "browseTable",
         "commitTableChanges",
         "connect",
         "deleteConnection",
@@ -102,6 +103,32 @@ describe("@cellar/ipc", () => {
           children: expect.any(Array),
         },
         duration_ms: expect.any(Number),
+      });
+    }
+  });
+
+  it("browseTable returns the QueryResult shape in mock mode", async () => {
+    const result: Result<QueryResult, CellarError> = await commands.browseTable({
+      connection_id: "any",
+      database: null,
+      schema: "public",
+      table: "users",
+      limit: 10,
+      sorts: [],
+      filters: [],
+      primary_key_fallback_ordering: true,
+    });
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") {
+      expect(result.data).toMatchObject({
+        columns: expect.any(Array),
+        rows: expect.any(Array),
+        notices: expect.any(Array),
+        notice_capture: {
+          supported: expect.any(Boolean),
+        },
+        duration_ms: expect.any(Number),
+        truncated: false,
       });
     }
   });

--- a/packages/ipc/src/mock.ts
+++ b/packages/ipc/src/mock.ts
@@ -13,6 +13,7 @@ import type {
   QueryHistoryRecord,
   QueryResult,
   Result,
+  TableBrowseRequest,
   TableChangeRequest,
   TableCommitPreview,
   TableCommitResult,
@@ -104,6 +105,22 @@ export const mockCommands = {
       execution_time_ms: null,
       duration_ms: 0,
       raw_json: [{ Plan: { "Node Type": "Result" } }],
+    }),
+
+  browseTable: async (
+    _request: TableBrowseRequest,
+  ): Promise<Result<QueryResult, CellarError>> =>
+    ok({
+      columns: [],
+      rows: [],
+      notices: [],
+      notice_capture: {
+        supported: false,
+        reason: "Mock IPC mode does not connect to a database server.",
+      },
+      rows_affected: null,
+      duration_ms: 0,
+      truncated: false,
     }),
 
   previewTableChanges: async (


### PR DESCRIPTION
## Summary
- Add a typed table browse request model for one-table grid loading, including filter and sort clauses plus primary-key fallback ordering.
- Route table browsing through a new Tauri command and Postgres driver path that validates schema metadata, quotes identifiers, binds values, preserves row-limit truncation, and avoids executable table SELECT assembly in React.
- Regenerate IPC bindings and update web-mode mocks/tests for the new command.

## Validation
- `cargo check --workspace`
- `pnpm typecheck`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p cellar-driver-postgres table_browse --lib`
- `pnpm --filter @cellar/ipc test`
- `pnpm --filter @cellar/desktop test`
