### PR TITLE
fix: polish sidebar empty states

### DIFF
--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -280,20 +280,28 @@ export function Sidebar({
         </div>
       </div>
 
-      <div className="mx-2 mb-1.5 flex h-6 shrink-0 items-center gap-1.5 rounded-[4px] border border-border-default bg-bg-inset px-2 focus-within:border-accent-line">
+      <div className="mx-2 mb-1.5 flex min-h-7 shrink-0 items-center gap-1.5 rounded-[4px] border border-border-default bg-bg-inset px-2 py-1 focus-within:border-accent-line">
         <Icon.search size={11} style={{ color: "var(--fg-3)" }} />
         <input
           placeholder="Filter…"
           value={filter}
           onChange={(e) => setFilter(e.target.value)}
-          className="flex-1 border-none bg-transparent text-[11.5px] text-fg-0 outline-none placeholder:text-fg-3"
+          className="flex-1 border-none bg-transparent py-0.5 text-[11.5px] leading-4 text-fg-0 outline-none placeholder:text-fg-3"
         />
         <span className="kbd">⌘F</span>
       </div>
 
       <div className="flex-1 overflow-y-auto pb-3">
+        <button
+          onClick={onNewConnection}
+          className="mx-2 mt-1 mb-3 flex w-[calc(100%-16px)] items-center gap-1.5 rounded-[4px] border border-dashed border-border-default px-2 py-1.5 text-[11.5px] text-fg-2 transition-[border-color,color,background] duration-150 hover:border-solid hover:border-accent-line hover:bg-accent-soft hover:text-accent"
+        >
+          <Icon.plus size={11} />
+          <span>New connection</span>
+        </button>
+
         {filtered.length === 0 && (
-          <div className="px-3 py-6 text-center text-[11px] text-fg-3">
+          <div className="px-3 py-5 text-center text-[11px] text-fg-3">
             no connections yet
           </div>
         )}
@@ -320,13 +328,6 @@ export function Sidebar({
           );
         })}
 
-        <button
-          onClick={onNewConnection}
-          className="m-2 flex w-[calc(100%-16px)] items-center gap-1.5 rounded-[4px] border border-dashed border-border-default px-2 py-1.5 text-[11.5px] text-fg-2 transition-[border-color,color,background] duration-150 hover:border-solid hover:border-accent-line hover:bg-accent-soft hover:text-accent"
-        >
-          <Icon.plus size={11} />
-          <span>New connection</span>
-        </button>
       </div>
 
       <ContextMenu state={menu} onClose={() => setMenu(null)} />

--- a/apps/desktop/src/components/Workspace.tsx
+++ b/apps/desktop/src/components/Workspace.tsx
@@ -4,7 +4,6 @@ import {
   type PendingChanges,
 } from "@cellar/data-grid";
 
-import { Icon } from "./icons";
 import { SqlEditor } from "./SqlEditor";
 import { useTabs, type TableTab } from "../state/tabs";
 import { useTableData } from "../hooks/useTableData";
@@ -17,7 +16,7 @@ export function Workspace({ onCommit }: { onCommit?: () => void } = {}) {
   const active = tabs.find((t) => t.id === activeId) ?? null;
 
   if (!active) {
-    return <EmptyWorkspace onCommit={onCommit} />;
+    return <EmptyWorkspace />;
   }
   if (active.kind === "query") {
     // `key` gives each query tab its own caret/wrap state.
@@ -95,7 +94,7 @@ function PaneMessage({ children }: { children: React.ReactNode }) {
   );
 }
 
-function EmptyWorkspace({ onCommit }: { onCommit?: () => void }) {
+function EmptyWorkspace() {
   return (
     <div className="flex flex-1 flex-col items-center justify-center gap-[14px] bg-bg-inset px-10 py-10 text-center text-[12.5px] text-fg-2">
       <span
@@ -134,17 +133,6 @@ function EmptyWorkspace({ onCommit }: { onCommit?: () => void }) {
           <kbd className="kbd">K</kbd>&nbsp;command palette
         </span>
       </div>
-      {onCommit && (
-        <button
-          onClick={onCommit}
-          title="Open the commit review modal"
-          className="mt-1 inline-flex h-[26px] items-center gap-[5px] whitespace-nowrap rounded-[4px] border border-border-default bg-transparent px-2.5 text-[11.5px] font-medium text-fg-1 transition-[background,color,border-color] duration-[120ms] hover:border-border-strong hover:bg-bg-3 hover:text-fg-0"
-        >
-          <Icon.commit size={11} />
-          <span>Review &amp; commit (preview)</span>
-          <kbd className="kbd ml-1">⌘S</kbd>
-        </button>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Adds vertical breathing room to the connections filter field.
- Moves the empty sidebar New connection action directly under the filter.
- Removes the empty-workspace Review & commit preview button.

## Validation

- `pnpm typecheck`
- Fetched latest `origin/main`, updated local `main`, and checked this branch merges cleanly with latest `main`.