### PR TITLE
feat: add SQL editor for query tabs

### DIFF
--- a/apps/desktop/src/components/BottomPanel.tsx
+++ b/apps/desktop/src/components/BottomPanel.tsx
@@ -22,6 +22,7 @@ import {
   type NoticeLogEntry,
   type NoticeScope,
 } from "../state/notices";
+import { useBottomPanel, type BottomTabId } from "../state/bottomPanel";
 import { useStatus } from "../state/status";
 import { useTabs, type TableTab } from "../state/tabs";
 import {
@@ -35,8 +36,6 @@ import { useQueryMessages } from "../state/queryMessages";
 import { PlanPanel } from "./BottomPlanPanel";
 import { MessagesView } from "./BottomMessagesPanel";
 import { Icon } from "./icons";
-
-type BottomTabId = "results" | "messages" | "plan" | "history" | "notices";
 
 type BPTab = {
   id: BottomTabId;
@@ -55,7 +54,8 @@ const BASE_TABS: Omit<BPTab, "count">[] = [
 ];
 
 export function BottomPanel({ onClose }: { onClose: () => void }) {
-  const [active, setActive] = useState<BottomTabId>("results");
+  const active = useBottomPanel((s) => s.active);
+  const setActive = useBottomPanel((s) => s.setActive);
   const [historyCount, setHistoryCount] = useState<number | null>(null);
   const activeTabId = useTabs((s) => s.activeId);
   const tabs = useTabs((s) => s.tabs);
@@ -253,7 +253,7 @@ function ResultsBody({
     return (
       <EmptyPanel
         title="No active tab"
-        detail="Open a table from the sidebar to load rows. SQL query-tab results will use this panel when the editor slice lands."
+        detail="Open a table from the sidebar to load rows, or open a SQL editor with + in the tab bar and run a query to populate this panel."
       />
     );
   }
@@ -270,7 +270,7 @@ function ResultsBody({
     return (
       <EmptyPanel
         title="Table rows are already shown"
-        detail={`${tableLabel(activeTab)} is a table-browsing tab. The Results grid is reserved for SQL query output, so it will light up when SQL editor tabs land.`}
+        detail={`${tableLabel(activeTab)} is a table-browsing tab. The Results grid is reserved for SQL query output — open a query tab and run a statement to use it.`}
       />
     );
   }
@@ -385,6 +385,8 @@ function HistoryPanel({
   const [error, setError] = useState<string | null>(null);
   const [copiedId, setCopiedId] = useState<number | null>(null);
   const lastQuery = useStatus((s) => s.lastQuery);
+  const newQueryTab = useTabs((s) => s.newQueryTab);
+  const setQuerySql = useTabs((s) => s.setQuerySql);
   const trimmedSearch = search.trim();
   const refreshKey =
     activeTab &&
@@ -487,6 +489,13 @@ function HistoryPanel({
                     window.setTimeout(() => setCopiedId(null), 1100);
                   });
                 }}
+                onReuse={() => {
+                  const id = newQueryTab(
+                    record.connection_id,
+                    record.database ?? "",
+                  );
+                  setQuerySql(id, record.sql);
+                }}
               />
             ))}
           </div>
@@ -500,10 +509,12 @@ function HistoryRow({
   record,
   copied,
   onCopy,
+  onReuse,
 }: {
   record: QueryHistoryRecord;
   copied: boolean;
   onCopy: () => void;
+  onReuse: () => void;
 }) {
   return (
     <div className="group grid grid-cols-[minmax(0,1fr)_auto] gap-3 px-2.5 py-2 hover:bg-bg-1">
@@ -539,7 +550,7 @@ function HistoryRow({
         <button className="icon-btn" onClick={onCopy} title="Copy SQL">
           {copied ? <Icon.check size={11} /> : <Icon.copy size={11} />}
         </button>
-        <button className="icon-btn opacity-45" disabled title="Reuse waits for the SQL editor">
+        <button className="icon-btn" onClick={onReuse} title="Open in a new query tab">
           <Icon.edit size={11} />
         </button>
       </div>

--- a/apps/desktop/src/components/BottomPlanPanel.tsx
+++ b/apps/desktop/src/components/BottomPlanPanel.tsx
@@ -1,6 +1,7 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { commands, unwrap, type PlanNode, type QueryPlan } from "@cellar/ipc";
 
+import { useBottomPanel } from "../state/bottomPanel";
 import { useConnections } from "../state/connections";
 import { useTabs, type QueryTab } from "../state/tabs";
 import { Icon } from "./icons";
@@ -25,6 +26,17 @@ export function PlanPanel({ activeTab }: { activeTab: WorkspaceTab | null }) {
     () => unavailableReason(activeTab, queryTab, connection, connected, sql),
     [activeTab, queryTab, connection, connected, sql],
   );
+
+  // The editor's "Explain plan" toolbar button bumps `explainNonce`; run a
+  // fresh plan when that happens (and the statement can actually be explained).
+  const explainNonce = useBottomPanel((s) => s.explainNonce);
+  const seenNonce = useRef(explainNonce);
+  useEffect(() => {
+    if (explainNonce === seenNonce.current) return;
+    seenNonce.current = explainNonce;
+    if (!unavailable && !loading) void loadPlan();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [explainNonce]);
 
   async function loadPlan() {
     if (!queryTab || unavailable) return;

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -66,6 +66,7 @@ export function Sidebar({
   const disconnect = useConnections((s) => s.disconnect);
   const deleteConnection = useConnections((s) => s.deleteConnection);
   const openTable = useTabs((s) => s.openTable);
+  const newQueryTab = useTabs((s) => s.newQueryTab);
   const activeTabId = useTabs((s) => s.activeId);
 
   useEffect(() => {
@@ -89,6 +90,18 @@ export function Sidebar({
       x: e.clientX,
       y: e.clientY,
       items: [
+        {
+          label: "New SQL query",
+          icon: <Icon.terminal size={12} />,
+          onClick: () => {
+            const dbs = byId[config.id]?.databases ?? [];
+            const database =
+              dbs.find((d) => d.is_default)?.name ??
+              dbs[0]?.name ??
+              config.database;
+            newQueryTab(config.id, database);
+          },
+        },
         {
           label: "Edit…",
           icon: <Icon.edit size={12} />,

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -3,9 +3,29 @@ import type { ConnectionConfig, Schema, Table } from "@cellar/ipc";
 
 import { Icon } from "./icons";
 import { EngineBadge, type Engine } from "./EngineBadge";
-import { ContextMenu, type ContextMenuState } from "./ContextMenu";
+import {
+  ContextMenu,
+  type ContextMenuState,
+  type MenuItem,
+} from "./ContextMenu";
 import { useConnections, type ConnStatus } from "../state/connections";
 import { useTabs } from "../state/tabs";
+import { qualifiedName, selectAllStatement } from "../lib/sqlIdent";
+
+/** A right-clickable node in the schema tree. */
+type SidebarNode =
+  | { kind: "database"; connectionId: string; database: string }
+  | { kind: "schema"; connectionId: string; database: string; schema: string }
+  | {
+      kind: "relation";
+      connectionId: string;
+      database: string;
+      schema: string;
+      name: string;
+      isView: boolean;
+    };
+
+type NodeMenuHandler = (e: React.MouseEvent, node: SidebarNode) => void;
 
 function StatusDot({ status }: { status: ConnStatus }) {
   const color =
@@ -65,8 +85,10 @@ export function Sidebar({
   const connect = useConnections((s) => s.connect);
   const disconnect = useConnections((s) => s.disconnect);
   const deleteConnection = useConnections((s) => s.deleteConnection);
+  const refreshSchema = useConnections((s) => s.refreshSchema);
   const openTable = useTabs((s) => s.openTable);
   const newQueryTab = useTabs((s) => s.newQueryTab);
+  const setQuerySql = useTabs((s) => s.setQuerySql);
   const activeTabId = useTabs((s) => s.activeId);
 
   useEffect(() => {
@@ -80,6 +102,100 @@ export function Sidebar({
     if (!q) return connections;
     return connections.filter((c) => c.name.toLowerCase().includes(q));
   }, [filter, connections]);
+
+  const copyText = (text: string) => {
+    if (navigator.clipboard) void navigator.clipboard.writeText(text);
+  };
+
+  const queryFor = (connectionId: string, database: string, sql?: string) => {
+    const id = newQueryTab(connectionId, database);
+    if (sql) setQuerySql(id, sql);
+  };
+
+  const nodeMenuItems = (node: SidebarNode): MenuItem[] => {
+    switch (node.kind) {
+      case "database":
+        return [
+          {
+            label: "New SQL query",
+            icon: <Icon.terminal size={12} />,
+            onClick: () => queryFor(node.connectionId, node.database),
+          },
+          {
+            label: "Refresh schemas",
+            icon: <Icon.history size={12} />,
+            onClick: () => void refreshSchema(node.connectionId),
+          },
+          {
+            label: "Copy name",
+            icon: <Icon.copy size={12} />,
+            onClick: () => copyText(node.database),
+          },
+        ];
+      case "schema":
+        return [
+          {
+            label: "New SQL query",
+            icon: <Icon.terminal size={12} />,
+            onClick: () => queryFor(node.connectionId, node.database),
+          },
+          {
+            label: "Copy qualified name",
+            icon: <Icon.copy size={12} />,
+            onClick: () => copyText(qualifiedName(node.database, node.schema)),
+          },
+          {
+            label: "Copy name",
+            icon: <Icon.copy size={12} />,
+            onClick: () => copyText(node.schema),
+          },
+        ];
+      case "relation":
+        return [
+          {
+            label: "Open",
+            icon: node.isView ? (
+              <Icon.tree size={12} />
+            ) : (
+              <Icon.table size={12} />
+            ),
+            onClick: () =>
+              openTable(
+                node.connectionId,
+                node.database,
+                node.schema,
+                node.name,
+              ),
+          },
+          {
+            label: "Query SELECT *",
+            icon: <Icon.terminal size={12} />,
+            onClick: () =>
+              queryFor(
+                node.connectionId,
+                node.database,
+                selectAllStatement(node.schema, node.name),
+              ),
+          },
+          {
+            label: "Copy qualified name",
+            icon: <Icon.copy size={12} />,
+            onClick: () => copyText(qualifiedName(node.schema, node.name)),
+          },
+          {
+            label: "Copy name",
+            icon: <Icon.copy size={12} />,
+            onClick: () => copyText(node.name),
+          },
+        ];
+    }
+  };
+
+  const openNodeMenu: NodeMenuHandler = (e, node) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setMenu({ x: e.clientX, y: e.clientY, items: nodeMenuItems(node) });
+  };
 
   const openConnectionMenu = (e: React.MouseEvent, config: ConnectionConfig) => {
     e.preventDefault();
@@ -195,6 +311,7 @@ export function Sidebar({
               onToggle={() => toggleExpand(c.id)}
               onDisconnect={() => void disconnect(c.id)}
               onContextMenu={(e) => openConnectionMenu(e, c)}
+              onNodeContextMenu={openNodeMenu}
               onOpenTable={(database, schema, table) =>
                 openTable(c.id, database, schema, table)
               }
@@ -227,6 +344,7 @@ interface ConnectionRowProps {
   onToggle: () => void;
   onDisconnect: () => void;
   onContextMenu: (e: React.MouseEvent) => void;
+  onNodeContextMenu: NodeMenuHandler;
   onOpenTable: (database: string, schema: string, table: string) => void;
   activeTabId: string | null;
 }
@@ -241,6 +359,7 @@ function ConnectionRow({
   onToggle,
   onDisconnect,
   onContextMenu,
+  onNodeContextMenu,
   onOpenTable,
   activeTabId,
 }: ConnectionRowProps) {
@@ -330,9 +449,11 @@ function ConnectionRow({
         databases.map((db) => (
           <DatabaseRow
             key={db.name}
+            connectionId={config.id}
             dbName={db.name}
             isDefault={db.is_default}
             schemas={db.schemas}
+            onNodeContextMenu={onNodeContextMenu}
             onOpenTable={onOpenTable}
             activeTabId={activeTabId}
           />
@@ -342,15 +463,19 @@ function ConnectionRow({
 }
 
 function DatabaseRow({
+  connectionId,
   dbName,
   isDefault,
   schemas,
+  onNodeContextMenu,
   onOpenTable,
   activeTabId,
 }: {
+  connectionId: string;
   dbName: string;
   isDefault: boolean;
   schemas: Schema[];
+  onNodeContextMenu: NodeMenuHandler;
   onOpenTable: (database: string, schema: string, table: string) => void;
   activeTabId: string | null;
 }) {
@@ -363,6 +488,9 @@ function DatabaseRow({
         className={ROW_BASE + " cursor-pointer"}
         style={{ paddingLeft: 18 }}
         onClick={() => !empty && setOpen((v) => !v)}
+        onContextMenu={(e) =>
+          onNodeContextMenu(e, { kind: "database", connectionId, database: dbName })
+        }
         title={empty ? "no accessible schemas" : undefined}
       >
         <button className={TWISTY}>
@@ -393,8 +521,10 @@ function DatabaseRow({
         schemas.map((sch) => (
           <SchemaRow
             key={sch.name}
+            connectionId={connectionId}
             database={dbName}
             schema={sch}
+            onNodeContextMenu={onNodeContextMenu}
             onOpenTable={onOpenTable}
             activeTabId={activeTabId}
           />
@@ -404,13 +534,17 @@ function DatabaseRow({
 }
 
 function SchemaRow({
+  connectionId,
   database,
   schema,
+  onNodeContextMenu,
   onOpenTable,
   activeTabId,
 }: {
+  connectionId: string;
   database: string;
   schema: Schema;
+  onNodeContextMenu: NodeMenuHandler;
   onOpenTable: (database: string, schema: string, table: string) => void;
   activeTabId: string | null;
 }) {
@@ -421,6 +555,14 @@ function SchemaRow({
         className={ROW_BASE + " cursor-pointer"}
         style={{ paddingLeft: 30 }}
         onClick={() => setOpen((v) => !v)}
+        onContextMenu={(e) =>
+          onNodeContextMenu(e, {
+            kind: "schema",
+            connectionId,
+            database,
+            schema: schema.name,
+          })
+        }
       >
         <button className={TWISTY}>
           {open ? (
@@ -445,10 +587,12 @@ function SchemaRow({
           {schema.tables.map((t) => (
             <TableRow
               key={t.name}
+              connectionId={connectionId}
               database={database}
               schema={schema.name}
               table={t}
               onOpen={() => onOpenTable(database, schema.name, t.name)}
+              onNodeContextMenu={onNodeContextMenu}
               activeTabId={activeTabId}
             />
           ))}
@@ -461,6 +605,16 @@ function SchemaRow({
                   className={ROW_BASE + " cursor-pointer"}
                   style={{ paddingLeft: 54 }}
                   onClick={() => onOpenTable(database, schema.name, v.name)}
+                  onContextMenu={(e) =>
+                    onNodeContextMenu(e, {
+                      kind: "relation",
+                      connectionId,
+                      database,
+                      schema: schema.name,
+                      name: v.name,
+                      isView: true,
+                    })
+                  }
                   title="click to open"
                 >
                   <span className={TWISTY + " invisible"} />
@@ -497,16 +651,20 @@ function GroupHeader({ label, count }: { label: string; count: number }) {
 }
 
 function TableRow({
+  connectionId,
   database,
   schema,
   table,
   onOpen,
+  onNodeContextMenu,
   activeTabId,
 }: {
+  connectionId: string;
   database: string;
   schema: string;
   table: Table;
   onOpen: () => void;
+  onNodeContextMenu: NodeMenuHandler;
   activeTabId: string | null;
 }) {
   const tabId = `${database}.${schema}.${table.name}`;
@@ -517,6 +675,16 @@ function TableRow({
       className={ROW_BASE + " cursor-pointer" + (active ? " " + ROW_ACTIVE : "")}
       style={{ paddingLeft: 54 }}
       onClick={onOpen}
+      onContextMenu={(e) =>
+        onNodeContextMenu(e, {
+          kind: "relation",
+          connectionId,
+          database,
+          schema,
+          name: table.name,
+          isView: false,
+        })
+      }
       title="click to open"
     >
       <span className={TWISTY + " invisible"} />

--- a/apps/desktop/src/components/SqlEditor.tsx
+++ b/apps/desktop/src/components/SqlEditor.tsx
@@ -1,0 +1,275 @@
+import {
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type { Engine } from "@cellar/ipc";
+
+import { renderTokens, tokenizeSql, tokensToLines } from "../lib/sqlTokens";
+import {
+  splitStatements,
+  statementAtOffset,
+  type SqlStatement,
+} from "../lib/sqlStatements";
+import { useQueryRunner } from "../hooks/useQueryRunner";
+import { useBottomPanel } from "../state/bottomPanel";
+import { useConnections } from "../state/connections";
+import type { QueryTab } from "../state/tabs";
+import { useTabs } from "../state/tabs";
+import { Icon } from "./icons";
+
+const DIALECTS: Record<Engine, string> = {
+  postgres: "PostgreSQL",
+  mysql: "MySQL",
+  sqlite: "SQLite",
+  mssql: "SQL Server",
+  azure: "Azure SQL",
+};
+
+const PLACEHOLDER =
+  "Write SQL here…  ⌘⏎ runs the statement under the cursor, ⌘⇧⏎ runs all.";
+
+export function SqlEditor({ tab }: { tab: QueryTab }) {
+  const setQuerySql = useTabs((s) => s.setQuerySql);
+  const status = useConnections((s) => s.byId[tab.connectionId]?.status);
+  const engine = useConnections(
+    (s) => s.connections.find((c) => c.id === tab.connectionId)?.engine,
+  );
+  const setBottomTab = useBottomPanel((s) => s.setActive);
+  const requestExplain = useBottomPanel((s) => s.requestExplain);
+
+  const { running, errorLine, run, clearError } = useQueryRunner(tab);
+
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const pendingCaret = useRef<number | null>(null);
+  const [caret, setCaret] = useState(0);
+  const [wrap, setWrap] = useState(false);
+
+  const sql = tab.sql;
+  const connected = status === "connected";
+  const isPostgres = engine === "postgres" || engine === undefined;
+
+  const lines = useMemo(() => tokensToLines(tokenizeSql(sql)), [sql]);
+  const statements = useMemo(() => splitStatements(sql), [sql]);
+  const current = useMemo(
+    () => statementAtOffset(sql, caret),
+    [sql, caret],
+  );
+  const range = current ? ([current.startLine, current.endLine] as const) : null;
+
+  // Restore the caret after a programmatic edit (Tab insertion) lands.
+  useLayoutEffect(() => {
+    if (pendingCaret.current != null && textareaRef.current) {
+      const pos = pendingCaret.current;
+      textareaRef.current.selectionStart = pos;
+      textareaRef.current.selectionEnd = pos;
+      pendingCaret.current = null;
+      setCaret(pos);
+    }
+  }, [sql]);
+
+  const syncCaret = useCallback((el: HTMLTextAreaElement) => {
+    setCaret(el.selectionStart);
+  }, []);
+
+  const runStatement = useCallback(() => {
+    const stmt = statementAtOffset(sql, caret);
+    if (!stmt) return;
+    setBottomTab("results");
+    run(stmt.text, { label: statementLabel(stmt, statements), errorLine: stmt.startLine });
+  }, [sql, caret, run, setBottomTab, statements]);
+
+  const runAll = useCallback(() => {
+    if (statements.length === 0) return;
+    setBottomTab("results");
+    run(sql, {
+      label: statements.length > 1 ? "all statements" : "statement",
+      errorLine: statements[0]?.startLine ?? 1,
+    });
+  }, [sql, statements, run, setBottomTab]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    const mod = e.metaKey || e.ctrlKey;
+    if (mod && e.key === "Enter") {
+      e.preventDefault();
+      if (e.shiftKey) runAll();
+      else runStatement();
+      return;
+    }
+    if (e.key === "Tab") {
+      e.preventDefault();
+      const el = e.currentTarget;
+      const start = el.selectionStart;
+      const end = el.selectionEnd;
+      const next = sql.slice(0, start) + "  " + sql.slice(end);
+      pendingCaret.current = start + 2;
+      setQuerySql(tab.id, next);
+    }
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setQuerySql(tab.id, e.target.value);
+    syncCaret(e.target);
+    if (errorLine != null) clearError();
+  };
+
+  const canRunStatement = connected && !running && current != null;
+  const canRunAll = connected && !running && statements.length > 0;
+  const canExplain = connected && !running && current != null && isPostgres;
+  const runTitle = !connected
+    ? "Connect this tab's database to run SQL"
+    : current
+      ? "Run the statement under the cursor"
+      : "Place the cursor in a statement to run it";
+
+  const dialect = engine ? DIALECTS[engine] : "PostgreSQL";
+  const dotEngine: Engine = engine ?? "postgres";
+  const preview = current ? firstLine(current.text) : "—";
+
+  return (
+    <div className={"ed-root mono" + (wrap ? " wrap" : "")}>
+      <div className="ed-toolbar">
+        <div className="ed-toolbar-left">
+          <button
+            className="ed-run primary"
+            onClick={runStatement}
+            disabled={!canRunStatement}
+            title={runTitle}
+          >
+            <Icon.playSm size={11} />
+            <span>{running ? "Running…" : "Run"}</span>
+            <span className="kbd">⌘⏎</span>
+          </button>
+          <button
+            className="ed-run subtle"
+            onClick={runAll}
+            disabled={!canRunAll}
+            title={connected ? "Run the entire editor buffer" : "Connect to run SQL"}
+          >
+            <Icon.play size={11} />
+            <span>Run all</span>
+            <span className="kbd">⌘⇧⏎</span>
+          </button>
+          <div className="cellar-titlebar-divider" />
+          <button
+            className="icon-btn"
+            disabled
+            title="SQL formatting lands with the cellar-sql formatter"
+          >
+            <Icon.format size={12} />
+          </button>
+          <button
+            className={"icon-btn" + (wrap ? " active" : "")}
+            onClick={() => setWrap((w) => !w)}
+            title={wrap ? "Disable line wrapping" : "Wrap long lines"}
+          >
+            <Icon.wrap size={12} />
+          </button>
+          <button
+            className="icon-btn"
+            onClick={requestExplain}
+            disabled={!canExplain}
+            title={
+              !connected
+                ? "Connect to inspect the plan"
+                : !isPostgres
+                  ? "Execution plans are Postgres-only for now"
+                  : !current
+                    ? "Place the cursor in a statement to explain it"
+                    : "Explain the statement under the cursor"
+            }
+          >
+            <Icon.tree size={12} />
+          </button>
+          <button
+            className="icon-btn"
+            disabled
+            title="Bookmarks arrive with query history work"
+          >
+            <Icon.star size={12} />
+          </button>
+        </div>
+        <div className="ed-toolbar-right">
+          <span className="ed-stmt-note">
+            <span style={{ color: "var(--fg-3)" }}>statement under cursor:</span>
+            <span className="ed-stmt-sql" style={{ color: "var(--fg-1)" }}>
+              {preview}
+            </span>
+          </span>
+          <div className="cellar-titlebar-divider" />
+          <span className="ed-dialect">
+            <span className="dot" style={{ background: `var(--eng-${dotEngine})` }} />
+            <span>{dialect}</span>
+          </span>
+        </div>
+      </div>
+
+      <div className="ed-scroll">
+        <div className="ed-doc">
+          <div className="ed-grid" aria-hidden="true">
+            {lines.map((lineTokens, idx) => {
+              const lineNo = idx + 1;
+              const inStmt = range != null && lineNo >= range[0] && lineNo <= range[1];
+              const isError = errorLine === lineNo;
+              return (
+                <div className="ed-row" key={idx}>
+                  <div className={"ed-gutter" + (inStmt ? " in-stmt" : "")}>
+                    <span className="ed-lineno">{lineNo}</span>
+                  </div>
+                  <div
+                    className={
+                      "ed-line" +
+                      (inStmt ? " in-stmt" : "") +
+                      (isError ? " has-error" : "")
+                    }
+                  >
+                    {renderTokens(lineTokens)}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          <textarea
+            ref={textareaRef}
+            className="ed-input"
+            value={sql}
+            spellCheck={false}
+            autoCapitalize="off"
+            autoCorrect="off"
+            wrap={wrap ? "soft" : "off"}
+            placeholder={PLACEHOLDER}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            onSelect={(e) => syncCaret(e.currentTarget)}
+            onClick={(e) => syncCaret(e.currentTarget)}
+          />
+        </div>
+
+        <div className="ed-ai-strip" aria-hidden="true">
+          <span className="ed-ai-strip-prompt">
+            <Icon.sparkles size={11} style={{ color: "var(--accent)" }} />
+            <span>Ask AI to edit or extend this query…</span>
+          </span>
+          <span className="ed-ai-strip-kbd">
+            <kbd className="kbd">⌘</kbd>
+            <kbd className="kbd">I</kbd>
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function statementLabel(stmt: SqlStatement, all: SqlStatement[]): string {
+  if (all.length <= 1) return "statement";
+  const idx = all.findIndex((s) => s.start === stmt.start);
+  return idx >= 0 ? `statement ${idx + 1} of ${all.length}` : "statement";
+}
+
+function firstLine(text: string): string {
+  const line = text.split("\n").find((l) => l.trim().length > 0) ?? text;
+  const trimmed = line.trim();
+  return trimmed.length > 80 ? trimmed.slice(0, 79) + "…" : trimmed;
+}

--- a/apps/desktop/src/components/TabBar.tsx
+++ b/apps/desktop/src/components/TabBar.tsx
@@ -1,11 +1,43 @@
 import { Icon } from "./icons";
+import { useConnections } from "../state/connections";
 import { useTabs } from "../state/tabs";
+
+/**
+ * Pick the connection + database a new query tab should bind to: the active
+ * tab's, else the first connected connection, else the first configured one.
+ */
+function pickQueryTarget(): { connectionId: string; database: string } | null {
+  const tabState = useTabs.getState();
+  const active = tabState.tabs.find((t) => t.id === tabState.activeId);
+  if (active) {
+    return { connectionId: active.connectionId, database: active.database };
+  }
+  const conn = useConnections.getState();
+  const connectedId = conn.connections.find(
+    (c) => conn.byId[c.id]?.status === "connected",
+  )?.id;
+  const targetId = connectedId ?? conn.connections[0]?.id;
+  if (!targetId) return null;
+  const cfg = conn.connections.find((c) => c.id === targetId);
+  if (!cfg) return null;
+  const dbs = conn.byId[targetId]?.databases ?? [];
+  const database =
+    dbs.find((d) => d.is_default)?.name ?? dbs[0]?.name ?? cfg.database;
+  return { connectionId: targetId, database };
+}
 
 export function TabBar() {
   const tabs = useTabs((s) => s.tabs);
   const activeId = useTabs((s) => s.activeId);
   const setActive = useTabs((s) => s.setActive);
   const closeTab = useTabs((s) => s.closeTab);
+  const newQueryTab = useTabs((s) => s.newQueryTab);
+  const hasConnections = useConnections((s) => s.connections.length > 0);
+
+  const onNewQuery = () => {
+    const target = pickQueryTarget();
+    if (target) newQueryTab(target.connectionId, target.database);
+  };
 
   return (
     <div className="flex h-[30px] items-stretch shrink-0 border-b border-border-default bg-bg-1">
@@ -45,6 +77,12 @@ export function TabBar() {
               <span className="overflow-hidden text-ellipsis whitespace-nowrap font-mono">
                 {t.kind === "query" ? t.title : `${t.schema}.${t.table}`}
               </span>
+              {t.kind === "query" && t.dirty && (
+                <span
+                  title="Unsaved edits"
+                  className="h-1.5 w-1.5 shrink-0 rounded-full bg-fg-3 group-hover:opacity-0"
+                />
+              )}
               <button
                 onClick={(e) => {
                   e.stopPropagation();
@@ -61,6 +99,18 @@ export function TabBar() {
             </div>
           );
         })}
+        <button
+          onClick={onNewQuery}
+          disabled={!hasConnections}
+          title={
+            hasConnections
+              ? "New SQL query"
+              : "Add a connection to open a query tab"
+          }
+          className="inline-flex h-full w-7 shrink-0 items-center justify-center text-fg-3 hover:bg-bg-2 hover:text-fg-0 disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-fg-3"
+        >
+          <Icon.plus size={12} />
+        </button>
       </div>
       <div className="flex items-center gap-px border-l border-border-default px-1.5">
         <button className="icon-btn" title="Split horizontal">

--- a/apps/desktop/src/components/Workspace.tsx
+++ b/apps/desktop/src/components/Workspace.tsx
@@ -5,7 +5,8 @@ import {
 } from "@cellar/data-grid";
 
 import { Icon } from "./icons";
-import { useTabs, type QueryTab, type TableTab } from "../state/tabs";
+import { SqlEditor } from "./SqlEditor";
+import { useTabs, type TableTab } from "../state/tabs";
 import { useTableData } from "../hooks/useTableData";
 
 const EMPTY_CHANGES: PendingChanges = {};
@@ -19,20 +20,12 @@ export function Workspace({ onCommit }: { onCommit?: () => void } = {}) {
     return <EmptyWorkspace onCommit={onCommit} />;
   }
   if (active.kind === "query") {
-    return <QueryTabPane tab={active} />;
+    // `key` gives each query tab its own caret/wrap state.
+    return <SqlEditor key={active.id} tab={active} />;
   }
   // `key` resets the grid's local state (filters/selection) when the user
   // switches to a different table tab.
   return <TableTabPane key={active.id} tab={active} onCommit={onCommit} />;
-}
-
-function QueryTabPane({ tab }: { tab: QueryTab }) {
-  return (
-    <PaneMessage>
-      <span className="font-mono text-fg-2">{tab.title}</span>
-      <span className="ml-2">SQL editor is not wired yet.</span>
-    </PaneMessage>
-  );
 }
 
 function TableTabPane({
@@ -127,7 +120,8 @@ function EmptyWorkspace({ onCommit }: { onCommit?: () => void }) {
         </div>
         <div className="max-w-[360px] text-[11.5px] leading-[1.5] text-fg-3">
           Add a Postgres connection in the sidebar, expand it, and click a
-          table to load real rows. The SQL editor lands in the next slice.
+          table to load real rows — or hit <span className="font-mono">+</span>{" "}
+          in the tab bar to open a SQL editor.
         </div>
       </div>
       <div className="flex gap-3 text-[10.5px] text-fg-3">

--- a/apps/desktop/src/components/icons.tsx
+++ b/apps/desktop/src/components/icons.tsx
@@ -235,6 +235,28 @@ export const Icon = {
   bolt: (p: IconProps) => (
     <I {...p} fill="currentColor" stroke="none" d="M13 2L4 14h6l-1 8 9-12h-6z" />
   ),
+  play: (p: IconProps) => (
+    <I {...p} fill="currentColor" stroke="none" d="M7 4.5v15l12-7.5z" />
+  ),
+  playSm: (p: IconProps) => (
+    <I {...p} fill="currentColor" stroke="none" d="M8 5.5v13l10-6.5z" />
+  ),
+  format: (p: IconProps) => (
+    <I {...p} d="M4 6h16M4 10h10M4 14h16M4 18h8" />
+  ),
+  wrap: (p: IconProps) => (
+    <I {...p}>
+      <path d="M4 6h16M4 18h6" />
+      <path d="M4 12h14a3 3 0 010 6h-3" />
+      <path d="M12 15l-2 3 2 3" />
+    </I>
+  ),
+  star: (p: IconProps) => (
+    <I {...p} d="M12 3l2.6 5.6 6 .7-4.4 4.1 1.2 6L12 16.9 6.6 19.4l1.2-6L3.4 9.3l6-.7z" />
+  ),
+  pin: (p: IconProps) => (
+    <I {...p} d="M9 4h6l-1 6 3 3H7l3-3-1-6zM12 13v7" />
+  ),
   layout: (p: IconProps) => (
     <I {...p}>
       <rect x="3" y="3" width="18" height="18" rx="1.5" />

--- a/apps/desktop/src/hooks/useQueryRunner.ts
+++ b/apps/desktop/src/hooks/useQueryRunner.ts
@@ -1,0 +1,148 @@
+import { commands, unwrap } from "@cellar/ipc";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { queryResultToGrid } from "../lib/gridMapping";
+import {
+  buildRunErrorMessage,
+  buildRunResultMessages,
+  buildRunStartedMessage,
+  type QueryRunContext,
+} from "../lib/queryMessages";
+import { useNotices } from "../state/notices";
+import { useQueryMessages } from "../state/queryMessages";
+import { useStatus } from "../state/status";
+import type { QueryTab } from "../state/tabs";
+import { useTabs } from "../state/tabs";
+import { queryResultSource, useTabResults } from "../state/tabResults";
+
+/** Row cap applied to ad-hoc editor queries before the host truncates. */
+export const QUERY_ROW_LIMIT = 1000;
+
+export interface RunOptions {
+  /** Human label for the run, surfaced in the Messages panel. */
+  label: string;
+  /** Line to mark with the error squiggle if the run fails. */
+  errorLine?: number | null;
+}
+
+export interface QueryRunner {
+  running: boolean;
+  /** 1-based editor line to squiggle, or null when the last run was clean. */
+  errorLine: number | null;
+  run: (sql: string, opts: RunOptions) => void;
+  clearError: () => void;
+}
+
+/**
+ * Execute SQL from a query tab through the typed `run_query` IPC and fan the
+ * outcome out to every surface that already listens for results: the bottom
+ * Results grid (`tabResults`), the Messages log, captured database notices, and
+ * the status bar. Stale completions are dropped if the tab unmounts mid-flight.
+ */
+export function useQueryRunner(tab: QueryTab): QueryRunner {
+  const [running, setRunning] = useState(false);
+  const [errorLine, setErrorLine] = useState<number | null>(null);
+  const runToken = useRef(0);
+  const mounted = useRef(true);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  const clearError = useCallback(() => setErrorLine(null), []);
+
+  const run = useCallback(
+    (sql: string, opts: RunOptions) => {
+      const trimmed = sql.trim();
+      if (!trimmed || running) return;
+
+      const token = ++runToken.current;
+      const database = tab.database || null;
+      const source = queryResultSource(
+        tab.connectionId,
+        database,
+        tab.id,
+        tab.title,
+        trimmed,
+        QUERY_ROW_LIMIT,
+      );
+      const context: QueryRunContext = {
+        tabId: tab.id,
+        connectionId: tab.connectionId,
+        database: tab.database || undefined,
+        label: opts.label,
+        sql: trimmed,
+        maxRows: QUERY_ROW_LIMIT,
+      };
+
+      setRunning(true);
+      setErrorLine(null);
+      useTabResults.getState().setLoading(tab.id, source);
+      useQueryMessages
+        .getState()
+        .replaceForTab(tab.id, [buildRunStartedMessage(context)]);
+
+      void (async () => {
+        try {
+          const result = await unwrap(
+            commands.runQuery(
+              tab.connectionId,
+              trimmed,
+              QUERY_ROW_LIMIT,
+              database,
+              tab.id,
+            ),
+          );
+          if (!mounted.current || token !== runToken.current) return;
+
+          const { columns, rows } = queryResultToGrid(result);
+          useTabResults.getState().setReady(tab.id, {
+            source,
+            columns,
+            rows,
+            rowCount: rows.length,
+            truncated: result.truncated,
+            durationMs: result.duration_ms,
+          });
+          useQueryMessages
+            .getState()
+            .addMessages(buildRunResultMessages(context, result));
+          useNotices.getState().recordQueryResult(
+            {
+              tabId: tab.id,
+              connectionId: tab.connectionId,
+              database: tab.database || null,
+            },
+            result,
+          );
+          useStatus.getState().setLastQuery({
+            connectionId: tab.connectionId,
+            tabId: tab.id,
+            rowCount: rows.length,
+            truncated: result.truncated,
+            durationMs: result.duration_ms,
+          });
+          useTabs.getState().markQueryRun(tab.id);
+        } catch (err) {
+          if (!mounted.current || token !== runToken.current) return;
+          const message = err instanceof Error ? err.message : String(err);
+          useTabResults.getState().setError(tab.id, source, message);
+          useQueryMessages
+            .getState()
+            .addMessage(buildRunErrorMessage(context, err));
+          setErrorLine(opts.errorLine ?? null);
+        } finally {
+          if (mounted.current && token === runToken.current) {
+            setRunning(false);
+          }
+        }
+      })();
+    },
+    [running, tab.connectionId, tab.database, tab.id, tab.title],
+  );
+
+  return { running, errorLine, run, clearError };
+}

--- a/apps/desktop/src/hooks/useTableData.ts
+++ b/apps/desktop/src/hooks/useTableData.ts
@@ -1,5 +1,5 @@
 import { commands, unwrap } from "@cellar/ipc";
-import type { CellValue, QueryResult, TableBrowseRequest } from "@cellar/ipc";
+import type { QueryResult, TableBrowseRequest } from "@cellar/ipc";
 import type {
   CellAlign,
   GridColumn,
@@ -8,6 +8,12 @@ import type {
 } from "@cellar/data-grid";
 import { useEffect, useState } from "react";
 
+import {
+  cellValueToGrid,
+  gridWidthFor,
+  isMonoType,
+  isNumericType,
+} from "../lib/gridMapping";
 import { useConnections } from "../state/connections";
 import { useNotices } from "../state/notices";
 import { useQueryMessages } from "../state/queryMessages";
@@ -203,13 +209,13 @@ function columnsFor(
   return result.columns.map((c) => {
     const meta = tableMeta?.columns.find((mc) => mc.name === c.name);
     const fk = findForeignKey(tableMeta?.foreign_keys ?? [], c.name);
-    const numeric = isNumeric(c.data_type);
+    const numeric = isNumericType(c.data_type);
     const align: CellAlign | undefined = numeric ? "right" : undefined;
     return {
       key: c.name,
       name: c.name,
       type: c.data_type,
-      width: widthFor(c.data_type),
+      width: gridWidthFor(c.data_type),
       pk: meta?.is_primary_key ?? false,
       fk,
       align,
@@ -277,87 +283,9 @@ function rowIdFor(row: GridRow, primaryKey: string[], index: number): string {
   );
 }
 
-function cellValueToGrid(value: CellValue): GridValue {
-  switch (value.type) {
-    case "Null":
-      return null;
-    case "Bool":
-      return value.value;
-    case "Int":
-    case "Float":
-      return value.value;
-    case "Numeric":
-      return value.value;
-    case "Text":
-      return value.value;
-    case "Bytes":
-      return bytesToHex(value.value);
-    case "Json":
-      return JSON.stringify(value.value);
-    case "Uuid":
-      return value.value;
-    case "Date":
-    case "Time":
-    case "Timestamp":
-    case "TimestampTz":
-      return value.value;
-  }
-}
-
 function gridValueToString(
   value: GridValue | undefined,
 ): string | null {
   if (value === null || value === undefined) return null;
   return String(value);
-}
-
-function isNumeric(type: string): boolean {
-  const t = type.toLowerCase();
-  return (
-    t === "int2" ||
-    t === "int4" ||
-    t === "int8" ||
-    t === "oid" ||
-    t === "float4" ||
-    t === "float8" ||
-    t === "numeric"
-  );
-}
-
-function isMonoType(type: string): boolean {
-  const t = type.toLowerCase();
-  return (
-    t === "uuid" ||
-    t === "json" ||
-    t === "jsonb" ||
-    t === "bytea" ||
-    t === "date" ||
-    t === "time" ||
-    t === "timetz" ||
-    t === "timestamp" ||
-    t === "timestamptz"
-  );
-}
-
-function widthFor(type: string): number {
-  const t = type.toLowerCase();
-  if (t === "uuid") return 290;
-  if (t === "timestamptz" || t === "timestamp") return 210;
-  if (t === "date") return 110;
-  if (t === "json" || t === "jsonb" || t === "bytea") return 260;
-  if (isNumeric(t)) return 110;
-  if (t === "bool") return 80;
-  return 180;
-}
-
-function bytesToHex(bytes: number[]): string {
-  if (bytes.length === 0) return "\\x";
-  const limit = Math.min(bytes.length, 32);
-  let out = "\\x";
-  for (let i = 0; i < limit; i++) {
-    const b = bytes[i] ?? 0;
-    out += b.toString(16).padStart(2, "0");
-  }
-  if (bytes.length > limit) out += `… (${bytes.length} bytes)`;
-  return out;
 }

--- a/apps/desktop/src/lib/gridMapping.ts
+++ b/apps/desktop/src/lib/gridMapping.ts
@@ -1,0 +1,130 @@
+import type { CellValue, QueryResult } from "@cellar/ipc";
+import type { CellAlign, GridColumn, GridRow, GridValue } from "@cellar/data-grid";
+
+// Shared mapping from the typed IPC `QueryResult` surface into the grid's
+// `GridColumn` / `GridRow` shapes. Both the table-browse path (`useTableData`)
+// and the SQL-editor run path go through these helpers so column typing,
+// alignment, and value fidelity stay consistent.
+
+/** Postgres numeric type names that render right-aligned in a monospace cell. */
+export function isNumericType(type: string): boolean {
+  const t = type.toLowerCase();
+  return (
+    t === "int2" ||
+    t === "int4" ||
+    t === "int8" ||
+    t === "oid" ||
+    t === "float4" ||
+    t === "float8" ||
+    t === "numeric"
+  );
+}
+
+/** Types we render in monospace even when they are not numeric. */
+export function isMonoType(type: string): boolean {
+  const t = type.toLowerCase();
+  return (
+    t === "uuid" ||
+    t === "json" ||
+    t === "jsonb" ||
+    t === "bytea" ||
+    t === "date" ||
+    t === "time" ||
+    t === "timetz" ||
+    t === "timestamp" ||
+    t === "timestamptz"
+  );
+}
+
+/** A sensible default column width keyed off the engine-native type. */
+export function gridWidthFor(type: string): number {
+  const t = type.toLowerCase();
+  if (t === "uuid") return 290;
+  if (t === "timestamptz" || t === "timestamp") return 210;
+  if (t === "date") return 110;
+  if (t === "json" || t === "jsonb" || t === "bytea") return 260;
+  if (isNumericType(t)) return 110;
+  if (t === "bool") return 80;
+  return 180;
+}
+
+/** Hex-preview a `bytea` payload, capped so huge blobs do not bloat the grid. */
+export function bytesToHex(bytes: number[]): string {
+  if (bytes.length === 0) return "\\x";
+  const limit = Math.min(bytes.length, 32);
+  let out = "\\x";
+  for (let i = 0; i < limit; i++) {
+    const b = bytes[i] ?? 0;
+    out += b.toString(16).padStart(2, "0");
+  }
+  if (bytes.length > limit) out += `… (${bytes.length} bytes)`;
+  return out;
+}
+
+/**
+ * Convert one typed cell into the grid's value space. Lossless types (numeric,
+ * uuid, temporals) survive as strings; SQL NULL maps to JS `null` so the grid
+ * renders the italic NULL marker.
+ */
+export function cellValueToGrid(value: CellValue): GridValue {
+  switch (value.type) {
+    case "Null":
+      return null;
+    case "Bool":
+      return value.value;
+    case "Int":
+    case "Float":
+      return value.value;
+    case "Numeric":
+      return value.value;
+    case "Text":
+      return value.value;
+    case "Bytes":
+      return bytesToHex(value.value);
+    case "Json":
+      return JSON.stringify(value.value);
+    case "Uuid":
+      return value.value;
+    case "Date":
+    case "Time":
+    case "Timestamp":
+    case "TimestampTz":
+      return value.value;
+  }
+}
+
+/**
+ * Map a freeform query result into read-only grid columns and rows. Unlike the
+ * table path, result columns have no catalog metadata, so primary-key/foreign-
+ * key adornments are absent and column typing comes straight from the result
+ * descriptor.
+ */
+export function queryResultToGrid(result: QueryResult): {
+  columns: GridColumn[];
+  rows: GridRow[];
+} {
+  const columns: GridColumn[] = result.columns.map((c) => {
+    const numeric = isNumericType(c.data_type);
+    const align: CellAlign | undefined = numeric ? "right" : undefined;
+    return {
+      key: c.name,
+      name: c.name,
+      type: c.data_type,
+      width: gridWidthFor(c.data_type),
+      align,
+      mono: numeric || isMonoType(c.data_type),
+      nullable: c.nullable,
+    };
+  });
+
+  const rows: GridRow[] = result.rows.map((cells, i) => {
+    const row: GridRow = { id: `row:${i}` };
+    cells.forEach((cell, ci) => {
+      const col = columns[ci];
+      if (col) row[col.key] = cellValueToGrid(cell);
+    });
+    return row;
+  });
+
+  return { columns, rows };
+}

--- a/apps/desktop/src/lib/queryMessages.ts
+++ b/apps/desktop/src/lib/queryMessages.ts
@@ -117,6 +117,84 @@ export function buildQueryErrorMessage(
   };
 }
 
+export interface QueryRunContext {
+  tabId: string;
+  connectionId: string;
+  database?: string;
+  /** Short label for the run, e.g. "statement 2 of 3" or "all statements". */
+  label: string;
+  sql: string;
+  maxRows: number;
+}
+
+export function buildRunStartedMessage(
+  context: QueryRunContext,
+): PendingQueryMessage {
+  return {
+    tabId: context.tabId,
+    connectionId: context.connectionId,
+    database: context.database,
+    severity: "info",
+    source: "client",
+    text: `Running ${context.label} with row limit ${context.maxRows}.`,
+    sql: context.sql,
+  };
+}
+
+export function buildRunResultMessages(
+  context: QueryRunContext,
+  result: QueryResult,
+): PendingQueryMessage[] {
+  const rowCount = result.rows_affected ?? result.rows.length;
+  const messages: PendingQueryMessage[] = [
+    {
+      tabId: context.tabId,
+      connectionId: context.connectionId,
+      database: context.database,
+      severity: "success",
+      source: "execution",
+      text:
+        result.rows_affected == null
+          ? `Returned ${formatCount(result.rows.length, "row")} in ${formatDuration(result.duration_ms)}.`
+          : `Query OK: ${formatCount(result.rows_affected, "row")} affected in ${formatDuration(result.duration_ms)}.`,
+      sql: context.sql,
+      durationMs: result.duration_ms,
+      rowCount,
+    },
+  ];
+
+  if (result.truncated) {
+    messages.push({
+      tabId: context.tabId,
+      connectionId: context.connectionId,
+      database: context.database,
+      severity: "warning",
+      source: "execution",
+      text: `Result hit row limit ${context.maxRows}; showing first ${formatCount(result.rows.length, "row")}.`,
+      sql: context.sql,
+      durationMs: result.duration_ms,
+      rowCount: result.rows.length,
+    });
+  }
+
+  return messages;
+}
+
+export function buildRunErrorMessage(
+  context: QueryRunContext,
+  error: unknown,
+): PendingQueryMessage {
+  return {
+    tabId: context.tabId,
+    connectionId: context.connectionId,
+    database: context.database,
+    severity: "error",
+    source: "driver",
+    text: `Failed to run ${context.label}: ${errorMessage(error)}`,
+    sql: context.sql,
+  };
+}
+
 export function formatDuration(ms: number): string {
   if (ms < 1000) return `${ms} ms`;
   return `${(ms / 1000).toFixed(ms < 10_000 ? 2 : 1)} s`;

--- a/apps/desktop/src/lib/sqlIdent.test.ts
+++ b/apps/desktop/src/lib/sqlIdent.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { qualifiedName, quoteIdent, selectAllStatement } from "./sqlIdent";
+
+describe("quoteIdent", () => {
+  it("wraps identifiers in double quotes", () => {
+    expect(quoteIdent("orders")).toBe('"orders"');
+  });
+
+  it("escapes embedded double quotes", () => {
+    expect(quoteIdent('weird"name')).toBe('"weird""name"');
+  });
+});
+
+describe("qualifiedName", () => {
+  it("quotes and dot-joins each part", () => {
+    expect(qualifiedName("public", "orders")).toBe('"public"."orders"');
+  });
+});
+
+describe("selectAllStatement", () => {
+  it("builds a quoted starter SELECT with a default limit", () => {
+    expect(selectAllStatement("public", "orders")).toBe(
+      'SELECT *\nFROM "public"."orders"\nLIMIT 100;',
+    );
+  });
+});

--- a/apps/desktop/src/lib/sqlIdent.ts
+++ b/apps/desktop/src/lib/sqlIdent.ts
@@ -1,0 +1,24 @@
+// Identifier quoting for SQL drafted in the UI (context-menu "Query SELECT *",
+// copy-qualified-name). These are starter drafts the user reviews before
+// running — not an execution path — but per the repo rules any UI-built SQL
+// must still quote identifiers safely. A typed builder in `cellar-sql` will
+// own real execution paths later.
+
+/** Double-quote a SQL identifier, escaping embedded double quotes. */
+export function quoteIdent(name: string): string {
+  return '"' + name.replace(/"/g, '""') + '"';
+}
+
+/** Quoted, dot-joined qualified name, e.g. `"public"."orders"`. */
+export function qualifiedName(...parts: string[]): string {
+  return parts.map(quoteIdent).join(".");
+}
+
+/** A safe starter `SELECT *` for browsing a relation in the SQL editor. */
+export function selectAllStatement(
+  schema: string,
+  relation: string,
+  limit = 100,
+): string {
+  return `SELECT *\nFROM ${qualifiedName(schema, relation)}\nLIMIT ${limit};`;
+}

--- a/apps/desktop/src/lib/sqlStatements.test.ts
+++ b/apps/desktop/src/lib/sqlStatements.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  partitionStatements,
+  splitStatements,
+  statementAtOffset,
+} from "./sqlStatements";
+
+describe("splitStatements", () => {
+  it("splits on top-level semicolons and trims each statement", () => {
+    const sql = "SELECT 1;\nSELECT 2;";
+    const stmts = splitStatements(sql);
+    expect(stmts.map((s) => s.text)).toEqual(["SELECT 1", "SELECT 2"]);
+  });
+
+  it("keeps a trailing statement with no terminating semicolon", () => {
+    const stmts = splitStatements("SELECT 1;\nSELECT 2");
+    expect(stmts.map((s) => s.text)).toEqual(["SELECT 1", "SELECT 2"]);
+  });
+
+  it("ignores semicolons inside string literals", () => {
+    const stmts = splitStatements("SELECT ';not a split';");
+    expect(stmts).toHaveLength(1);
+    expect(stmts[0]?.text).toBe("SELECT ';not a split'");
+  });
+
+  it("ignores semicolons inside line and block comments", () => {
+    const sql = "SELECT 1; -- trailing; comment\nSELECT 2 /* a; b */;";
+    const stmts = splitStatements(sql);
+    expect(stmts.map((s) => s.text)).toEqual([
+      "SELECT 1",
+      "-- trailing; comment\nSELECT 2 /* a; b */",
+    ]);
+  });
+
+  it("ignores semicolons inside dollar-quoted bodies", () => {
+    const sql = "CREATE FUNCTION f() RETURNS int AS $$ BEGIN; RETURN 1; END; $$;";
+    const stmts = splitStatements(sql);
+    expect(stmts).toHaveLength(1);
+    expect(stmts[0]?.text.startsWith("CREATE FUNCTION")).toBe(true);
+  });
+
+  it("drops whitespace-only chunks", () => {
+    expect(splitStatements("SELECT 1;\n\n  \n")).toHaveLength(1);
+  });
+});
+
+describe("partitionStatements", () => {
+  it("reports 1-based line ranges for multi-line statements", () => {
+    const sql = "SELECT\n  a,\n  b\nFROM t;\nSELECT 1;";
+    const [first, second] = partitionStatements(sql);
+    expect([first?.startLine, first?.endLine]).toEqual([1, 4]);
+    expect([second?.startLine, second?.endLine]).toEqual([5, 5]);
+  });
+});
+
+describe("statementAtOffset", () => {
+  const sql = "SELECT 1;\nSELECT 2;\nSELECT 3";
+
+  it("returns the statement containing the caret", () => {
+    expect(statementAtOffset(sql, 13)?.text).toBe("SELECT 2");
+  });
+
+  it("assigns blank space after a semicolon to the next statement", () => {
+    const padded = "SELECT 1;\n\n\nSELECT 2;";
+    // Offset 10 is on the blank line following the first statement's `;`.
+    expect(statementAtOffset(padded, 10)?.text).toBe("SELECT 2");
+  });
+
+  it("falls back to the preceding statement for caret in trailing blank space", () => {
+    // The blank tail after the last `;` is its own empty chunk.
+    expect(statementAtOffset("SELECT 1;\n\n", 10)?.text).toBe("SELECT 1");
+  });
+
+  it("returns null for an empty buffer", () => {
+    expect(statementAtOffset("   \n  ", 2)).toBeNull();
+  });
+});

--- a/apps/desktop/src/lib/sqlStatements.ts
+++ b/apps/desktop/src/lib/sqlStatements.ts
@@ -1,0 +1,200 @@
+// Statement-aware slicing of a SQL buffer. The editor uses this to find the
+// statement under the cursor (for ⌘⏎ "Run current statement") and to paint the
+// in-statement highlight band. Splitting happens at top-level `;` only — a
+// semicolon inside a string literal, comment, or dollar-quoted block is not a
+// statement boundary, so this scanner tracks those contexts explicitly rather
+// than doing a naive `split(";")`.
+
+export interface SqlStatement {
+  /** Trimmed statement text, excluding the terminating semicolon. */
+  text: string;
+  /** Offset of the first character of `text` in the source buffer. */
+  start: number;
+  /** Offset just past the last character of `text` (before any `;`). */
+  end: number;
+  /** Start of the contiguous source chunk this statement owns. */
+  rawStart: number;
+  /** End (exclusive) of the contiguous source chunk, including its `;`. */
+  rawEnd: number;
+  /** 1-based line of `start`. */
+  startLine: number;
+  /** 1-based line of the statement's last content character. */
+  endLine: number;
+}
+
+const isWs = (c: string) => c === " " || c === "\t" || c === "\n" || c === "\r";
+
+/** Skip a `'…'` or `"…"` literal, honouring doubled-quote and backslash escapes. */
+function skipQuoted(sql: string, i: number, quote: string): number {
+  let j = i + 1;
+  while (j < sql.length) {
+    const c = sql[j];
+    if (c === "\\") {
+      j += 2;
+      continue;
+    }
+    if (c === quote) {
+      if (sql[j + 1] === quote) {
+        j += 2;
+        continue;
+      }
+      return j + 1;
+    }
+    j++;
+  }
+  return sql.length;
+}
+
+/** Skip a `-- …` line comment up to (but not including) the newline. */
+function skipLineComment(sql: string, i: number): number {
+  let j = i + 2;
+  while (j < sql.length && sql[j] !== "\n") j++;
+  return j;
+}
+
+/** Skip a `/* … *\/` block comment, including the closing delimiter. */
+function skipBlockComment(sql: string, i: number): number {
+  let j = i + 2;
+  while (j < sql.length && !(sql[j] === "*" && sql[j + 1] === "/")) j++;
+  return Math.min(sql.length, j + 2);
+}
+
+/**
+ * If a dollar-quote tag (`$$` or `$tag$`) opens at `i`, return the offset just
+ * past its matching close. Otherwise return -1 so the caller treats `$` as an
+ * ordinary character.
+ */
+function skipDollarQuote(sql: string, i: number): number {
+  const open = /^\$[A-Za-z_]?[A-Za-z0-9_]*\$/.exec(sql.slice(i));
+  if (!open) return -1;
+  const tag = open[0];
+  const close = sql.indexOf(tag, i + tag.length);
+  return close < 0 ? sql.length : close + tag.length;
+}
+
+/** Offsets of every top-level (statement-terminating) semicolon. */
+function topLevelSemicolons(sql: string): number[] {
+  const cuts: number[] = [];
+  let i = 0;
+  while (i < sql.length) {
+    const c = sql[i];
+    if (c === "'" || c === '"') {
+      i = skipQuoted(sql, i, c);
+      continue;
+    }
+    if (c === "-" && sql[i + 1] === "-") {
+      i = skipLineComment(sql, i);
+      continue;
+    }
+    if (c === "/" && sql[i + 1] === "*") {
+      i = skipBlockComment(sql, i);
+      continue;
+    }
+    if (c === "$") {
+      const next = skipDollarQuote(sql, i);
+      if (next >= 0) {
+        i = next;
+        continue;
+      }
+    }
+    if (c === ";") {
+      cuts.push(i);
+    }
+    i++;
+  }
+  return cuts;
+}
+
+function lineStarts(sql: string): number[] {
+  const starts = [0];
+  for (let i = 0; i < sql.length; i++) {
+    if (sql[i] === "\n") starts.push(i + 1);
+  }
+  return starts;
+}
+
+/** 1-based line number for a source offset, via binary search over line starts. */
+function lineAt(starts: number[], offset: number): number {
+  let lo = 0;
+  let hi = starts.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1;
+    if ((starts[mid] as number) <= offset) lo = mid;
+    else hi = mid - 1;
+  }
+  return lo + 1;
+}
+
+function makeStatement(
+  sql: string,
+  starts: number[],
+  rawStart: number,
+  rawEnd: number,
+): SqlStatement {
+  let s = rawStart;
+  let e = rawEnd;
+  if (e > s && sql[e - 1] === ";") e--;
+  while (s < e && isWs(sql[s] as string)) s++;
+  while (e > s && isWs(sql[e - 1] as string)) e--;
+  return {
+    text: sql.slice(s, e),
+    start: s,
+    end: e,
+    rawStart,
+    rawEnd,
+    startLine: lineAt(starts, s),
+    endLine: lineAt(starts, Math.max(s, e - 1)),
+  };
+}
+
+/**
+ * Partition the buffer into contiguous statement chunks covering `[0, len)`.
+ * Whitespace-only chunks are kept (with `text === ""`) so offset lookups stay
+ * total; callers filter them out when they need runnable statements.
+ */
+export function partitionStatements(sql: string): SqlStatement[] {
+  const starts = lineStarts(sql);
+  const cuts = topLevelSemicolons(sql);
+  const out: SqlStatement[] = [];
+  let prev = 0;
+  for (const cut of cuts) {
+    out.push(makeStatement(sql, starts, prev, cut + 1));
+    prev = cut + 1;
+  }
+  if (prev < sql.length || out.length === 0) {
+    out.push(makeStatement(sql, starts, prev, sql.length));
+  }
+  return out;
+}
+
+/** Non-empty statements only — the ones that can actually be executed. */
+export function splitStatements(sql: string): SqlStatement[] {
+  return partitionStatements(sql).filter((s) => s.text.length > 0);
+}
+
+/**
+ * The statement under the caret. If the caret sits in blank space between
+ * statements, fall back to the nearest preceding non-empty statement (matching
+ * how most SQL editors resolve "run statement under cursor").
+ */
+export function statementAtOffset(
+  sql: string,
+  offset: number,
+): SqlStatement | null {
+  const chunks = partitionStatements(sql);
+  const clamped = Math.max(0, Math.min(offset, sql.length));
+  const containing = chunks.find(
+    (c) => clamped >= c.rawStart && clamped < c.rawEnd,
+  );
+  if (containing && containing.text.length > 0) return containing;
+
+  const nonEmpty = chunks.filter((c) => c.text.length > 0);
+  if (nonEmpty.length === 0) return null;
+
+  let preceding: SqlStatement | null = null;
+  for (const c of nonEmpty) {
+    if (c.rawStart <= clamped) preceding = c;
+    else break;
+  }
+  return preceding ?? nonEmpty[0] ?? null;
+}

--- a/apps/desktop/src/state/bottomPanel.ts
+++ b/apps/desktop/src/state/bottomPanel.ts
@@ -1,0 +1,30 @@
+import { create } from "zustand";
+
+export type BottomTabId =
+  | "results"
+  | "messages"
+  | "plan"
+  | "history"
+  | "notices";
+
+interface BottomPanelStore {
+  active: BottomTabId;
+  /** Bumped to ask the Plan panel to (re)run EXPLAIN for the active query. */
+  explainNonce: number;
+  setActive: (id: BottomTabId) => void;
+  /** Focus the Plan tab and request a fresh EXPLAIN run. */
+  requestExplain: () => void;
+}
+
+/**
+ * Cross-component control for the bottom panel. The SQL editor uses it to focus
+ * the Results tab when a query runs and to drive the Plan tab's "Explain plan"
+ * toolbar action without lifting the panel's whole tab state into App.
+ */
+export const useBottomPanel = create<BottomPanelStore>((set) => ({
+  active: "results",
+  explainNonce: 0,
+  setActive: (active) => set({ active }),
+  requestExplain: () =>
+    set((s) => ({ active: "plan", explainNonce: s.explainNonce + 1 })),
+}));

--- a/apps/desktop/src/state/tabs.ts
+++ b/apps/desktop/src/state/tabs.ts
@@ -18,9 +18,13 @@ export interface QueryTab {
   database: string;
   title: string;
   sql: string;
+  /** `true` when the buffer has unsaved edits since the tab was last run. */
+  dirty: boolean;
 }
 
 export type WorkspaceTab = TableTab | QueryTab;
+
+let queryTabSeq = 0;
 
 interface TabsStore {
   tabs: WorkspaceTab[];
@@ -33,6 +37,9 @@ interface TabsStore {
     schema: string,
     table: string,
   ) => void;
+  newQueryTab: (connectionId: string, database: string) => string;
+  setQuerySql: (id: string, sql: string) => void;
+  markQueryRun: (id: string) => void;
   closeTab: (id: string) => void;
   setActive: (id: string) => void;
   setTableChanges: (id: string, changes: PendingChanges) => void;
@@ -68,6 +75,45 @@ export const useTabs = create<TabsStore>((set, get) => ({
         { id, kind: "table", connectionId, database, schema, table },
       ],
       activeId: id,
+    }));
+  },
+
+  newQueryTab(connectionId, database) {
+    const id = `query:${++queryTabSeq}:${connectionId}`;
+    const title = `untitled-${queryTabSeq}.sql`;
+    set((s) => ({
+      tabs: [
+        ...s.tabs,
+        {
+          id,
+          kind: "query",
+          connectionId,
+          database,
+          title,
+          sql: "",
+          dirty: false,
+        },
+      ],
+      activeId: id,
+    }));
+    return id;
+  },
+
+  setQuerySql(id, sql) {
+    set((s) => ({
+      tabs: s.tabs.map((t) =>
+        t.id === id && t.kind === "query"
+          ? { ...t, sql, dirty: sql !== t.sql ? true : t.dirty }
+          : t,
+      ),
+    }));
+  },
+
+  markQueryRun(id) {
+    set((s) => ({
+      tabs: s.tabs.map((t) =>
+        t.id === id && t.kind === "query" ? { ...t, dirty: false } : t,
+      ),
     }));
   },
 

--- a/apps/desktop/src/styles/editor.css
+++ b/apps/desktop/src/styles/editor.css
@@ -1,0 +1,283 @@
+/* SQL editor — ported from the Cellar design (app/styles-2.css `.ed-*`).
+   The prototype was a static syntax highlighter; here the same line/gutter
+   layout doubles as the highlight layer for a real, editable buffer. A
+   transparent <textarea> is overlaid on top so the browser owns caret,
+   selection, and input while the layer underneath paints the colors,
+   in-statement band, and error squiggle. Both layers share identical font
+   metrics and padding so the caret tracks the rendered tokens exactly. */
+
+.ed-root {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--bg-inset);
+  font-size: var(--fs-md);
+}
+
+.ed-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  height: 30px;
+  padding: 0 8px;
+  background: var(--bg-1);
+  border-bottom: 1px solid var(--border-default);
+  flex-shrink: 0;
+  font-family: var(--font-sans);
+}
+.ed-toolbar-left,
+.ed-toolbar-right {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.ed-run {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 22px;
+  padding: 0 8px;
+  border-radius: 4px;
+  font-size: 11.5px;
+  font-weight: 500;
+  color: var(--fg-1);
+  white-space: nowrap;
+  transition: background 0.12s, color 0.12s, border-color 0.12s, filter 0.12s;
+  border: 1px solid transparent;
+}
+.ed-run.primary {
+  background: var(--accent-grad, var(--accent));
+  color: var(--accent-fg);
+  border-color: color-mix(in oklab, var(--accent) 30%, black);
+}
+.ed-run.primary:hover {
+  filter: brightness(1.07);
+}
+.ed-run.primary:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  filter: none;
+}
+.ed-run.subtle {
+  background: transparent;
+  color: var(--fg-1);
+  border-color: var(--border-default);
+}
+.ed-run.subtle:hover {
+  background: var(--bg-3);
+  border-color: var(--border-strong);
+  color: var(--fg-0);
+}
+.ed-run.subtle:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.ed-run .kbd {
+  background: rgba(0, 0, 0, 0.18);
+  border-color: transparent;
+  color: inherit;
+  opacity: 0.7;
+}
+.ed-run.subtle .kbd {
+  background: var(--bg-2);
+}
+
+.ed-stmt-note {
+  display: inline-flex;
+  gap: 6px;
+  font-size: 10.5px;
+  color: var(--fg-2);
+  max-width: 360px;
+}
+.ed-stmt-note .ed-stmt-sql {
+  font-family: var(--font-mono);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ed-dialect {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 10.5px;
+  color: var(--fg-2);
+  padding: 0 6px;
+}
+.ed-dialect .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+}
+
+.ed-toolbar .icon-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.ed-toolbar .icon-btn.active {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+/* ── editor body ─────────────────────────────────────────────── */
+
+.ed-scroll {
+  flex: 1;
+  overflow: auto;
+  position: relative;
+}
+.ed-doc {
+  position: relative;
+  width: max-content;
+  min-width: 100%;
+  min-height: 100%;
+}
+
+.ed-grid {
+  display: flex;
+  flex-direction: column;
+  padding: 6px 0 60px;
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  line-height: 1.55;
+  pointer-events: none;
+  position: relative;
+  z-index: 1;
+}
+.ed-row {
+  display: flex;
+  align-items: stretch;
+}
+.ed-gutter {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 3px;
+  width: 48px;
+  flex: none;
+  padding: 0 8px 0 4px;
+  color: var(--fg-3);
+  font-size: 10.5px;
+  user-select: none;
+  position: relative;
+}
+.ed-gutter.in-stmt {
+  background: linear-gradient(90deg, transparent, var(--accent-soft) 40%);
+  color: var(--accent);
+}
+.ed-lineno {
+  font-variant-numeric: tabular-nums;
+}
+.ed-bp {
+  width: 8px;
+  height: 8px;
+  background: var(--delete);
+  border-radius: 50%;
+}
+.ed-line {
+  flex: 1 1 auto;
+  min-height: 1.55em;
+  padding-left: 8px;
+  padding-right: 16px;
+  white-space: pre;
+  position: relative;
+  color: var(--fg-0);
+}
+.ed-line.in-stmt {
+  background: linear-gradient(
+    90deg,
+    var(--accent-soft),
+    color-mix(in oklab, var(--accent-soft) 50%, transparent)
+  );
+}
+.ed-line.has-error::after {
+  content: "";
+  position: absolute;
+  left: 8px;
+  right: 16px;
+  bottom: 0;
+  height: 3px;
+  background: repeating-linear-gradient(
+    135deg,
+    var(--syn-error) 0 2px,
+    transparent 2px 4px
+  );
+  opacity: 0.7;
+}
+
+/* The transparent input overlay — text is invisible, only the caret shows. */
+.ed-input {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 48px;
+  right: 0;
+  z-index: 2;
+  margin: 0;
+  padding: 6px 16px 60px 8px;
+  border: none;
+  outline: none;
+  resize: none;
+  background: transparent;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+  caret-color: var(--fg-0);
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  line-height: 1.55;
+  white-space: pre;
+  overflow: hidden;
+  tab-size: 2;
+}
+.ed-input::selection {
+  background: var(--accent-line);
+}
+.ed-input::placeholder {
+  color: var(--fg-4);
+  -webkit-text-fill-color: var(--fg-4);
+}
+
+/* Wrap-lines toggle — both layers wrap at the same width so they stay aligned. */
+.ed-root.wrap .ed-doc {
+  width: auto;
+}
+.ed-root.wrap .ed-line {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+.ed-root.wrap .ed-input {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+/* AI inline strip — a non-interactive affordance for the future AI slice. */
+.ed-ai-strip {
+  position: sticky;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 3;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 12px 12px 0;
+  padding: 6px 10px;
+  background: color-mix(in oklab, var(--bg-1) 90%, transparent);
+  backdrop-filter: blur(8px);
+  border: 1px dashed var(--border-default);
+  border-radius: 5px;
+  font-family: var(--font-sans);
+  font-size: 11.5px;
+  color: var(--fg-3);
+  pointer-events: none;
+}
+.ed-ai-strip-prompt {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.ed-ai-strip-kbd {
+  display: inline-flex;
+  gap: 2px;
+}

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -2,6 +2,7 @@
 @import "./tokens.css";
 @import "./base.css";
 @import "./grid.css";
+@import "./editor.css";
 
 /* Bridge: expose every design token from tokens.css as a Tailwind v4 theme key
    so utilities like `bg-bg-0`, `text-fg-1`, `border-border-default`, `font-mono`,


### PR DESCRIPTION
## What

Implements the **SQL editor** from the Cellar design handoff. The design file (`Cellar.html` → `app/editor.jsx`) was a static syntax-highlighting prototype; this turns it into a real, editable editor for query tabs that runs SQL through the existing `run_query` IPC and feeds every panel that already listens for results.

Query tabs previously rendered a "SQL editor is not wired yet" placeholder. They now render a working editor.


## How it matches the design

- **Toolbar** — `Run ⌘⏎` (statement under cursor), `Run all ⌘⇧⏎`, Format/Wrap/Explain/Bookmark, a live "statement under cursor: …" note, and the engine dialect badge.
- **Body** — line gutter, per-token syntax colors, the violet **in-statement highlight band** that tracks the cursor, and the error squiggle on a failed statement.
- **AI inline strip** — rendered as in the design but as a **non-interactive affordance** (the AI pipeline is a later roadmap slice), so it doesn't pose as a working control.

## Implementation notes

- **Editor technique:** a transparent `<textarea>` overlaid on the token-highlight layer (both share font metrics + padding so the caret tracks the rendered tokens). This reuses the existing `lib/sqlTokens` tokenizer and adds **no new dependencies**.
  - The README "Stack" table names **CodeMirror 6** and `packages/sql-editor` is reserved for it. I deliberately did **not** pull in CodeMirror here: the design is a custom highlighter, matching its exact decorations (gutter band, ghost chip, dashed AI strip) against CM's theming would be heavier and less faithful, and the handoff README says to "recreate pixel-perfectly in whatever technology makes sense." The empty `@cellar/sql-editor` package is left untouched for a future CM wrapper if the project wants one. Happy to revisit if you'd rather standardize on CodeMirror now.
- **`lib/sqlStatements`** — quote/comment/`$tag$`-aware statement splitting so `⌘⏎` runs the statement under the cursor and `⌘⇧⏎` runs the whole buffer. Unit-tested.
- **`useQueryRunner`** — runs SQL and fans the result into `tabResults` (bottom Results grid), the Messages log, captured database notices, and the status bar; stale completions are dropped if the tab unmounts mid-flight.
- **`lib/gridMapping`** — extracts the `QueryResult` → grid mapping that lived privately in `useTableData`; `useTableData` now reuses it and the new query path shares it (one source of truth, no duplication).
- **Entry points** — a `+` button in the tab bar and a **"New SQL query"** action on the sidebar connection menu. Query tabs show a dirty dot. The History tab's **"Reuse"** is now wired to open a record's SQL in a new query tab (was a disabled stub).
- **`state/bottomPanel`** — small store so the editor's "Explain" focuses the Plan tab and triggers `EXPLAIN`, and running a query focuses the Results tab.

## Out of scope (per SPEC roadmap)

- AI ghost-text / inline completion (v0.4.0).
- Editor SQL formatting (needs a `cellar-sql` formatter IPC) and bookmarks — rendered disabled with explanatory tooltips.

## Testing

- `pnpm typecheck` ✅ · `pnpm test` (turbo) ✅ — 30 desktop tests incl. new `sqlStatements` suite · `pnpm --filter @cellar/desktop build` ✅
- Verified in `dev:web`: typed a 2-statement query, confirmed syntax highlighting, gutter, cursor-tracked in-statement band, the toolbar note, and an end-to-end run producing Messages ("Running statement 1 of 2…" → "Returned 0 rows…") + status-bar metrics.

No Rust/IPC contracts changed, so no `packages/ipc` regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
