### PR TITLE
feat: add SQL editor intellisense

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@cellar/data-grid": "workspace:*",
     "@cellar/ipc": "workspace:*",
+    "@cellar/sql-editor": "workspace:0.1.0-alpha",
     "@tauri-apps/api": "^2.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/apps/desktop/src/components/SqlEditor.tsx
+++ b/apps/desktop/src/components/SqlEditor.tsx
@@ -1,13 +1,11 @@
 import {
   useCallback,
-  useLayoutEffect,
   useMemo,
-  useRef,
   useState,
 } from "react";
-import type { Engine } from "@cellar/ipc";
+import type { Database, Engine } from "@cellar/ipc";
+import { SqlCodeEditor } from "@cellar/sql-editor";
 
-import { renderTokens, tokenizeSql, tokensToLines } from "../lib/sqlTokens";
 import {
   splitStatements,
   statementAtOffset,
@@ -31,9 +29,14 @@ const DIALECTS: Record<Engine, string> = {
 const PLACEHOLDER =
   "Write SQL here…  ⌘⏎ runs the statement under the cursor, ⌘⇧⏎ runs all.";
 
+const EMPTY_DATABASES: Database[] = [];
+
 export function SqlEditor({ tab }: { tab: QueryTab }) {
   const setQuerySql = useTabs((s) => s.setQuerySql);
   const status = useConnections((s) => s.byId[tab.connectionId]?.status);
+  const databases = useConnections(
+    (s) => s.byId[tab.connectionId]?.databases ?? EMPTY_DATABASES,
+  );
   const engine = useConnections(
     (s) => s.connections.find((c) => c.id === tab.connectionId)?.engine,
   );
@@ -42,8 +45,6 @@ export function SqlEditor({ tab }: { tab: QueryTab }) {
 
   const { running, errorLine, run, clearError } = useQueryRunner(tab);
 
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const pendingCaret = useRef<number | null>(null);
   const [caret, setCaret] = useState(0);
   const [wrap, setWrap] = useState(false);
 
@@ -51,7 +52,6 @@ export function SqlEditor({ tab }: { tab: QueryTab }) {
   const connected = status === "connected";
   const isPostgres = engine === "postgres" || engine === undefined;
 
-  const lines = useMemo(() => tokensToLines(tokenizeSql(sql)), [sql]);
   const statements = useMemo(() => splitStatements(sql), [sql]);
   const current = useMemo(
     () => statementAtOffset(sql, caret),
@@ -59,27 +59,16 @@ export function SqlEditor({ tab }: { tab: QueryTab }) {
   );
   const range = current ? ([current.startLine, current.endLine] as const) : null;
 
-  // Restore the caret after a programmatic edit (Tab insertion) lands.
-  useLayoutEffect(() => {
-    if (pendingCaret.current != null && textareaRef.current) {
-      const pos = pendingCaret.current;
-      textareaRef.current.selectionStart = pos;
-      textareaRef.current.selectionEnd = pos;
-      pendingCaret.current = null;
-      setCaret(pos);
-    }
-  }, [sql]);
-
-  const syncCaret = useCallback((el: HTMLTextAreaElement) => {
-    setCaret(el.selectionStart);
-  }, []);
-
-  const runStatement = useCallback(() => {
-    const stmt = statementAtOffset(sql, caret);
+  const runStatementAt = useCallback((offset: number) => {
+    const stmt = statementAtOffset(sql, offset);
     if (!stmt) return;
     setBottomTab("results");
     run(stmt.text, { label: statementLabel(stmt, statements), errorLine: stmt.startLine });
-  }, [sql, caret, run, setBottomTab, statements]);
+  }, [sql, run, setBottomTab, statements]);
+
+  const runStatement = useCallback(() => {
+    runStatementAt(caret);
+  }, [caret, runStatementAt]);
 
   const runAll = useCallback(() => {
     if (statements.length === 0) return;
@@ -90,30 +79,10 @@ export function SqlEditor({ tab }: { tab: QueryTab }) {
     });
   }, [sql, statements, run, setBottomTab]);
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    const mod = e.metaKey || e.ctrlKey;
-    if (mod && e.key === "Enter") {
-      e.preventDefault();
-      if (e.shiftKey) runAll();
-      else runStatement();
-      return;
-    }
-    if (e.key === "Tab") {
-      e.preventDefault();
-      const el = e.currentTarget;
-      const start = el.selectionStart;
-      const end = el.selectionEnd;
-      const next = sql.slice(0, start) + "  " + sql.slice(end);
-      pendingCaret.current = start + 2;
-      setQuerySql(tab.id, next);
-    }
-  };
-
-  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setQuerySql(tab.id, e.target.value);
-    syncCaret(e.target);
+  const handleEditorChange = useCallback((next: string) => {
+    setQuerySql(tab.id, next);
     if (errorLine != null) clearError();
-  };
+  }, [clearError, errorLine, setQuerySql, tab.id]);
 
   const canRunStatement = connected && !running && current != null;
   const canRunAll = connected && !running && statements.length > 0;
@@ -207,45 +176,20 @@ export function SqlEditor({ tab }: { tab: QueryTab }) {
       </div>
 
       <div className="ed-scroll">
-        <div className="ed-doc">
-          <div className="ed-grid" aria-hidden="true">
-            {lines.map((lineTokens, idx) => {
-              const lineNo = idx + 1;
-              const inStmt = range != null && lineNo >= range[0] && lineNo <= range[1];
-              const isError = errorLine === lineNo;
-              return (
-                <div className="ed-row" key={idx}>
-                  <div className={"ed-gutter" + (inStmt ? " in-stmt" : "")}>
-                    <span className="ed-lineno">{lineNo}</span>
-                  </div>
-                  <div
-                    className={
-                      "ed-line" +
-                      (inStmt ? " in-stmt" : "") +
-                      (isError ? " has-error" : "")
-                    }
-                  >
-                    {renderTokens(lineTokens)}
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-          <textarea
-            ref={textareaRef}
-            className="ed-input"
-            value={sql}
-            spellCheck={false}
-            autoCapitalize="off"
-            autoCorrect="off"
-            wrap={wrap ? "soft" : "off"}
-            placeholder={PLACEHOLDER}
-            onChange={handleChange}
-            onKeyDown={handleKeyDown}
-            onSelect={(e) => syncCaret(e.currentTarget)}
-            onClick={(e) => syncCaret(e.currentTarget)}
-          />
-        </div>
+        <SqlCodeEditor
+          value={sql}
+          engine={engine}
+          databases={databases}
+          database={tab.database}
+          placeholder={PLACEHOLDER}
+          wrap={wrap}
+          currentStatementRange={range}
+          errorLine={errorLine}
+          onChange={handleEditorChange}
+          onCursorChange={setCaret}
+          onRunStatement={runStatementAt}
+          onRunAll={runAll}
+        />
 
         <div className="ed-ai-strip" aria-hidden="true">
           <span className="ed-ai-strip-prompt">

--- a/apps/desktop/src/styles/editor.css
+++ b/apps/desktop/src/styles/editor.css
@@ -124,9 +124,156 @@
 
 .ed-scroll {
   flex: 1;
-  overflow: auto;
+  overflow: hidden;
   position: relative;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
+
+.cellar-cm {
+  flex: 1;
+  min-height: 0;
+}
+.cellar-cm .cm-editor {
+  height: 100%;
+  background: var(--bg-inset);
+  color: var(--fg-0);
+  outline: none;
+}
+.cellar-cm .cm-editor.cm-focused {
+  outline: none;
+}
+.cellar-cm .cm-scroller {
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  line-height: 1.55;
+}
+.cellar-cm .cm-content {
+  min-height: 100%;
+  padding: 6px 0 60px;
+  caret-color: var(--fg-0);
+}
+.cellar-cm .cm-line {
+  padding: 0 16px 0 8px;
+}
+.cellar-cm .cm-gutters {
+  width: 48px;
+  background: var(--bg-inset);
+  border-right: none;
+  color: var(--fg-3);
+  font-size: 10.5px;
+}
+.cellar-cm .cm-lineNumbers .cm-gutterElement {
+  min-width: 48px;
+  padding: 0 8px 0 4px;
+  text-align: right;
+}
+.cellar-cm .cm-foldGutter {
+  display: none;
+}
+.cellar-cm .cm-activeLineGutter {
+  background: transparent;
+  color: var(--accent);
+}
+.cellar-cm .cm-activeLine {
+  background: transparent;
+}
+.cellar-cm .cm-selectionBackground,
+.cellar-cm .cm-focused .cm-selectionBackground,
+.cellar-cm ::selection {
+  background: var(--accent-line) !important;
+}
+.cellar-cm .cm-cursor {
+  border-left-color: var(--fg-0);
+}
+.cellar-cm .cm-placeholder {
+  color: var(--fg-4);
+}
+.cellar-cm .cm-line.cm-cellar-current-statement {
+  background: linear-gradient(
+    90deg,
+    var(--accent-soft),
+    color-mix(in oklab, var(--accent-soft) 50%, transparent)
+  );
+}
+.cellar-cm .cm-line.cm-cellar-error-line {
+  text-decoration-line: underline;
+  text-decoration-style: wavy;
+  text-decoration-color: var(--syn-error);
+  text-decoration-thickness: 1.5px;
+  text-underline-offset: 3px;
+}
+.cellar-cm .cm-gutterElement.cm-cellar-current-statement {
+  background: linear-gradient(90deg, transparent, var(--accent-soft) 40%);
+  color: var(--accent);
+}
+.cm-tooltip.cm-tooltip-autocomplete {
+  background: color-mix(in oklab, var(--bg-1) 96%, black);
+  border: 1px solid var(--border-strong);
+  border-radius: 6px;
+  box-shadow: var(--shadow-popover, 0 14px 36px rgba(0, 0, 0, 0.35));
+  color: var(--fg-1);
+  font-family: var(--font-sans);
+  overflow: hidden;
+}
+.cm-tooltip.cm-tooltip-autocomplete > ul {
+  max-height: min(340px, 45vh);
+}
+.cm-tooltip.cm-tooltip-autocomplete ul li {
+  min-height: 24px;
+  padding: 2px 8px 2px 6px;
+  font-size: 12px;
+}
+.cm-tooltip.cm-tooltip-autocomplete ul li[aria-selected] {
+  background: var(--accent-soft);
+  color: var(--fg-0);
+}
+.cm-tooltip-autocomplete .cm-completionLabel {
+  font-family: var(--font-mono);
+}
+.cm-tooltip-autocomplete .cm-completionDetail {
+  color: var(--fg-3);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+}
+.cm-tooltip-autocomplete .cm-completionMatchedText {
+  color: var(--accent);
+  text-decoration: none;
+}
+.cm-tooltip-autocomplete .cm-completionSection {
+  background: var(--bg-2);
+  color: var(--fg-3);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0;
+  padding: 4px 8px;
+  text-transform: uppercase;
+}
+.cm-cellar-token-keyword {
+  color: var(--syn-kw);
+  font-weight: 600;
+}
+.cm-cellar-token-function {
+  color: var(--syn-fn);
+}
+.cm-cellar-token-string {
+  color: var(--syn-str);
+}
+.cm-cellar-token-number {
+  color: var(--syn-num);
+}
+.cm-cellar-token-comment {
+  color: var(--syn-comment);
+  font-style: italic;
+}
+.cm-cellar-token-operator {
+  color: var(--syn-op);
+}
+.cm-cellar-token-identifier {
+  color: var(--syn-ident);
+}
+
 .ed-doc {
   position: relative;
   width: max-content;

--- a/packages/sql-editor/package.json
+++ b/packages/sql-editor/package.json
@@ -3,13 +3,30 @@
   "version": "0.1.0-alpha",
   "private": true,
   "type": "module",
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./src/index.tsx",
+  "types": "./src/index.tsx",
   "scripts": {
-    "lint": "node ../../scripts/check-ts-entry.mjs src/index.ts",
+    "lint": "node ../../scripts/check-ts-entry.mjs src/index.tsx",
     "test": "vitest run --passWithNoTests"
   },
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.tsx"
+  },
+  "dependencies": {
+    "@codemirror/autocomplete": "^6.20.2",
+    "@codemirror/commands": "^6.10.3",
+    "@codemirror/lang-sql": "^6.10.0",
+    "@codemirror/language": "^6.12.3",
+    "@codemirror/search": "^6.7.0",
+    "@codemirror/state": "^6.6.0",
+    "@codemirror/view": "^6.43.0",
+    "@lezer/highlight": "^1.2.3"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.3",
+    "react": "^18.3.1"
   }
 }

--- a/packages/sql-editor/src/completion.ts
+++ b/packages/sql-editor/src/completion.ts
@@ -1,0 +1,361 @@
+import type {
+  Completion,
+  CompletionContext,
+  CompletionResult,
+} from "@codemirror/autocomplete";
+import type {
+  SqlColumnMeta,
+  SqlDatabaseMeta,
+  SqlRelationMeta,
+} from "./types";
+
+interface CompletionConfig {
+  databases: readonly SqlDatabaseMeta[];
+  database: string | null;
+}
+
+interface RelationRef {
+  schema: string;
+  name: string;
+  columns: readonly SqlColumnMeta[];
+  kind: "table" | "view";
+}
+
+interface ParsedSqlContext {
+  relationContext: boolean;
+  aliasOrQualifier: string | null;
+  replacementFrom: number;
+  text: string;
+}
+
+const RELATION_PRECEDERS = new Set([
+  "from",
+  "join",
+  "into",
+  "update",
+  "table",
+  "describe",
+  "truncate",
+]);
+
+const COLUMN_PRECEDERS = new Set([
+  "select",
+  "where",
+  "and",
+  "or",
+  "on",
+  "by",
+  "group",
+  "order",
+  "having",
+  "set",
+  "returning",
+]);
+
+const KEYWORD_COMPLETIONS: readonly Completion[] = [
+  "SELECT",
+  "FROM",
+  "WHERE",
+  "JOIN",
+  "LEFT JOIN",
+  "INNER JOIN",
+  "GROUP BY",
+  "ORDER BY",
+  "HAVING",
+  "LIMIT",
+  "INSERT INTO",
+  "UPDATE",
+  "DELETE FROM",
+  "CREATE TABLE",
+  "ALTER TABLE",
+  "DROP TABLE",
+  "WITH",
+  "VALUES",
+  "RETURNING",
+  "EXPLAIN",
+].map((label) => ({
+  label,
+  type: "keyword",
+  section: "keywords",
+  boost: -5,
+}));
+
+const SNIPPET_COMPLETIONS: readonly Completion[] = [
+  {
+    label: "sel",
+    detail: "select rows",
+    apply: "SELECT *\nFROM \nLIMIT 100;",
+    type: "keyword",
+    section: "snippets",
+    boost: 20,
+  },
+  {
+    label: "ins",
+    detail: "insert row",
+    apply: "INSERT INTO \n  ()\nVALUES\n  ();",
+    type: "keyword",
+    section: "snippets",
+    boost: 12,
+  },
+  {
+    label: "upd",
+    detail: "update rows",
+    apply: "UPDATE \nSET \nWHERE ;",
+    type: "keyword",
+    section: "snippets",
+    boost: 12,
+  },
+  {
+    label: "del",
+    detail: "delete rows",
+    apply: "DELETE FROM \nWHERE ;",
+    type: "keyword",
+    section: "snippets",
+    boost: 12,
+  },
+  {
+    label: "jln",
+    detail: "left join",
+    apply: "LEFT JOIN  ON ",
+    type: "keyword",
+    section: "snippets",
+    boost: 8,
+  },
+];
+
+export function cellarCompletionSource(config: CompletionConfig) {
+  return (context: CompletionContext): CompletionResult | null => {
+    const parsed = parseCompletionContext(context);
+    if (!parsed) return null;
+
+    const relations = relationsFor(config);
+    const aliases = aliasesFor(context.state.doc.toString(), context.pos, relations);
+    const options = completionOptions(parsed, relations, aliases);
+
+    return {
+      from: parsed.replacementFrom,
+      options,
+      validFor: /^[\w$"]*$/,
+    };
+  };
+}
+
+function parseCompletionContext(context: CompletionContext): ParsedSqlContext | null {
+  const match = context.matchBefore(/[A-Za-z_][\w$]*(?:\.[A-Za-z_][\w$]*)?|\./);
+  const explicitEmpty = context.explicit && context.pos > 0;
+  if (!match && !explicitEmpty) return null;
+
+  const before = context.state.sliceDoc(0, context.pos);
+  const text = match?.text ?? "";
+  const tokenFrom = match?.from ?? context.pos;
+  const lastDot = text.lastIndexOf(".");
+  const aliasOrQualifier = lastDot >= 0 ? text.slice(0, lastDot) : null;
+  const replacementFrom = lastDot >= 0 ? tokenFrom + lastDot + 1 : tokenFrom;
+  const previous = previousWord(before.slice(0, tokenFrom)).toLowerCase();
+  const relationContext = RELATION_PRECEDERS.has(previous);
+  const columnContext = COLUMN_PRECEDERS.has(previous);
+
+  if (!context.explicit && text.length === 0 && !relationContext && !columnContext) {
+    return null;
+  }
+
+  return {
+    relationContext,
+    aliasOrQualifier,
+    replacementFrom,
+    text,
+  };
+}
+
+function completionOptions(
+  context: ParsedSqlContext,
+  relations: readonly RelationRef[],
+  aliases: ReadonlyMap<string, RelationRef>,
+): Completion[] {
+  if (context.aliasOrQualifier) {
+    const qualifier = normalizeIdentifier(context.aliasOrQualifier);
+    const aliasRelation = aliases.get(qualifier);
+    if (aliasRelation) return columnOptions(aliasRelation.columns, aliasRelation.name, 30);
+
+    const schemaRelations = relations.filter(
+      (relation) => relation.schema.toLowerCase() === qualifier,
+    );
+    if (schemaRelations.length > 0) return relationOptions(schemaRelations, false);
+
+    const relation = relations.find(
+      (candidate) => candidate.name.toLowerCase() === qualifier,
+    );
+    if (relation) return columnOptions(relation.columns, relation.name, 24);
+  }
+
+  if (context.relationContext) {
+    return [
+      ...relationOptions(relations, true),
+      ...relationOptions(relations, false),
+      ...schemaOptions(relations),
+      ...KEYWORD_COMPLETIONS,
+    ];
+  }
+
+  const scopedColumns = columnsForAliases(aliases);
+  const columnSource = scopedColumns.length > 0 ? scopedColumns : allColumns(relations);
+
+  return [
+    ...SNIPPET_COMPLETIONS,
+    ...columnOptions(columnSource, "schema", scopedColumns.length > 0 ? 18 : 0),
+    ...relationOptions(relations, true).map((option) => ({ ...option, boost: -8 })),
+    ...KEYWORD_COMPLETIONS,
+  ];
+}
+
+function relationsFor(config: CompletionConfig): RelationRef[] {
+  const db = databaseFor(config.databases, config.database);
+  if (!db) return [];
+
+  return db.schemas.flatMap((schema) => [
+    ...schema.tables.map((table) => relationRef(schema.name, table, "table")),
+    ...schema.views.map((view) => relationRef(schema.name, view, "view")),
+  ]);
+}
+
+function relationRef(
+  schema: string,
+  relation: SqlRelationMeta,
+  kind: "table" | "view",
+): RelationRef {
+  return {
+    schema,
+    name: relation.name,
+    columns: relation.columns,
+    kind,
+  };
+}
+
+function databaseFor(
+  databases: readonly SqlDatabaseMeta[],
+  database: string | null,
+): SqlDatabaseMeta | null {
+  if (database) {
+    const match = databases.find((db) => db.name === database);
+    if (match) return match;
+  }
+  return databases.find((db) => db.is_default) ?? databases[0] ?? null;
+}
+
+function relationOptions(
+  relations: readonly RelationRef[],
+  qualified: boolean,
+): Completion[] {
+  const seen = new Set<string>();
+  return relations.flatMap((relation) => {
+    const label = qualified ? `${relation.schema}.${relation.name}` : relation.name;
+    const key = `${label}:${relation.kind}`;
+    if (seen.has(key)) return [];
+    seen.add(key);
+    return [
+      {
+        label,
+        detail: relation.kind,
+        type: relation.kind === "view" ? "interface" : "type",
+        section: relation.kind === "view" ? "views" : "tables",
+        boost: relation.kind === "table" ? 15 : 8,
+      },
+    ];
+  });
+}
+
+function schemaOptions(relations: readonly RelationRef[]): Completion[] {
+  const names = new Set(relations.map((relation) => relation.schema));
+  return [...names].map((label) => ({
+    label,
+    detail: "schema",
+    type: "namespace",
+    section: "schemas",
+  }));
+}
+
+function columnOptions(
+  columns: readonly SqlColumnMeta[],
+  source: string,
+  boost: number,
+): Completion[] {
+  const seen = new Set<string>();
+  return columns.flatMap((column) => {
+    const key = column.name.toLowerCase();
+    if (seen.has(key)) return [];
+    seen.add(key);
+    return [
+      {
+        label: column.name,
+        detail: column.data_type || source,
+        type: "property",
+        section: "columns",
+        boost: column.is_primary_key ? boost + 4 : boost,
+      },
+    ];
+  });
+}
+
+function columnsForAliases(aliases: ReadonlyMap<string, RelationRef>): SqlColumnMeta[] {
+  const columns: SqlColumnMeta[] = [];
+  for (const [alias, relation] of aliases) {
+    for (const column of relation.columns) {
+      columns.push({
+        ...column,
+        name: aliases.size > 1 ? `${alias}.${column.name}` : column.name,
+      });
+    }
+  }
+  return columns;
+}
+
+function allColumns(relations: readonly RelationRef[]): SqlColumnMeta[] {
+  return relations.flatMap((relation) => relation.columns);
+}
+
+function aliasesFor(
+  sqlText: string,
+  position: number,
+  relations: readonly RelationRef[],
+): Map<string, RelationRef> {
+  const statement = currentStatementText(sqlText, position);
+  const aliases = new Map<string, RelationRef>();
+  const pattern =
+    /\b(?:from|join|update|into)\s+((?:"[^"]+"|[A-Za-z_][\w$]*)(?:\s*\.\s*(?:"[^"]+"|[A-Za-z_][\w$]*))?)(?:\s+(?:as\s+)?(?!(?:on|where|join|left|right|inner|outer|full|cross|group|order|limit|having|set|values|returning)\b)("?[\w$]+"?))?/gi;
+
+  for (const match of statement.matchAll(pattern)) {
+    const relationName = normalizeIdentifier((match[1] ?? "").split(".").pop() ?? "");
+    const relationSchema = relationQualifier(match[1] ?? "");
+    const relation = relations.find((candidate) => {
+      if (candidate.name.toLowerCase() !== relationName) return false;
+      return relationSchema ? candidate.schema.toLowerCase() === relationSchema : true;
+    });
+    if (!relation) continue;
+
+    aliases.set(relation.name.toLowerCase(), relation);
+    if (match[2]) aliases.set(normalizeIdentifier(match[2]), relation);
+  }
+
+  return aliases;
+}
+
+function currentStatementText(sqlText: string, position: number): string {
+  const start = sqlText.lastIndexOf(";", Math.max(0, position - 1)) + 1;
+  const end = sqlText.indexOf(";", position);
+  return sqlText.slice(start, end === -1 ? sqlText.length : end);
+}
+
+function relationQualifier(raw: string): string | null {
+  const parts = raw.split(".");
+  if (parts.length < 2) return null;
+  return normalizeIdentifier(parts[0] ?? "");
+}
+
+function normalizeIdentifier(value: string): string {
+  return value.trim().replace(/^"|"$/g, "").toLowerCase();
+}
+
+function previousWord(text: string): string {
+  const match = text.match(/([A-Za-z_][\w$]*)\s*$/);
+  return match?.[1] ?? "";
+}

--- a/packages/sql-editor/src/index.ts
+++ b/packages/sql-editor/src/index.ts
@@ -1,2 +1,0 @@
-// CodeMirror 6 SQL editor wrapper lands here.
-export {};

--- a/packages/sql-editor/src/index.tsx
+++ b/packages/sql-editor/src/index.tsx
@@ -1,0 +1,376 @@
+import {
+  autocompletion,
+  closeBrackets,
+  closeBracketsKeymap,
+  type CompletionContext,
+  type CompletionResult,
+  completionKeymap,
+} from "@codemirror/autocomplete";
+import {
+  defaultKeymap,
+  history,
+  historyKeymap,
+  indentWithTab,
+} from "@codemirror/commands";
+import {
+  MSSQL,
+  MySQL,
+  PostgreSQL,
+  SQLite,
+  StandardSQL,
+  sql,
+  type SQLDialect,
+} from "@codemirror/lang-sql";
+import {
+  bracketMatching,
+  HighlightStyle,
+  foldGutter,
+  indentOnInput,
+  syntaxHighlighting,
+} from "@codemirror/language";
+import { highlightSelectionMatches, searchKeymap } from "@codemirror/search";
+import {
+  Compartment,
+  EditorState,
+  RangeSetBuilder,
+  type Extension,
+} from "@codemirror/state";
+import {
+  crosshairCursor,
+  Decoration,
+  drawSelection,
+  dropCursor,
+  EditorView,
+  highlightActiveLine,
+  highlightActiveLineGutter,
+  keymap,
+  lineNumbers,
+  placeholder as editorPlaceholder,
+  rectangularSelection,
+  scrollPastEnd,
+} from "@codemirror/view";
+import { tags } from "@lezer/highlight";
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  type KeyboardEvent,
+  type MutableRefObject,
+} from "react";
+import { cellarCompletionSource } from "./completion";
+import type { SqlDatabaseMeta, SqlEngine } from "./types";
+
+export type {
+  SqlColumnMeta,
+  SqlDatabaseMeta,
+  SqlEngine,
+  SqlRelationMeta,
+  SqlSchemaMeta,
+} from "./types";
+
+export interface SqlEditorProps {
+  value: string;
+  engine?: SqlEngine;
+  databases?: readonly SqlDatabaseMeta[];
+  database?: string | null;
+  placeholder?: string;
+  wrap?: boolean;
+  currentStatementRange?: readonly [number, number] | null;
+  errorLine?: number | null;
+  className?: string;
+  onChange: (value: string) => void;
+  onCursorChange?: (offset: number) => void;
+  onRunStatement?: (offset: number) => void;
+  onRunAll?: () => void;
+}
+
+interface LatestCallbacks {
+  onChange: SqlEditorProps["onChange"];
+  onCursorChange?: SqlEditorProps["onCursorChange"];
+  onRunStatement?: SqlEditorProps["onRunStatement"];
+  onRunAll?: SqlEditorProps["onRunAll"];
+}
+
+const updateCompartment = new Compartment();
+const languageCompartment = new Compartment();
+const completionCompartment = new Compartment();
+const wrappingCompartment = new Compartment();
+const decorationCompartment = new Compartment();
+const placeholderCompartment = new Compartment();
+
+export function SqlCodeEditor({
+  value,
+  engine = "postgres",
+  databases = [],
+  database = null,
+  placeholder = "",
+  wrap = false,
+  currentStatementRange = null,
+  errorLine = null,
+  className = "",
+  onChange,
+  onCursorChange,
+  onRunStatement,
+  onRunAll,
+}: SqlEditorProps) {
+  const host = useRef<HTMLDivElement>(null);
+  const viewRef = useRef<EditorView | null>(null);
+  const latest = useRef<LatestCallbacks>({ onChange });
+
+  latest.current = {
+    onChange,
+    onCursorChange,
+    onRunStatement,
+    onRunAll,
+  };
+
+  const completionSource = useMemo(
+    () => cellarCompletionSource({ databases, database }),
+    [databases, database],
+  );
+
+  useLayoutEffect(() => {
+    if (!host.current || viewRef.current) return;
+
+    const view = new EditorView({
+      parent: host.current,
+      state: EditorState.create({
+        doc: value,
+        extensions: [
+          baseExtensions(latest),
+          languageCompartment.of(languageExtension(engine)),
+          completionCompartment.of(completionExtension(completionSource)),
+          wrappingCompartment.of(wrap ? EditorView.lineWrapping : []),
+          placeholderCompartment.of(editorPlaceholder(placeholder)),
+          decorationCompartment.of(lineDecorations(currentStatementRange, errorLine)),
+          updateCompartment.of(updateExtension(latest)),
+        ],
+      }),
+    });
+
+    viewRef.current = view;
+    latest.current.onCursorChange?.(view.state.selection.main.head);
+
+    return () => {
+      view.destroy();
+      viewRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    const current = view.state.doc.toString();
+    if (current === value) return;
+
+    view.dispatch({
+      changes: { from: 0, to: current.length, insert: value },
+    });
+  }, [value]);
+
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    view.dispatch({
+      effects: languageCompartment.reconfigure(languageExtension(engine)),
+    });
+  }, [engine]);
+
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    view.dispatch({
+      effects: completionCompartment.reconfigure(
+        completionExtension(completionSource),
+      ),
+    });
+  }, [completionSource]);
+
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    view.dispatch({
+      effects: wrappingCompartment.reconfigure(wrap ? EditorView.lineWrapping : []),
+    });
+  }, [wrap]);
+
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    view.dispatch({
+      effects: placeholderCompartment.reconfigure(editorPlaceholder(placeholder)),
+    });
+  }, [placeholder]);
+
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    view.dispatch({
+      effects: decorationCompartment.reconfigure(
+        lineDecorations(currentStatementRange, errorLine),
+      ),
+    });
+  }, [currentStatementRange, errorLine]);
+
+  return (
+    <div
+      ref={host}
+      className={["cellar-cm", className].filter(Boolean).join(" ")}
+      onKeyDown={stopHandledRunKeys}
+    />
+  );
+}
+
+function baseExtensions(latest: MutableRefObject<LatestCallbacks>): Extension {
+  return [
+    lineNumbers(),
+    highlightActiveLineGutter(),
+    history(),
+    foldGutter(),
+    drawSelection(),
+    dropCursor(),
+    EditorState.allowMultipleSelections.of(true),
+    indentOnInput(),
+    syntaxHighlighting(sqlHighlightStyle, { fallback: true }),
+    bracketMatching(),
+    closeBrackets(),
+    rectangularSelection(),
+    crosshairCursor(),
+    highlightActiveLine(),
+    highlightSelectionMatches(),
+    scrollPastEnd(),
+    keymap.of([
+      {
+        key: "Mod-Enter",
+        run(view) {
+          latest.current.onRunStatement?.(view.state.selection.main.head);
+          return true;
+        },
+      },
+      {
+        key: "Mod-Shift-Enter",
+        run() {
+          latest.current.onRunAll?.();
+          return true;
+        },
+      },
+      indentWithTab,
+      ...closeBracketsKeymap,
+      ...completionKeymap,
+      ...searchKeymap,
+      ...historyKeymap,
+      ...defaultKeymap,
+    ]),
+  ];
+}
+
+const sqlHighlightStyle = HighlightStyle.define([
+  { tag: tags.keyword, class: "cm-cellar-token-keyword" },
+  { tag: tags.operatorKeyword, class: "cm-cellar-token-keyword" },
+  { tag: tags.function(tags.variableName), class: "cm-cellar-token-function" },
+  { tag: tags.standard(tags.variableName), class: "cm-cellar-token-function" },
+  { tag: tags.string, class: "cm-cellar-token-string" },
+  { tag: tags.number, class: "cm-cellar-token-number" },
+  { tag: tags.comment, class: "cm-cellar-token-comment" },
+  { tag: tags.operator, class: "cm-cellar-token-operator" },
+  { tag: tags.variableName, class: "cm-cellar-token-identifier" },
+  { tag: tags.name, class: "cm-cellar-token-identifier" },
+]);
+
+function updateExtension(latest: MutableRefObject<LatestCallbacks>): Extension {
+  return EditorView.updateListener.of((update) => {
+    if (update.docChanged) {
+      latest.current.onChange(update.state.doc.toString());
+    }
+    if (update.docChanged || update.selectionSet) {
+      latest.current.onCursorChange?.(update.state.selection.main.head);
+    }
+  });
+}
+
+function languageExtension(engine: SqlEngine): Extension {
+  return sql({
+    dialect: dialectFor(engine),
+    upperCaseKeywords: true,
+  });
+}
+
+function completionExtension(source: (context: CompletionContext) => CompletionResult | null) {
+  return autocompletion({
+    activateOnTyping: true,
+    maxRenderedOptions: 80,
+    override: [source],
+  });
+}
+
+function lineDecorations(
+  range: readonly [number, number] | null,
+  errorLine: number | null,
+): Extension {
+  return EditorView.decorations.of((view) => {
+    const builder = new RangeSetBuilder<Decoration>();
+    const lines = view.state.doc.lines;
+    const classes = new Map<number, string[]>();
+
+    if (range) {
+      const fromLine = clampLine(range[0], lines);
+      const toLine = clampLine(range[1], lines);
+      for (let lineNo = fromLine; lineNo <= toLine; lineNo++) {
+        appendLineClass(classes, lineNo, "cm-cellar-current-statement");
+      }
+    }
+
+    if (errorLine != null) {
+      appendLineClass(classes, clampLine(errorLine, lines), "cm-cellar-error-line");
+    }
+
+    for (const [lineNo, lineClasses] of [...classes].sort((a, b) => a[0] - b[0])) {
+      const line = view.state.doc.line(lineNo);
+      builder.add(
+        line.from,
+        line.from,
+        Decoration.line({ class: lineClasses.join(" ") }),
+      );
+    }
+
+    return builder.finish();
+  });
+}
+
+function appendLineClass(
+  classes: Map<number, string[]>,
+  lineNo: number,
+  className: string,
+) {
+  const existing = classes.get(lineNo) ?? [];
+  existing.push(className);
+  classes.set(lineNo, existing);
+}
+
+function clampLine(line: number, max: number) {
+  return Math.max(1, Math.min(max, line));
+}
+
+function dialectFor(engine: SqlEngine): SQLDialect {
+  switch (engine) {
+    case "postgres":
+      return PostgreSQL;
+    case "mysql":
+      return MySQL;
+    case "sqlite":
+      return SQLite;
+    case "mssql":
+    case "azure":
+      return MSSQL;
+    default:
+      return StandardSQL;
+  }
+}
+
+function stopHandledRunKeys(event: KeyboardEvent<HTMLDivElement>) {
+  const mod = event.metaKey || event.ctrlKey;
+  if (mod && event.key === "Enter") {
+    event.stopPropagation();
+  }
+}

