### PR TITLE
fix: correct context menu positioning

### DIFF
--- a/apps/desktop/src/components/ContextMenu.test.ts
+++ b/apps/desktop/src/components/ContextMenu.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { contextMenuPosition } from "./ContextMenu";
+
+describe("contextMenuPosition", () => {
+  it("compensates fixed coordinates for the app UI scale", () => {
+    expect(
+      contextMenuPosition({
+        x: 154,
+        y: 67,
+        viewportWidth: 800,
+        viewportHeight: 600,
+        menuWidth: 190,
+        menuHeight: 123,
+        scale: 1.75,
+      }),
+    ).toEqual({
+      left: 88,
+      top: 38.285714285714285,
+    });
+  });
+
+  it("clamps the menu inside the visible viewport before scale compensation", () => {
+    expect(
+      contextMenuPosition({
+        x: 780,
+        y: 590,
+        viewportWidth: 800,
+        viewportHeight: 600,
+        menuWidth: 190,
+        menuHeight: 123,
+        scale: 2,
+      }),
+    ).toEqual({
+      left: 301,
+      top: 234.5,
+    });
+  });
+});

--- a/apps/desktop/src/components/ContextMenu.tsx
+++ b/apps/desktop/src/components/ContextMenu.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useRef, type ReactNode } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 
 export interface MenuItem {
   label: string;
@@ -14,6 +20,46 @@ export interface ContextMenuState {
   items: MenuItem[];
 }
 
+export interface ContextMenuPositionInput {
+  x: number;
+  y: number;
+  viewportWidth: number;
+  viewportHeight: number;
+  menuWidth: number;
+  menuHeight: number;
+  scale: number;
+  margin?: number;
+}
+
+export function contextMenuPosition({
+  x,
+  y,
+  viewportWidth,
+  viewportHeight,
+  menuWidth,
+  menuHeight,
+  scale,
+  margin = 8,
+}: ContextMenuPositionInput): { left: number; top: number } {
+  const safeScale = Number.isFinite(scale) && scale > 0 ? scale : 1;
+  const maxVisualLeft = Math.max(margin, viewportWidth - menuWidth - margin);
+  const maxVisualTop = Math.max(margin, viewportHeight - menuHeight - margin);
+  const visualLeft = Math.min(Math.max(x, margin), maxVisualLeft);
+  const visualTop = Math.min(Math.max(y, margin), maxVisualTop);
+
+  return {
+    left: visualLeft / safeScale,
+    top: visualTop / safeScale,
+  };
+}
+
+function uiScale(): number {
+  const scale = Number.parseFloat(
+    getComputedStyle(document.documentElement).getPropertyValue("--ui-scale"),
+  );
+  return Number.isFinite(scale) && scale > 0 ? scale : 1;
+}
+
 /**
  * Lightweight right-click menu. Renders at a fixed viewport position, closes
  * on outside click, Escape, scroll, or window blur. Items are flat (no
@@ -27,6 +73,9 @@ export function ContextMenu({
   onClose: () => void;
 }) {
   const ref = useRef<HTMLDivElement>(null);
+  const [position, setPosition] = useState<{ left: number; top: number } | null>(
+    null,
+  );
 
   useEffect(() => {
     if (!state) return;
@@ -38,29 +87,53 @@ export function ContextMenu({
     };
     window.addEventListener("mousedown", onDocClick);
     window.addEventListener("keydown", onKey);
+    window.addEventListener("scroll", onClose, true);
     window.addEventListener("blur", onClose);
     window.addEventListener("resize", onClose);
     return () => {
       window.removeEventListener("mousedown", onDocClick);
       window.removeEventListener("keydown", onKey);
+      window.removeEventListener("scroll", onClose, true);
       window.removeEventListener("blur", onClose);
       window.removeEventListener("resize", onClose);
     };
   }, [state, onClose]);
 
+  useLayoutEffect(() => {
+    if (!state || !ref.current) {
+      setPosition(null);
+      return;
+    }
+
+    const scale = uiScale();
+    const rect = ref.current.getBoundingClientRect();
+    setPosition(
+      contextMenuPosition({
+        x: state.x,
+        y: state.y,
+        viewportWidth: window.innerWidth,
+        viewportHeight: window.innerHeight,
+        menuWidth: rect.width,
+        menuHeight: rect.height,
+        scale,
+      }),
+    );
+  }, [state]);
+
   if (!state) return null;
 
-  // Keep the menu on-screen if it would overflow the right/bottom edge.
-  const maxX = window.innerWidth - 200;
-  const maxY = window.innerHeight - state.items.length * 28 - 12;
-  const left = Math.min(state.x, Math.max(8, maxX));
-  const top = Math.min(state.y, Math.max(8, maxY));
+  const scale = uiScale();
+  const fallback = {
+    left: state.x / scale,
+    top: state.y / scale,
+  };
+  const { left, top } = position ?? fallback;
 
   return (
     <div
       ref={ref}
       className="fixed z-[1000] min-w-[176px] rounded-[6px] border border-border-strong bg-bg-2 py-1 shadow-[0_8px_24px_rgba(0,0,0,0.4)]"
-      style={{ left, top }}
+      style={{ left, top, opacity: position ? undefined : 0 }}
       role="menu"
     >
       {state.items.map((item, i) => (


### PR DESCRIPTION
## Summary

Fixes the sidebar context menu appearing away from the cursor when the app UI scale is not the default.

## Details

The desktop app applies custom font-size scaling through `body.style.zoom` and exposes that value as `--ui-scale`. The context menu was using raw viewport `clientX` and `clientY` coordinates directly for a fixed element inside the zoomed app surface, so the painted menu could be offset from the right-click location.

This change measures the rendered menu, clamps it inside the visible viewport, and compensates the fixed coordinates by the current UI scale. It also adds the existing documented scroll-close behavior and unit coverage for scaled and viewport-edge placement.

## Validation

- `pnpm --filter @cellar/desktop test`
- `pnpm --filter @cellar/desktop typecheck`

Note: I attempted an in-app browser sanity check, but the Browser connector was unavailable in this session.
