### PR TITLE
feat: add grid column sorting

### DIFF
--- a/apps/desktop/src/components/Workspace.tsx
+++ b/apps/desktop/src/components/Workspace.tsx
@@ -85,6 +85,8 @@ function TableTabPane({
         onEdit={grid.setEditing}
         filters={grid.filters}
         onFiltersChange={grid.setFilters}
+        sort={grid.sort}
+        onSortChange={grid.setSort}
         onCommit={onCommit}
         onRevert={() => clearTableChanges(tab.id)}
       />

--- a/apps/desktop/src/hooks/useTableData.ts
+++ b/apps/desktop/src/hooks/useTableData.ts
@@ -1,6 +1,11 @@
 import { commands, unwrap } from "@cellar/ipc";
 import type { CellValue, QueryResult, TableBrowseRequest } from "@cellar/ipc";
-import type { CellAlign, GridColumn, GridRow } from "@cellar/data-grid";
+import type {
+  CellAlign,
+  GridColumn,
+  GridRow,
+  GridValue,
+} from "@cellar/data-grid";
 import { useEffect, useState } from "react";
 
 import { useConnections } from "../state/connections";
@@ -272,12 +277,12 @@ function rowIdFor(row: GridRow, primaryKey: string[], index: number): string {
   );
 }
 
-function cellValueToGrid(value: CellValue): string | number | null {
+function cellValueToGrid(value: CellValue): GridValue {
   switch (value.type) {
     case "Null":
       return null;
     case "Bool":
-      return value.value ? "true" : "false";
+      return value.value;
     case "Int":
     case "Float":
       return value.value;
@@ -300,7 +305,7 @@ function cellValueToGrid(value: CellValue): string | number | null {
 }
 
 function gridValueToString(
-  value: string | number | null | undefined,
+  value: GridValue | undefined,
 ): string | null {
   if (value === null || value === undefined) return null;
   return String(value);

--- a/apps/desktop/src/styles/grid.css
+++ b/apps/desktop/src/styles/grid.css
@@ -304,7 +304,19 @@
   border-right: 1px solid var(--border-default);
 }
 .grid-header-cell:hover { background: var(--bg-2); }
+.grid-header-cell:focus-visible {
+  outline: 1.5px solid var(--accent);
+  outline-offset: -1.5px;
+  z-index: 4;
+}
 .grid-header-cell.frozen { background: var(--bg-1); }
+.grid-header-cell.is-sorted {
+  color: var(--fg-0);
+  background: color-mix(in oklab, var(--accent-soft) 42%, var(--bg-1));
+}
+.grid-header-cell.is-sorted.frozen {
+  background: color-mix(in oklab, var(--accent-soft) 42%, var(--bg-1));
+}
 .grid-header-icon { color: var(--fg-3); display: inline-flex; }
 .grid-header-name {
   overflow: hidden;
@@ -326,10 +338,15 @@
   width: 14px;
   height: 14px;
   color: var(--fg-3);
-  opacity: 0;
-  transition: opacity 0.1s;
+  opacity: 0.35;
+  transition: color 0.1s, opacity 0.1s;
 }
-.grid-header-cell:hover .grid-header-sort { opacity: 1; }
+.grid-header-cell:hover .grid-header-sort,
+.grid-header-cell:focus-visible .grid-header-sort { opacity: 1; }
+.grid-header-cell.is-sorted .grid-header-sort {
+  color: var(--accent);
+  opacity: 1;
+}
 .grid-col-resize {
   position: absolute;
   right: 0;

--- a/packages/data-grid/src/Cell.tsx
+++ b/packages/data-grid/src/Cell.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useRef, useState } from "react";
 import { GridIcon } from "./icons";
 import { statusDotColor, statusTextColor } from "./status";
-import type { GridColumn } from "./types";
+import type { GridColumn, GridValue } from "./types";
 
-type Value = string | number | null | undefined;
+type Value = GridValue | undefined;
 
 export function CellValue({ col, value }: { col: GridColumn; value: Value }) {
   if (value === null || value === undefined) {
@@ -21,7 +21,7 @@ export function CellValue({ col, value }: { col: GridColumn; value: Value }) {
   if (col.fk) {
     return (
       <span className="cell-fk">
-        <span className={col.mono ? "mono" : ""}>{value}</span>
+        <span className={col.mono ? "mono" : ""}>{String(value)}</span>
         <button className="cell-fk-jump" title={`Jump to ${col.fk}`}>
           <GridIcon.link2 size={9} />
         </button>
@@ -31,11 +31,11 @@ export function CellValue({ col, value }: { col: GridColumn; value: Value }) {
   if (col.align === "right") {
     return (
       <span className="mono tnum" style={{ textAlign: "right", width: "100%" }}>
-        {value}
+        {String(value)}
       </span>
     );
   }
-  return <span className={col.mono ? "mono" : ""}>{value}</span>;
+  return <span className={col.mono ? "mono" : ""}>{String(value)}</span>;
 }
 
 export type CellEditorProps = {

--- a/packages/data-grid/src/DataGrid.tsx
+++ b/packages/data-grid/src/DataGrid.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CellEditor, CellValue } from "./Cell";
 import { FilterBar } from "./FilterBar";
 import { filterRows } from "./filters";
 import { GridIcon } from "./icons";
 import { PendingBar } from "./PendingBar";
+import { cycleSortState, sortGridRows } from "./sort";
 import { TypeIcon } from "./TypeIcon";
 import type {
   CellAddress,
@@ -13,6 +14,7 @@ import type {
   GridRow,
   PendingChange,
   PendingChanges,
+  SortState,
 } from "./types";
 
 const ROWNO_WIDTH = 36;
@@ -33,6 +35,9 @@ export type DataGridProps = {
 
   filters: ColumnFilters;
   onFiltersChange: (next: ColumnFilters) => void;
+
+  sort?: SortState;
+  onSortChange?: (next: SortState) => void;
 
   /**
    * Number of leftmost columns to freeze. The frozen columns stick to the left
@@ -68,21 +73,89 @@ export function DataGrid({
   onEdit,
   filters,
   onFiltersChange,
+  sort,
+  onSortChange,
   frozenCount = 2,
   totalRows,
   onCommit,
   onRevert,
   readOnly = false,
 }: DataGridProps) {
+  const [internalSort, setInternalSort] = useState<SortState>(null);
+  const activeSort = sort ?? internalSort;
+
   // Local search across visible page. Server-side filtering happens upstream
   // for large tables; the chips drive both.
-  const visibleRows = useMemo(() => {
+  const filteredRows = useMemo(() => {
     return filterRows(rows, columns, filters, changes);
   }, [rows, columns, filters, changes]);
+
+  const visibleRows = useMemo(
+    () => sortGridRows(filteredRows, columns, activeSort, changes),
+    [filteredRows, columns, activeSort, changes],
+  );
 
   const minTableWidth = useMemo(
     () => columns.reduce((acc, c) => acc + c.width, ROWNO_WIDTH + 8),
     [columns],
+  );
+
+  const applySort = useCallback(
+    (next: SortState) => {
+      if (sort === undefined) setInternalSort(next);
+      onSortChange?.(next);
+    },
+    [onSortChange, sort],
+  );
+
+  const translateAddress = useCallback(
+    (
+      address: CellAddress | null,
+      before: readonly GridRow[],
+      after: readonly GridRow[],
+    ): CellAddress | null => {
+      if (!address) return null;
+      const row = before[address.row];
+      if (!row) return null;
+      const nextRow = after.findIndex((candidate) => candidate.id === row.id);
+      if (nextRow === -1) return null;
+      return { row: nextRow, col: address.col };
+    },
+    [],
+  );
+
+  const sameAddress = useCallback(
+    (left: CellAddress | null, right: CellAddress | null) =>
+      left?.row === right?.row && left?.col === right?.col,
+    [],
+  );
+
+  const previousVisibleRows = useRef<readonly GridRow[]>(visibleRows);
+  useEffect(() => {
+    const before = previousVisibleRows.current;
+    previousVisibleRows.current = visibleRows;
+    if (before === visibleRows) return;
+
+    const nextSelection = translateAddress(selection, before, visibleRows);
+    const nextEditing = translateAddress(editing, before, visibleRows);
+    if (!sameAddress(nextSelection, selection)) onSelect(nextSelection);
+    if (!sameAddress(nextEditing, editing)) onEdit(nextEditing);
+  }, [
+    editing,
+    onEdit,
+    onSelect,
+    sameAddress,
+    selection,
+    translateAddress,
+    visibleRows,
+  ]);
+
+  const handleSort = useCallback(
+    (columnKey: string) => {
+      const next = cycleSortState(activeSort, columnKey);
+      applySort(next);
+    },
+    [activeSort, applySort],
   );
 
   const handleCellEdit = useCallback(
@@ -129,31 +202,58 @@ export function DataGrid({
             <div className="grid-cell grid-cell-rowno">
               <GridIcon.hash size={9} stroke="var(--fg-3)" />
             </div>
-            {columns.map((c, ci) => (
-              <div
-                key={c.key}
-                className={
-                  "grid-cell grid-header-cell" +
-                  (ci < frozenCount ? " frozen" : "")
-                }
-                style={{ width: c.width, flexBasis: c.width }}
-              >
-                <span className="grid-header-icon">
-                  <TypeIcon col={c} />
-                </span>
-                <span className="grid-header-name">{c.name}</span>
-                <span className="grid-header-type">{c.type}</span>
-                <button
-                  className="grid-header-sort"
-                  aria-label={`Sort ${c.name}`}
-                  disabled
-                  title="Sorting is not available yet"
+            {columns.map((c, ci) => {
+              const sorted = activeSort?.columnKey === c.key ? activeSort : null;
+              const ariaSort =
+                sorted?.direction === "asc"
+                  ? "ascending"
+                  : sorted?.direction === "desc"
+                    ? "descending"
+                    : "none";
+              const SortIcon =
+                sorted?.direction === "desc"
+                  ? GridIcon.sortDesc
+                  : GridIcon.sortAsc;
+              const nextSortLabel =
+                sorted?.direction === "asc"
+                  ? "Sort descending"
+                  : sorted?.direction === "desc"
+                    ? "Clear sort"
+                    : "Sort ascending";
+              return (
+                <div
+                  key={c.key}
+                  className={
+                    "grid-cell grid-header-cell" +
+                    (ci < frozenCount ? " frozen" : "") +
+                    (sorted ? " is-sorted" : "")
+                  }
+                  role="columnheader"
+                  aria-sort={ariaSort}
+                  aria-label={`${c.name}, ${c.type}. ${nextSortLabel}.`}
+                  tabIndex={0}
+                  style={{ width: c.width, flexBasis: c.width }}
+                  title={nextSortLabel}
+                  onClick={() => handleSort(c.key)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      handleSort(c.key);
+                    }
+                  }}
                 >
-                  <GridIcon.sortAsc size={10} />
-                </button>
-                <span className="grid-col-resize" />
-              </div>
-            ))}
+                  <span className="grid-header-icon">
+                    <TypeIcon col={c} />
+                  </span>
+                  <span className="grid-header-name">{c.name}</span>
+                  <span className="grid-header-type">{c.type}</span>
+                  <span className="grid-header-sort" aria-hidden="true">
+                    <SortIcon size={10} />
+                  </span>
+                  <span className="grid-col-resize" />
+                </div>
+              );
+            })}
           </div>
 
           {visibleRows.map((row, ri) => {
@@ -242,7 +342,9 @@ export function DataGrid({
                           title={`Was: ${cellChange.from ?? "NULL"}`}
                         >
                           <span className="grid-cell-prev-strike">
-                            {cellChange.from === null ? "NULL" : cellChange.from}
+                            {cellChange.from === null
+                              ? "NULL"
+                              : String(cellChange.from)}
                           </span>
                         </span>
                       )}
@@ -275,6 +377,7 @@ export function DataGrid({
 export type UseGridStateOptions = {
   initialFilters?: ColumnFilters;
   initialChanges?: PendingChanges;
+  initialSort?: SortState;
 };
 
 /**
@@ -285,9 +388,11 @@ export type UseGridStateOptions = {
 export function useGridState({
   initialFilters = [],
   initialChanges = {},
+  initialSort = null,
 }: UseGridStateOptions = {}) {
   const [filters, setFilters] = useState<ColumnFilters>(initialFilters);
   const [changes, setChanges] = useState<PendingChanges>(initialChanges);
+  const [sort, setSort] = useState<SortState>(initialSort);
   const [selection, setSelection] = useState<CellAddress | null>(null);
   const [editing, setEditing] = useState<CellAddress | null>(null);
 
@@ -298,6 +403,8 @@ export function useGridState({
     setFilters,
     changes,
     setChanges,
+    sort,
+    setSort,
     selection,
     setSelection,
     editing,

--- a/packages/data-grid/src/filters.ts
+++ b/packages/data-grid/src/filters.ts
@@ -180,12 +180,12 @@ function displayValue(
 }
 
 function compareOrdered(
-  value: string | number | null,
+  value: GridRow[string],
   needle: string,
   category: ReturnType<typeof columnCategory>,
   operator: "greaterThan" | "lessThan",
 ): boolean {
-  if (value === null) return false;
+  if (value === null || value === undefined) return false;
 
   let left: number;
   let right: number;
@@ -215,8 +215,8 @@ function columnCategory(
   return "unknown";
 }
 
-function normalizeString(value: string | number | null): string {
-  if (value === null) return "";
+function normalizeString(value: GridRow[string]): string {
+  if (value === null || value === undefined) return "";
   return String(value).toLowerCase();
 }
 

--- a/packages/data-grid/src/icons.tsx
+++ b/packages/data-grid/src/icons.tsx
@@ -58,6 +58,11 @@ export const GridIcon = {
       <path d="M7 4v16M3 16l4 4 4-4" />
     </I>
   ),
+  sortDesc: (p: IconProps) => (
+    <I {...p}>
+      <path d="M7 20V4M3 8l4-4 4 4" />
+    </I>
+  ),
   key: (p: IconProps) => (
     <I {...p}>
       <circle cx="8" cy="15" r="4" />

--- a/packages/data-grid/src/index.ts
+++ b/packages/data-grid/src/index.ts
@@ -9,9 +9,13 @@ export type {
   FilterOperator,
   GridColumn,
   GridRow,
+  GridValue,
   GridStatusCounts,
   PendingChange,
   PendingChanges,
+  SortClause,
+  SortDirection,
+  SortState,
 } from "./types";
 
 export { countChanges, statusDotColor, statusTextColor } from "./status";
@@ -27,6 +31,7 @@ export {
   operatorsForColumn,
   rowMatchesFilters,
 } from "./filters";
+export { compareGridValues, cycleSortState, sortGridRows } from "./sort";
 export { DataGrid, useGridState, type DataGridProps } from "./DataGrid";
 export { CellEditor, CellValue, type CellEditorProps } from "./Cell";
 export { FilterBar, type FilterBarProps } from "./FilterBar";

--- a/packages/data-grid/src/sort.test.ts
+++ b/packages/data-grid/src/sort.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import type { GridColumn, GridRow, PendingChanges } from "./types";
+import { compareGridValues, cycleSortState, sortGridRows } from "./sort";
+
+const columns: readonly GridColumn[] = [
+  { key: "name", name: "name", type: "text", width: 120 },
+  { key: "amount", name: "amount", type: "numeric", width: 90 },
+  { key: "active", name: "active", type: "bool", width: 70 },
+  { key: "created_at", name: "created_at", type: "timestamptz", width: 180 },
+];
+
+describe("cycleSortState", () => {
+  it("cycles unsorted to ascending to descending to unsorted", () => {
+    const asc = cycleSortState(null, "name");
+    expect(asc).toEqual({ columnKey: "name", direction: "asc" });
+    const desc = cycleSortState(asc, "name");
+    expect(desc).toEqual({ columnKey: "name", direction: "desc" });
+    expect(cycleSortState(desc, "name")).toBeNull();
+  });
+
+  it("starts ascending when switching columns", () => {
+    expect(
+      cycleSortState({ columnKey: "amount", direction: "desc" }, "name"),
+    ).toEqual({ columnKey: "name", direction: "asc" });
+  });
+});
+
+describe("compareGridValues", () => {
+  it("sorts nullish values after real values", () => {
+    expect(compareGridValues(null, "A", columns[0]!)).toBeGreaterThan(0);
+    expect(compareGridValues(undefined, null, columns[0]!)).toBe(0);
+  });
+
+  it("sorts numeric strings by numeric value for numeric columns", () => {
+    expect(compareGridValues("9.5", "10", columns[1]!)).toBeLessThan(0);
+  });
+
+  it("sorts booleans false before true", () => {
+    expect(compareGridValues(false, true, columns[2]!)).toBeLessThan(0);
+    expect(compareGridValues("true", "false", columns[2]!)).toBeGreaterThan(0);
+  });
+
+  it("sorts practical date-like strings chronologically", () => {
+    expect(
+      compareGridValues(
+        "2026-05-28 09:00:00+00",
+        "2026-05-29 08:00:00+00",
+        columns[3]!,
+      ),
+    ).toBeLessThan(0);
+  });
+});
+
+describe("sortGridRows", () => {
+  const rows: readonly GridRow[] = [
+    { id: "r1", name: "A", amount: "10", active: true },
+    { id: "r2", name: "B", amount: "2", active: false },
+    { id: "r3", name: "C", amount: "2", active: true },
+    { id: "r4", name: "D", amount: null, active: false },
+  ];
+
+  it("sorts stably and keeps row ids attached to their rows", () => {
+    expect(
+      sortGridRows(rows, columns, { columnKey: "amount", direction: "asc" }).map(
+        (row) => row.id,
+      ),
+    ).toEqual(["r2", "r3", "r1", "r4"]);
+  });
+
+  it("uses pending displayed values for local ordering", () => {
+    const changes: PendingChanges = {
+      r1: { kind: "update", edits: { amount: { from: "10", to: "1" } } },
+    };
+    expect(
+      sortGridRows(
+        rows,
+        columns,
+        { columnKey: "amount", direction: "asc" },
+        changes,
+      ).map((row) => row.id),
+    ).toEqual(["r1", "r2", "r3", "r4"]);
+  });
+});

--- a/packages/data-grid/src/sort.ts
+++ b/packages/data-grid/src/sort.ts
@@ -1,0 +1,210 @@
+import type {
+  GridColumn,
+  GridRow,
+  GridValue,
+  PendingChanges,
+  SortState,
+} from "./types";
+
+export function cycleSortState(
+  current: SortState,
+  columnKey: string,
+): SortState {
+  // Database grids benefit from a reversible three-state cycle: first click
+  // sorts ascending, second descending, third returns to the source/page order.
+  if (!current || current.columnKey !== columnKey) {
+    return { columnKey, direction: "asc" };
+  }
+  if (current.direction === "asc") {
+    return { columnKey, direction: "desc" };
+  }
+  return null;
+}
+
+export function sortGridRows(
+  rows: readonly GridRow[],
+  columns: readonly GridColumn[],
+  sort: SortState,
+  changes: PendingChanges = {},
+): GridRow[] {
+  if (!sort) return [...rows];
+
+  const column = columns.find((c) => c.key === sort.columnKey);
+  if (!column) return [...rows];
+
+  const direction = sort.direction === "asc" ? 1 : -1;
+  return rows
+    .map((row, index) => ({ row, index }))
+    .sort((a, b) => {
+      const compared =
+        compareGridValues(
+          sortValueFor(a.row, sort.columnKey, changes),
+          sortValueFor(b.row, sort.columnKey, changes),
+          column,
+        ) * direction;
+      return compared === 0 ? a.index - b.index : compared;
+    })
+    .map(({ row }) => row);
+}
+
+export function compareGridValues(
+  left: GridValue | undefined,
+  right: GridValue | undefined,
+  column?: GridColumn,
+): number {
+  const a = normalizeNull(left);
+  const b = normalizeNull(right);
+  if (a === null && b === null) return 0;
+  if (a === null) return 1;
+  if (b === null) return -1;
+
+  const boolA = booleanValue(a, column);
+  const boolB = booleanValue(b, column);
+  if (boolA !== null && boolB !== null) {
+    return Number(boolA) - Number(boolB);
+  }
+
+  const numA = numericValue(a, column);
+  const numB = numericValue(b, column);
+  if (numA !== null && numB !== null) {
+    return numA === numB ? 0 : numA < numB ? -1 : 1;
+  }
+
+  const timeA = temporalValue(a, column);
+  const timeB = temporalValue(b, column);
+  if (timeA !== null && timeB !== null) {
+    return timeA === timeB ? 0 : timeA < timeB ? -1 : 1;
+  }
+
+  return stringCompare(String(a), String(b));
+}
+
+function sortValueFor(
+  row: GridRow,
+  columnKey: string,
+  changes: PendingChanges,
+): GridValue | undefined {
+  return changes[row.id]?.edits[columnKey]?.to ?? row[columnKey];
+}
+
+function normalizeNull(value: GridValue | undefined): GridValue | null {
+  return value === undefined ? null : value;
+}
+
+function booleanValue(
+  value: Exclude<GridValue, null>,
+  column?: GridColumn,
+): boolean | null {
+  if (typeof value === "boolean") return value;
+  if (!column || !isBooleanType(column.type)) return null;
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return null;
+}
+
+function numericValue(
+  value: Exclude<GridValue, null>,
+  column?: GridColumn,
+): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (!column || !isNumericType(column.type)) return null;
+  if (typeof value !== "string" || value.trim() === "") return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function temporalValue(
+  value: Exclude<GridValue, null>,
+  column?: GridColumn,
+): number | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (trimmed === "") return null;
+
+  if (column && isTimeOnlyType(column.type)) {
+    return timeOnlyValue(trimmed);
+  }
+
+  if (!looksDateLike(trimmed) && (!column || !isTemporalType(column.type))) {
+    return null;
+  }
+
+  const normalized = normalizeDateString(trimmed);
+  const parsed = Date.parse(normalized);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function timeOnlyValue(value: string): number | null {
+  const match = /^(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,6}))?)?/.exec(value);
+  if (!match) return null;
+  const hours = Number(match[1]);
+  const minutes = Number(match[2]);
+  const seconds = Number(match[3] ?? "0");
+  if (hours > 23 || minutes > 59 || seconds > 59) return null;
+  return ((hours * 60 + minutes) * 60 + seconds) * 1000;
+}
+
+function normalizeDateString(value: string): string {
+  let out = value.includes("T") ? value : value.replace(" ", "T");
+  out = out.replace(/([+-]\d{2})$/, "$1:00");
+  return out;
+}
+
+function looksDateLike(value: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}(?:[ T]\d{2}:\d{2})?/.test(value);
+}
+
+function isBooleanType(type: string): boolean {
+  const t = type.toLowerCase();
+  return t === "bool" || t === "boolean";
+}
+
+function isNumericType(type: string): boolean {
+  const t = type.toLowerCase();
+  return (
+    t === "int2" ||
+    t === "int4" ||
+    t === "int8" ||
+    t === "integer" ||
+    t === "bigint" ||
+    t === "smallint" ||
+    t === "oid" ||
+    t === "float4" ||
+    t === "float8" ||
+    t === "real" ||
+    t === "double precision" ||
+    t === "numeric" ||
+    t.startsWith("numeric(") ||
+    t.startsWith("decimal(")
+  );
+}
+
+function isTemporalType(type: string): boolean {
+  const t = type.toLowerCase();
+  return (
+    t === "date" ||
+    t === "time" ||
+    t === "timetz" ||
+    t === "timestamp" ||
+    t === "timestamptz" ||
+    t.startsWith("timestamp(") ||
+    t.startsWith("time(")
+  );
+}
+
+function isTimeOnlyType(type: string): boolean {
+  const t = type.toLowerCase();
+  return t === "time" || t === "timetz" || t.startsWith("time(");
+}
+
+function stringCompare(left: string, right: string): number {
+  const primary = left.localeCompare(right, undefined, {
+    numeric: true,
+    sensitivity: "base",
+  });
+  if (primary !== 0) return primary;
+  return left.localeCompare(right, undefined, {
+    numeric: true,
+    sensitivity: "variant",
+  });
+}

--- a/packages/data-grid/src/types.ts
+++ b/packages/data-grid/src/types.ts
@@ -1,6 +1,7 @@
 /** Public types for the Cellar data grid. */
 
 export type CellAlign = "left" | "right" | "center";
+export type GridValue = string | number | boolean | null;
 
 /**
  * A single column definition. Mirrors a SQL column with enough metadata for the
@@ -23,15 +24,28 @@ export type GridColumn = {
 /** Row values are keyed by column key. Use `null` for SQL NULL. */
 export type GridRow = {
   id: string;
-  [key: string]: string | number | null | undefined;
+  [key: string]: GridValue | undefined;
 };
 
 export type ChangeKind = "insert" | "update" | "delete";
 
 export type CellChange = {
-  from: string | number | null;
-  to: string | number | null;
+  from: GridValue;
+  to: GridValue;
 };
+
+export type SortDirection = "asc" | "desc";
+
+/**
+ * Single-column sort intent. The host can map this to a server request later;
+ * the grid uses the same model for local page sorting in the current slice.
+ */
+export type SortClause = {
+  columnKey: string;
+  direction: SortDirection;
+};
+
+export type SortState = SortClause | null;
 
 /**
  * A pending change against a row. `edits` is sparse — only the columns the user


### PR DESCRIPTION
## Summary
- Adds single-column sort state and callbacks to the data grid for future server-backed table browsing.
- Enables header click, Enter, and Space sorting with visible active state, direction icons, and `aria-sort`.
- Sorts the loaded page locally with stable, type-aware comparison while preserving row-id based pending edits and selection/editor anchors.

## Validation
- `pnpm --filter @cellar/data-grid test`
- `pnpm --filter @cellar/data-grid lint`
- `pnpm typecheck`
- `git diff --check`