--- a/packages/sql-editor/src/types.ts
+++ b/packages/sql-editor/src/types.ts
@@ -1,0 +1,26 @@
+export type SqlEngine = "postgres" | "mysql" | "sqlite" | "mssql" | "azure";
+
+export interface SqlColumnMeta {
+  name: string;
+  data_type: string;
+  nullable?: boolean;
+  is_primary_key?: boolean;
+}
+
+export interface SqlRelationMeta {
+  name: string;
+  schema: string;
+  columns: SqlColumnMeta[];
+}
+
+export interface SqlSchemaMeta {
+  name: string;
+  tables: SqlRelationMeta[];
+  views: SqlRelationMeta[];
+}
+
+export interface SqlDatabaseMeta {
+  name: string;
+  is_default?: boolean;
+  schemas: SqlSchemaMeta[];
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@cellar/ipc':
         specifier: workspace:*
         version: link:../../packages/ipc
+      '@cellar/sql-editor':
+        specifier: workspace:0.1.0-alpha
+        version: link:../../packages/sql-editor
       '@tauri-apps/api':
         specifier: ^2.0.0
         version: 2.11.0
@@ -86,7 +89,39 @@ importers:
 
   packages/plugin-sdk: {}
 
-  packages/sql-editor: {}
+  packages/sql-editor:
+    dependencies:
+      '@codemirror/autocomplete':
+        specifier: ^6.20.2
+        version: 6.20.2
+      '@codemirror/commands':
+        specifier: ^6.10.3
+        version: 6.10.3
+      '@codemirror/lang-sql':
+        specifier: ^6.10.0
+        version: 6.10.0
+      '@codemirror/language':
+        specifier: ^6.12.3
+        version: 6.12.3
+      '@codemirror/search':
+        specifier: ^6.7.0
+        version: 6.7.0
+      '@codemirror/state':
+        specifier: ^6.6.0
+        version: 6.6.0
+      '@codemirror/view':
+        specifier: ^6.43.0
+        version: 6.43.0
+      '@lezer/highlight':
+        specifier: ^1.2.3
+        version: 1.2.3
+    devDependencies:
+      '@types/react':
+        specifier: ^18.3.3
+        version: 18.3.29
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
 
   packages/ui: {}
 
@@ -174,6 +209,27 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@codemirror/autocomplete@6.20.2':
+    resolution: {integrity: sha512-G5FPkgIiLjOgZMjqVjvuKQ1rGPtHogLldJr33eFJdVLtmwY+giGrlv/ewljLz6b9BSQLkjxuwBc6g6omDM+YxQ==}
+
+  '@codemirror/commands@6.10.3':
+    resolution: {integrity: sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==}
+
+  '@codemirror/lang-sql@6.10.0':
+    resolution: {integrity: sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w==}
+
+  '@codemirror/language@6.12.3':
+    resolution: {integrity: sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==}
+
+  '@codemirror/search@6.7.0':
+    resolution: {integrity: sha512-ZvGm99wc/s2cITtMT15LFdn8aH/aS+V+DqyGq/N5ZlV5vWtH+nILvC2nw0zX7ByNoHHDZ2IxxdW38O0tc5nVHg==}
+
+  '@codemirror/state@6.6.0':
+    resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
+
+  '@codemirror/view@6.43.0':
+    resolution: {integrity: sha512-V7ZCLQO3Jus9hzh2jVCCPW3mO4IBMr43O37PqSUYautJSnnJF41YlgLw21x0fLJTYvJ+Vkm6Gp+qKGH9pltgXA==}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -328,6 +384,18 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@lezer/common@1.5.2':
+    resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
+
+  '@lezer/highlight@1.2.3':
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/lr@1.4.10':
+    resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
+
+  '@marijn/find-cluster-break@1.0.2':
+    resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -747,6 +815,9 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -969,6 +1040,9 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  style-mod@4.1.3:
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
+
   tailwindcss@4.3.0:
     resolution: {integrity: sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==}
 
@@ -1077,6 +1151,9 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
@@ -1215,6 +1292,55 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
+  '@codemirror/autocomplete@6.20.2':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
+
+  '@codemirror/commands@6.10.3':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
+
+  '@codemirror/lang-sql@6.10.0':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.2
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/language@6.12.3':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      style-mod: 4.1.3
+
+  '@codemirror/search@6.7.0':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      crelt: 1.0.6
+
+  '@codemirror/state@6.6.0':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.2
+
+  '@codemirror/view@6.43.0':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      crelt: 1.0.6
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
+
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
@@ -1302,6 +1428,18 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@lezer/common@1.5.2': {}
+
+  '@lezer/highlight@1.2.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/lr@1.4.10':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@marijn/find-cluster-break@1.0.2': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -1633,6 +1771,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  crelt@1.0.6: {}
+
   csstype@3.2.3: {}
 
   debug@4.4.3:
@@ -1839,6 +1979,8 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  style-mod@4.1.3: {}
+
   tailwindcss@4.3.0: {}
 
   tapable@2.3.3: {}
@@ -1938,6 +2080,8 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  w3c-keyname@2.2.8: {}
 
   why-is-node-running@2.3.0:
     dependencies:


### PR DESCRIPTION
## Summary

- replace the desktop SQL textarea overlay with a CodeMirror 6-backed `@cellar/sql-editor` wrapper
- add schema-aware SQL completions for cached tables, views, columns, simple aliases, keywords, and first-pass snippets
- style CodeMirror, syntax highlighting, current-statement/error-line decorations, and the autocomplete popup to match the existing Cellar editor UI

## Impact

This gives the SQL editor a real extensible editor foundation and a first pass at IntelliSense without changing the existing run-current-statement, run-all, wrap, or Explain toolbar behavior.

## Validation

- `pnpm --filter @cellar/sql-editor lint`
- `pnpm --filter @cellar/desktop typecheck`
- `pnpm --filter @cellar/desktop test`
- `pnpm --filter @cellar/sql-editor test`
- `pnpm --filter @cellar/desktop build`

Note: the build passes with Vite's large-chunk warning after bundling the editor packages.