### PR TITLE
feat(data-grid): add multi-clause filter builder

### DIFF
--- a/apps/desktop/src/styles/grid.css
+++ b/apps/desktop/src/styles/grid.css
@@ -39,22 +39,60 @@
   gap: 4px;
   flex: 1;
   min-width: 0;
+  overflow: hidden;
 }
-.grid-filter-chip {
+.grid-filter-chip-wrap {
   display: inline-flex;
   align-items: center;
   gap: 4px;
+  min-width: 0;
+  flex-shrink: 0;
+}
+.grid-filter-logic {
+  height: 18px;
+  padding: 0 3px;
+  border-radius: 3px;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  color: var(--fg-3);
+  text-transform: uppercase;
+}
+.grid-filter-logic:hover { background: var(--bg-3); color: var(--fg-1); }
+.grid-filter-chip {
+  display: inline-flex;
+  align-items: center;
   height: 20px;
-  padding: 0 4px 0 7px;
+  max-width: 360px;
   background: var(--accent-soft);
   border: 1px solid var(--accent-line);
   border-radius: 4px;
   font-size: 10.5px;
   color: var(--fg-0);
+  overflow: hidden;
 }
 .grid-filter-chip .mono { font-family: var(--font-mono); }
 .grid-filter-op { color: var(--accent); }
-.grid-filter-chip button {
+.grid-filter-value {
+  color: var(--syn-str);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.grid-filter-chip-main {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  height: 100%;
+  padding: 0 4px 0 7px;
+}
+.grid-filter-chip-main .mono:first-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.grid-filter-remove,
+.grid-filter-cancel {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -62,8 +100,14 @@
   height: 14px;
   border-radius: 2px;
   color: var(--fg-2);
+  flex-shrink: 0;
 }
-.grid-filter-chip button:hover { background: rgba(0,0,0,0.2); color: var(--fg-0); }
+.grid-filter-remove { margin-right: 3px; }
+.grid-filter-remove:hover,
+.grid-filter-cancel:hover {
+  background: rgba(0,0,0,0.2);
+  color: var(--fg-0);
+}
 
 .grid-filter-add {
   display: inline-flex;
@@ -77,6 +121,81 @@
   color: var(--fg-2);
 }
 .grid-filter-add:hover { color: var(--fg-0); border-color: var(--border-strong); }
+.grid-filter-add:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.grid-filter-composer {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 22px;
+  min-width: 0;
+  padding: 0 4px;
+  border: 1px solid var(--border-strong);
+  border-radius: 4px;
+  background: var(--bg-2);
+  box-shadow: 0 4px 14px rgba(0,0,0,0.18);
+  flex-shrink: 0;
+}
+.grid-filter-select,
+.grid-filter-input {
+  height: 18px;
+  min-width: 0;
+  border: 1px solid var(--border-default);
+  border-radius: 3px;
+  background: var(--bg-inset);
+  color: var(--fg-0);
+  font-size: 10.5px;
+  outline: none;
+}
+.grid-filter-select {
+  max-width: 150px;
+  padding: 0 18px 0 5px;
+}
+.grid-filter-logic-select {
+  width: 54px;
+  text-transform: uppercase;
+}
+.grid-filter-operator-select {
+  max-width: 104px;
+}
+.grid-filter-input {
+  width: 132px;
+  padding: 0 6px;
+}
+.grid-filter-select:focus,
+.grid-filter-input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent-line);
+}
+.grid-filter-apply {
+  height: 18px;
+  padding: 0 6px;
+  border-radius: 3px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 10.5px;
+  font-weight: 600;
+}
+.grid-filter-apply:hover:not(:disabled) {
+  background: var(--accent-line);
+  color: var(--fg-0);
+}
+.grid-filter-apply:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+.grid-filter-clear {
+  height: 20px;
+  padding: 0 5px;
+  border-radius: 3px;
+  color: var(--fg-3);
+  font-size: 10.5px;
+  flex-shrink: 0;
+}
+.grid-filter-clear:hover { background: var(--bg-3); color: var(--fg-1); }
 
 .grid-filterbar-summary {
   display: inline-flex;

--- a/packages/data-grid/src/DataGrid.tsx
+++ b/packages/data-grid/src/DataGrid.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from "react";
 import { CellEditor, CellValue } from "./Cell";
 import { FilterBar } from "./FilterBar";
+import { filterRows } from "./filters";
 import { GridIcon } from "./icons";
 import { PendingBar } from "./PendingBar";
 import { TypeIcon } from "./TypeIcon";
@@ -76,16 +77,8 @@ export function DataGrid({
   // Local search across visible page. Server-side filtering happens upstream
   // for large tables; the chips drive both.
   const visibleRows = useMemo(() => {
-    const entries = Object.entries(filters);
-    if (entries.length === 0) return rows;
-    return rows.filter((row) =>
-      entries.every(([k, needle]) =>
-        String(row[k] ?? "")
-          .toLowerCase()
-          .includes(String(needle).toLowerCase()),
-      ),
-    );
-  }, [rows, filters]);
+    return filterRows(rows, columns, filters, changes);
+  }, [rows, columns, filters, changes]);
 
   const minTableWidth = useMemo(
     () => columns.reduce((acc, c) => acc + c.width, ROWNO_WIDTH + 8),
@@ -122,10 +115,12 @@ export function DataGrid({
   return (
     <div className="grid-root mono">
       <FilterBar
+        columns={columns}
         filters={filters}
         setFilters={onFiltersChange}
-        totalRows={totalRows ?? rows.length}
+        totalRows={rows.length}
         filteredRows={visibleRows.length}
+        serverRows={totalRows}
       />
 
       <div className="grid-scroll">
@@ -288,7 +283,7 @@ export type UseGridStateOptions = {
  * a store and the grid stays exactly the same.
  */
 export function useGridState({
-  initialFilters = {},
+  initialFilters = [],
   initialChanges = {},
 }: UseGridStateOptions = {}) {
   const [filters, setFilters] = useState<ColumnFilters>(initialFilters);

--- a/packages/data-grid/src/FilterBar.tsx
+++ b/packages/data-grid/src/FilterBar.tsx
@@ -1,19 +1,143 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  createFilterId,
+  filterNeedsValue,
+  filterOperatorLabel,
+  filterValuePreview,
+  nextOperatorForColumn,
+  operatorsForColumn,
+} from "./filters";
 import { GridIcon } from "./icons";
-import type { ColumnFilters } from "./types";
+import type {
+  ColumnFilters,
+  FilterClause,
+  FilterLogic,
+  FilterOperator,
+  GridColumn,
+} from "./types";
+
+type ComposerDraft = {
+  id: string | null;
+  columnKey: string;
+  operator: FilterOperator;
+  value: string;
+  logic: FilterLogic;
+};
 
 export type FilterBarProps = {
+  columns: readonly GridColumn[];
   filters: ColumnFilters;
   setFilters: (next: ColumnFilters) => void;
   totalRows: number;
   filteredRows: number;
+  serverRows?: number;
 };
 
 export function FilterBar({
+  columns,
   filters,
   setFilters,
   totalRows,
   filteredRows,
+  serverRows,
 }: FilterBarProps) {
+  const [draft, setDraft] = useState<ComposerDraft | null>(null);
+  const columnRef = useRef<HTMLSelectElement | null>(null);
+  const valueRef = useRef<HTMLInputElement | null>(null);
+  const columnsByKey = useMemo(
+    () => new Map(columns.map((column) => [column.key, column])),
+    [columns],
+  );
+
+  const focusKey = draft
+    ? `${draft.id ?? "new"}:${draft.columnKey}:${draft.operator}`
+    : null;
+
+  useEffect(() => {
+    if (!draft) return;
+    const column = columnsByKey.get(draft.columnKey);
+    if (column && filterNeedsValue(draft.operator)) {
+      valueRef.current?.focus();
+      valueRef.current?.select();
+      return;
+    }
+    columnRef.current?.focus();
+  }, [columnsByKey, focusKey]);
+
+  const openAdd = () => {
+    const first = columns[0];
+    if (!first) return;
+    const operator = operatorsForColumn(first)[0] ?? "equals";
+    setDraft({
+      id: null,
+      columnKey: first.key,
+      operator,
+      value: "",
+      logic: "and",
+    });
+  };
+
+  const openEdit = (clause: FilterClause) => {
+    const column = columnsByKey.get(clause.columnKey);
+    setDraft({
+      id: clause.id,
+      columnKey: clause.columnKey,
+      operator: column ? nextOperatorForColumn(column, clause.operator) : clause.operator,
+      value: clause.value ?? "",
+      logic: clause.logic,
+    });
+  };
+
+  const applyDraft = () => {
+    if (!draft) return;
+    const column = columnsByKey.get(draft.columnKey);
+    if (!column) return;
+    const operator = nextOperatorForColumn(column, draft.operator);
+    const needsValue = filterNeedsValue(operator);
+    const value = draft.value.trim();
+    if (needsValue && value.length === 0) return;
+
+    const clause: FilterClause = {
+      id: draft.id ?? createFilterId(),
+      columnKey: draft.columnKey,
+      operator,
+      logic: draft.id
+        ? draft.logic
+        : filters.length === 0
+          ? "and"
+          : draft.logic,
+      ...(needsValue ? { value } : {}),
+    };
+
+    if (draft.id) {
+      setFilters(filters.map((item) => (item.id === draft.id ? clause : item)));
+    } else {
+      setFilters([...filters, clause]);
+    }
+    setDraft(null);
+  };
+
+  const removeFilter = (id: string) => {
+    setFilters(filters.filter((clause) => clause.id !== id));
+    if (draft?.id === id) setDraft(null);
+  };
+
+  const toggleLogic = (id: string) => {
+    setFilters(
+      filters.map((clause) =>
+        clause.id === id
+          ? { ...clause, logic: clause.logic === "or" ? "and" : "or" }
+          : clause,
+      ),
+    );
+  };
+
+  const draftColumn = draft ? columnsByKey.get(draft.columnKey) : null;
+  const draftOperators = draftColumn ? operatorsForColumn(draftColumn) : [];
+  const needsValue = draft ? filterNeedsValue(draft.operator) : false;
+  const canApply =
+    !!draft && !!draftColumn && (!needsValue || draft.value.trim().length > 0);
+
   return (
     <div className="grid-filterbar">
       <div className="grid-filterbar-label">
@@ -21,39 +145,178 @@ export function FilterBar({
         <span>where</span>
       </div>
       <div className="grid-filterbar-chips">
-        {Object.entries(filters).map(([k, v]) => (
-          <span key={k} className="grid-filter-chip">
-            <span className="mono">{k}</span>
-            <span className="grid-filter-op">=</span>
-            <span className="mono" style={{ color: "var(--syn-str)" }}>
-              {"'"}
-              {v}
-              {"'"}
+        {filters.map((clause, index) => {
+          const column = columnsByKey.get(clause.columnKey);
+          return (
+            <span key={clause.id} className="grid-filter-chip-wrap">
+              {index > 0 && (
+                <button
+                  className="grid-filter-logic"
+                  onClick={() => toggleLogic(clause.id)}
+                  title="Toggle AND/OR"
+                >
+                  {clause.logic}
+                </button>
+              )}
+              <span className="grid-filter-chip">
+                <button
+                  className="grid-filter-chip-main"
+                  onClick={() => openEdit(clause)}
+                  title="Edit filter"
+                >
+                  <span className="mono">{column?.name ?? clause.columnKey}</span>
+                  <span className="grid-filter-op">
+                    {filterOperatorLabel(clause.operator)}
+                  </span>
+                  {filterNeedsValue(clause.operator) && (
+                    <span className="mono grid-filter-value">
+                      {filterValuePreview(clause)}
+                    </span>
+                  )}
+                </button>
+                <button
+                  className="grid-filter-remove"
+                  onClick={() => removeFilter(clause.id)}
+                  aria-label={`Remove filter on ${column?.name ?? clause.columnKey}`}
+                >
+                  <GridIcon.close size={9} />
+                </button>
+              </span>
             </span>
-            <button
-              onClick={() => {
-                const next = { ...filters };
-                delete next[k];
-                setFilters(next);
+          );
+        })}
+
+        {draft ? (
+          <div
+            className="grid-filter-composer"
+            onKeyDown={(e) => {
+              if (e.key === "Escape") {
+                e.stopPropagation();
+                setDraft(null);
+              }
+              if (e.key === "Enter") {
+                e.preventDefault();
+                applyDraft();
+              }
+            }}
+          >
+            {filters.length > 0 && !draft.id && (
+              <select
+                className="grid-filter-select grid-filter-logic-select"
+                value={draft.logic}
+                onChange={(e) =>
+                  setDraft({ ...draft, logic: e.target.value as FilterLogic })
+                }
+                aria-label="Filter join"
+              >
+                <option value="and">and</option>
+                <option value="or">or</option>
+              </select>
+            )}
+            <select
+              ref={columnRef}
+              className="grid-filter-select"
+              value={draft.columnKey}
+              onChange={(e) => {
+                const nextColumn = columnsByKey.get(e.target.value);
+                if (!nextColumn) return;
+                const operator = nextOperatorForColumn(nextColumn, draft.operator);
+                setDraft({ ...draft, columnKey: nextColumn.key, operator });
               }}
-              aria-label={`Remove filter on ${k}`}
+              aria-label="Filter column"
+            >
+              {columns.map((column) => (
+                <option key={column.key} value={column.key}>
+                  {column.name}
+                </option>
+              ))}
+            </select>
+            <select
+              className="grid-filter-select grid-filter-operator-select"
+              value={draft.operator}
+              onChange={(e) =>
+                setDraft({
+                  ...draft,
+                  operator: e.target.value as FilterOperator,
+                  value: filterNeedsValue(e.target.value as FilterOperator)
+                    ? draft.value
+                    : "",
+                })
+              }
+              aria-label="Filter operator"
+            >
+              {draftOperators.map((operator) => (
+                <option key={operator} value={operator}>
+                  {filterOperatorLabel(operator)}
+                </option>
+              ))}
+            </select>
+            {needsValue && (
+              <input
+                ref={valueRef}
+                className="grid-filter-input mono"
+                value={draft.value}
+                list={draftColumn?.enum ? `filter-values-${draftColumn.key}` : undefined}
+                onChange={(e) => setDraft({ ...draft, value: e.target.value })}
+                placeholder="value"
+                aria-label="Filter value"
+              />
+            )}
+            {draftColumn?.enum && (
+              <datalist id={`filter-values-${draftColumn.key}`}>
+                {draftColumn.enum.map((value) => (
+                  <option key={value} value={value} />
+                ))}
+              </datalist>
+            )}
+            <button
+              className="grid-filter-apply"
+              onClick={applyDraft}
+              disabled={!canApply}
+            >
+              {draft.id ? "save" : "apply"}
+            </button>
+            <button
+              className="grid-filter-cancel"
+              onClick={() => setDraft(null)}
+              aria-label="Cancel filter"
             >
               <GridIcon.close size={9} />
             </button>
-          </span>
-        ))}
-        <button className="grid-filter-add">
-          <GridIcon.plus size={10} />
-          <span>add</span>
-        </button>
+          </div>
+        ) : (
+          <button className="grid-filter-add" onClick={openAdd} disabled={columns.length === 0}>
+            <GridIcon.plus size={10} />
+            <span>add</span>
+          </button>
+        )}
+
+        {filters.length > 1 && (
+          <button
+            className="grid-filter-clear"
+            onClick={() => {
+              setFilters([]);
+              setDraft(null);
+            }}
+          >
+            clear
+          </button>
+        )}
       </div>
-      <div className="grid-filterbar-summary mono">
+      <div
+        className="grid-filterbar-summary mono"
+        title={
+          serverRows === undefined
+            ? "Filtered rows in the loaded page"
+            : `Filtered rows in the loaded page. Server total: ${serverRows.toLocaleString()}`
+        }
+      >
         <span style={{ color: "var(--fg-1)" }}>
           {filteredRows.toLocaleString()}
         </span>
         <span style={{ color: "var(--fg-3)" }}>/</span>
         <span style={{ color: "var(--fg-2)" }}>{totalRows.toLocaleString()}</span>
-        <span style={{ color: "var(--fg-3)" }}> rows</span>
+        <span style={{ color: "var(--fg-3)" }}> page rows</span>
       </div>
     </div>
   );

--- a/packages/data-grid/src/filters.test.ts
+++ b/packages/data-grid/src/filters.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluateFilterClause,
+  filterRows,
+  operatorsForColumn,
+} from "./filters";
+import type { FilterClause, GridColumn, GridRow, PendingChanges } from "./types";
+
+const columns: readonly GridColumn[] = [
+  { key: "status", name: "status", type: "text", width: 120 },
+  { key: "total", name: "total", type: "numeric", width: 90 },
+  { key: "note", name: "note", type: "text", width: 160, nullable: true },
+  { key: "created_at", name: "created_at", type: "timestamptz", width: 180 },
+  { key: "active", name: "active", type: "bool", width: 80 },
+];
+
+const rows: readonly GridRow[] = [
+  {
+    id: "r1",
+    status: "paid",
+    total: 42,
+    note: "VIP customer",
+    created_at: "2026-05-01T10:00:00Z",
+    active: "true",
+  },
+  {
+    id: "r2",
+    status: "pending",
+    total: 12,
+    note: null,
+    created_at: "2026-05-03T10:00:00Z",
+    active: "false",
+  },
+  {
+    id: "r3",
+    status: "paid",
+    total: 99,
+    note: "expedite",
+    created_at: "2026-05-05T10:00:00Z",
+    active: "true",
+  },
+];
+
+function clause(
+  id: string,
+  columnKey: string,
+  operator: FilterClause["operator"],
+  value?: string,
+  logic: FilterClause["logic"] = "and",
+): FilterClause {
+  return { id, columnKey, operator, value, logic };
+}
+
+describe("filterRows", () => {
+  it("supports multiple clauses against the same column", () => {
+    const result = filterRows(rows, columns, [
+      clause("a", "status", "equals", "paid"),
+      clause("b", "status", "notEquals", "pending"),
+      clause("c", "total", "greaterThan", "50"),
+    ]);
+
+    expect(result.map((row) => row.id)).toEqual(["r3"]);
+  });
+
+  it("combines clauses with OR when requested", () => {
+    const result = filterRows(rows, columns, [
+      clause("a", "status", "equals", "pending"),
+      clause("b", "total", "greaterThan", "90", "or"),
+    ]);
+
+    expect(result.map((row) => row.id)).toEqual(["r2", "r3"]);
+  });
+
+  it("evaluates null and string operators deterministically", () => {
+    expect(
+      filterRows(rows, columns, [clause("a", "note", "isNull")]).map(
+        (row) => row.id,
+      ),
+    ).toEqual(["r2"]);
+    expect(
+      filterRows(rows, columns, [clause("a", "note", "contains", "vip")]).map(
+        (row) => row.id,
+      ),
+    ).toEqual(["r1"]);
+  });
+
+  it("uses pending edit values without dropping the pending change", () => {
+    const changes: PendingChanges = {
+      r2: {
+        kind: "update",
+        edits: { status: { from: "pending", to: "paid" } },
+      },
+    };
+
+    const result = filterRows(
+      rows,
+      columns,
+      [clause("a", "status", "equals", "paid")],
+      changes,
+    );
+
+    expect(result.map((row) => row.id)).toEqual(["r1", "r2", "r3"]);
+    expect(changes.r2?.edits.status?.to).toBe("paid");
+  });
+});
+
+describe("operatorsForColumn", () => {
+  it("omits text-only operators for numeric and boolean columns", () => {
+    expect(operatorsForColumn(columns[1]!)).toEqual([
+      "equals",
+      "notEquals",
+      "greaterThan",
+      "lessThan",
+    ]);
+    expect(operatorsForColumn(columns[4]!)).toEqual(["equals", "notEquals"]);
+  });
+
+  it("adds null operators only for nullable columns", () => {
+    expect(operatorsForColumn(columns[2]!)).toContain("isNull");
+    expect(operatorsForColumn(columns[0]!)).not.toContain("isNull");
+  });
+});
+
+describe("evaluateFilterClause", () => {
+  it("compares dates through parseable timestamps", () => {
+    expect(
+      evaluateFilterClause(rows[2]!.created_at, columns[3]!, {
+        id: "a",
+        columnKey: "created_at",
+        operator: "greaterThan",
+        value: "2026-05-04T00:00:00Z",
+        logic: "and",
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/data-grid/src/filters.ts
+++ b/packages/data-grid/src/filters.ts
@@ -1,0 +1,225 @@
+import type {
+  FilterClause,
+  FilterLogic,
+  FilterOperator,
+  GridColumn,
+  GridRow,
+  PendingChanges,
+} from "./types";
+
+export const FILTER_OPERATORS: readonly {
+  value: FilterOperator;
+  label: string;
+  needsValue: boolean;
+}[] = [
+  { value: "equals", label: "=", needsValue: true },
+  { value: "notEquals", label: "!=", needsValue: true },
+  { value: "contains", label: "contains", needsValue: true },
+  { value: "startsWith", label: "starts with", needsValue: true },
+  { value: "greaterThan", label: ">", needsValue: true },
+  { value: "lessThan", label: "<", needsValue: true },
+  { value: "isNull", label: "is null", needsValue: false },
+  { value: "isNotNull", label: "is not null", needsValue: false },
+];
+
+const NUMERIC_TYPES = [
+  "int",
+  "int2",
+  "int4",
+  "int8",
+  "integer",
+  "bigint",
+  "smallint",
+  "serial",
+  "bigserial",
+  "float",
+  "float4",
+  "float8",
+  "real",
+  "double",
+  "numeric",
+  "decimal",
+  "money",
+  "oid",
+];
+
+const DATE_TYPES = ["date", "time", "timestamp", "timestamptz", "timetz"];
+const BOOL_TYPES = ["bool", "boolean"];
+const TEXT_TYPES = ["text", "char", "varchar", "citext", "uuid", "json", "jsonb"];
+
+export function operatorMeta(operator: FilterOperator) {
+  return FILTER_OPERATORS.find((op) => op.value === operator) ?? FILTER_OPERATORS[0]!;
+}
+
+export function filterOperatorLabel(operator: FilterOperator): string {
+  return operatorMeta(operator).label;
+}
+
+export function filterNeedsValue(operator: FilterOperator): boolean {
+  return operatorMeta(operator).needsValue;
+}
+
+export function operatorsForColumn(column: GridColumn): FilterOperator[] {
+  const base: FilterOperator[] = ["equals", "notEquals"];
+  const category = columnCategory(column);
+
+  if (category === "text") {
+    base.push("contains", "startsWith");
+  }
+
+  if (category === "number" || category === "date") {
+    base.push("greaterThan", "lessThan");
+  }
+
+  if (column.nullable) {
+    base.push("isNull", "isNotNull");
+  }
+
+  return base;
+}
+
+export function nextOperatorForColumn(
+  column: GridColumn,
+  operator: FilterOperator,
+): FilterOperator {
+  const operators = operatorsForColumn(column);
+  return operators.includes(operator) ? operator : operators[0]!;
+}
+
+export function filterRows(
+  rows: readonly GridRow[],
+  columns: readonly GridColumn[],
+  filters: readonly FilterClause[],
+  changes: PendingChanges = {},
+): GridRow[] {
+  if (filters.length === 0) return [...rows];
+  const columnsByKey = new Map(columns.map((column) => [column.key, column]));
+  const validFilters = filters.filter((clause) => {
+    const column = columnsByKey.get(clause.columnKey);
+    return column && operatorsForColumn(column).includes(clause.operator);
+  });
+
+  if (validFilters.length === 0) return [...rows];
+  return rows.filter((row) => rowMatchesFilters(row, columnsByKey, validFilters, changes));
+}
+
+export function rowMatchesFilters(
+  row: GridRow,
+  columnsByKey: ReadonlyMap<string, GridColumn>,
+  filters: readonly FilterClause[],
+  changes: PendingChanges = {},
+): boolean {
+  let matched = false;
+
+  filters.forEach((clause, index) => {
+    const column = columnsByKey.get(clause.columnKey);
+    const clauseMatched = column
+      ? evaluateFilterClause(displayValue(row, clause.columnKey, changes), column, clause)
+      : true;
+    if (index === 0) {
+      matched = clauseMatched;
+      return;
+    }
+    matched =
+      normalizedLogic(clause.logic) === "or"
+        ? matched || clauseMatched
+        : matched && clauseMatched;
+  });
+
+  return matched;
+}
+
+export function evaluateFilterClause(
+  rawValue: GridRow[string],
+  column: GridColumn,
+  clause: FilterClause,
+): boolean {
+  if (!operatorsForColumn(column).includes(clause.operator)) return true;
+  const value = rawValue ?? null;
+
+  if (clause.operator === "isNull") return value === null;
+  if (clause.operator === "isNotNull") return value !== null;
+
+  const needle = clause.value ?? "";
+  if (needle.length === 0) return true;
+
+  const category = columnCategory(column);
+  if (clause.operator === "greaterThan" || clause.operator === "lessThan") {
+    return compareOrdered(value, needle, category, clause.operator);
+  }
+
+  const current = normalizeString(value);
+  const expected = normalizeString(needle);
+
+  if (clause.operator === "equals") return current === expected;
+  if (clause.operator === "notEquals") return current !== expected;
+  if (clause.operator === "contains") return current.includes(expected);
+  if (clause.operator === "startsWith") return current.startsWith(expected);
+  return true;
+}
+
+export function filterValuePreview(clause: FilterClause): string {
+  if (!filterNeedsValue(clause.operator)) return "";
+  const value = clause.value ?? "";
+  return `"${value.replaceAll('"', '\\"')}"`;
+}
+
+export function createFilterId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `filter-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+function displayValue(
+  row: GridRow,
+  columnKey: string,
+  changes: PendingChanges,
+): GridRow[string] {
+  return changes[row.id]?.edits[columnKey]?.to ?? row[columnKey];
+}
+
+function compareOrdered(
+  value: string | number | null,
+  needle: string,
+  category: ReturnType<typeof columnCategory>,
+  operator: "greaterThan" | "lessThan",
+): boolean {
+  if (value === null) return false;
+
+  let left: number;
+  let right: number;
+  if (category === "number") {
+    left = Number(value);
+    right = Number(needle);
+  } else if (category === "date") {
+    left = Date.parse(String(value));
+    right = Date.parse(needle);
+  } else {
+    return false;
+  }
+
+  if (!Number.isFinite(left) || !Number.isFinite(right)) return false;
+  return operator === "greaterThan" ? left > right : left < right;
+}
+
+function columnCategory(
+  column: GridColumn,
+): "text" | "number" | "date" | "bool" | "unknown" {
+  if (column.enum) return "text";
+  const type = column.type.toLowerCase();
+  if (BOOL_TYPES.some((t) => type.includes(t))) return "bool";
+  if (NUMERIC_TYPES.some((t) => type.includes(t))) return "number";
+  if (DATE_TYPES.some((t) => type.includes(t))) return "date";
+  if (TEXT_TYPES.some((t) => type.includes(t))) return "text";
+  return "unknown";
+}
+
+function normalizeString(value: string | number | null): string {
+  if (value === null) return "";
+  return String(value).toLowerCase();
+}
+
+function normalizedLogic(logic: FilterLogic): FilterLogic {
+  return logic === "or" ? "or" : "and";
+}

--- a/packages/data-grid/src/index.ts
+++ b/packages/data-grid/src/index.ts
@@ -4,6 +4,9 @@ export type {
   CellChange,
   ChangeKind,
   ColumnFilters,
+  FilterClause,
+  FilterLogic,
+  FilterOperator,
   GridColumn,
   GridRow,
   GridStatusCounts,
@@ -12,6 +15,18 @@ export type {
 } from "./types";
 
 export { countChanges, statusDotColor, statusTextColor } from "./status";
+export {
+  FILTER_OPERATORS,
+  createFilterId,
+  evaluateFilterClause,
+  filterNeedsValue,
+  filterOperatorLabel,
+  filterRows,
+  filterValuePreview,
+  nextOperatorForColumn,
+  operatorsForColumn,
+  rowMatchesFilters,
+} from "./filters";
 export { DataGrid, useGridState, type DataGridProps } from "./DataGrid";
 export { CellEditor, CellValue, type CellEditorProps } from "./Cell";
 export { FilterBar, type FilterBarProps } from "./FilterBar";

--- a/packages/data-grid/src/types.ts
+++ b/packages/data-grid/src/types.ts
@@ -49,7 +49,28 @@ export type CellAddress = {
   col: number;
 };
 
-export type ColumnFilters = Record<string, string>;
+export type FilterLogic = "and" | "or";
+
+export type FilterOperator =
+  | "equals"
+  | "notEquals"
+  | "contains"
+  | "startsWith"
+  | "greaterThan"
+  | "lessThan"
+  | "isNull"
+  | "isNotNull";
+
+export type FilterClause = {
+  id: string;
+  columnKey: string;
+  operator: FilterOperator;
+  value?: string;
+  /** Joins this clause to the previous clause. Ignored for the first clause. */
+  logic: FilterLogic;
+};
+
+export type ColumnFilters = FilterClause[];
 
 export type GridStatusCounts = {
   total: number;


### PR DESCRIPTION
## Summary
- Replace the grid filter state with typed multi-clause filters that support duplicate columns and AND/OR joins.
- Add a compact inline filter composer with column/operator/value controls, editable chips, remove buttons, clear-all, and loaded-page row counts.
- Add deterministic local loaded-page filter evaluation with type-aware operator availability and pending-edit aware values.

## Validation
- pnpm --filter @cellar/data-grid test
- pnpm --filter @cellar/data-grid lint
- pnpm typecheck
- pnpm test
- pnpm lint
- pnpm --filter @cellar/desktop build
