### PR TITLE
feat: add tab context menu

### DIFF
--- a/apps/desktop/src/components/TabBar.tsx
+++ b/apps/desktop/src/components/TabBar.tsx
@@ -1,6 +1,14 @@
+import { useState, type MouseEvent as ReactMouseEvent } from "react";
+
+import {
+  ContextMenu,
+  type ContextMenuState,
+  type MenuItem,
+} from "./ContextMenu";
 import { Icon } from "./icons";
+import { qualifiedName, selectAllStatement } from "../lib/sqlIdent";
 import { useConnections } from "../state/connections";
-import { useTabs } from "../state/tabs";
+import { useTabs, type WorkspaceTab } from "../state/tabs";
 
 /**
  * Pick the connection + database a new query tab should bind to: the active
@@ -27,6 +35,7 @@ function pickQueryTarget(): { connectionId: string; database: string } | null {
 }
 
 export function TabBar() {
+  const [menu, setMenu] = useState<ContextMenuState | null>(null);
   const tabs = useTabs((s) => s.tabs);
   const activeId = useTabs((s) => s.activeId);
   const split = useTabs((s) => s.split);
@@ -35,13 +44,87 @@ export function TabBar() {
   const closeTab = useTabs((s) => s.closeTab);
   const splitActiveTab = useTabs((s) => s.splitActiveTab);
   const reopenClosedTab = useTabs((s) => s.reopenClosedTab);
+  const closeOtherTabs = useTabs((s) => s.closeOtherTabs);
+  const closeTabsToRight = useTabs((s) => s.closeTabsToRight);
   const newQueryTab = useTabs((s) => s.newQueryTab);
+  const setQuerySql = useTabs((s) => s.setQuerySql);
+  const refreshTable = useTabs((s) => s.refreshTable);
   const hasConnections = useConnections((s) => s.connections.length > 0);
   const canSplit = tabs.length > 1 && activeId != null;
 
   const onNewQuery = () => {
     const target = pickQueryTarget();
     if (target) newQueryTab(target.connectionId, target.database);
+  };
+
+  const copyText = (text: string) => {
+    if (navigator.clipboard) void navigator.clipboard.writeText(text);
+  };
+
+  const queryFor = (tab: WorkspaceTab, sql?: string) => {
+    const id = newQueryTab(tab.connectionId, tab.database);
+    if (sql) {
+      setQuerySql(id, sql);
+    }
+  };
+
+  const menuItemsFor = (tab: WorkspaceTab): MenuItem[] => {
+    const index = tabs.findIndex((t) => t.id === tab.id);
+    const hasRightTabs = index >= 0 && index < tabs.length - 1;
+    const name =
+      tab.kind === "query" ? tab.title : qualifiedName(tab.schema, tab.table);
+
+    return [
+      {
+        label: "New SQL query",
+        icon: <Icon.terminal size={12} />,
+        onClick: () => queryFor(tab),
+      },
+      ...(tab.kind === "table"
+        ? [
+            {
+              label: "Refresh",
+              icon: <Icon.history size={12} />,
+              onClick: () => refreshTable(tab.id),
+            },
+            {
+              label: "Query SELECT *",
+              icon: <Icon.terminal size={12} />,
+              onClick: () =>
+                queryFor(tab, selectAllStatement(tab.schema, tab.table)),
+            },
+          ]
+        : []),
+      {
+        label: tab.kind === "query" ? "Copy title" : "Copy qualified name",
+        icon: <Icon.copy size={12} />,
+        onClick: () => copyText(name),
+      },
+      {
+        label: "Close",
+        icon: <Icon.close size={12} />,
+        onClick: () => closeTab(tab.id),
+      },
+      {
+        label: "Close Others",
+        icon: <Icon.close size={12} />,
+        disabled: tabs.length < 2,
+        onClick: () => closeOtherTabs(tab.id),
+      },
+      {
+        label: "Close Tabs to the Right",
+        icon: <Icon.close size={12} />,
+        disabled: !hasRightTabs,
+        onClick: () => closeTabsToRight(tab.id),
+      },
+    ];
+  };
+
+  const openTabMenu = (e: ReactMouseEvent, tab: WorkspaceTab) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setActive(tab.id);
+    setMenu({ x: e.clientX, y: e.clientY, items: menuItemsFor(tab) });
   };
 
   return (
@@ -58,6 +141,7 @@ export function TabBar() {
             <div
               key={t.id}
               onClick={() => setActive(t.id)}
+              onContextMenu={(e) => openTabMenu(e, t)}
               className={
                 "group relative inline-flex items-center gap-1.5 h-full pl-2.5 pr-2 max-w-[260px] shrink-0 border-r border-border-default text-[11.5px] cursor-pointer transition-[background,color] duration-100 " +
                 (isActive
@@ -157,6 +241,7 @@ export function TabBar() {
           <Icon.history size={12} />
         </button>
       </div>
+      <ContextMenu state={menu} onClose={() => setMenu(null)} />
     </div>
   );
 }

--- a/apps/desktop/src/state/tabs.test.ts
+++ b/apps/desktop/src/state/tabs.test.ts
@@ -1,6 +1,21 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
+import type { PendingChanges } from "@cellar/data-grid";
+import { tableResultSource, useTabResults } from "./tabResults";
 import { useTabs } from "./tabs";
+
+const source = tableResultSource(
+  "conn-1",
+  "app",
+  "public",
+  "orders",
+  "SELECT * FROM public.orders LIMIT 100",
+  100,
+);
+
+const changes: PendingChanges = {
+  "row-1": { kind: "update", edits: { name: { from: "old", to: "new" } } },
+};
 
 describe("tab workspace state", () => {
   beforeEach(() => {
@@ -12,6 +27,7 @@ describe("tab workspace state", () => {
       tableChanges: {},
       refreshKeys: {},
     });
+    useTabResults.setState({ byTabId: {} });
   });
 
   it("splits the active tab against a neighboring tab", () => {
@@ -69,5 +85,45 @@ describe("tab workspace state", () => {
     expect(reopened).toMatchObject({ id, kind: "query", sql: "select 1;" });
     expect(useTabs.getState().activeId).toBe(id);
     expect(useTabs.getState().closedTabs).toHaveLength(0);
+  });
+
+  it("closes other tabs and clears their scoped state", () => {
+    const store = useTabs.getState();
+    store.openTable("conn-1", "app", "public", "orders");
+    store.openTable("conn-1", "app", "public", "customers");
+    store.openTable("conn-1", "app", "events", "devices");
+
+    const keepId = "conn-1::app.public.customers";
+    const closedId = "conn-1::app.public.orders";
+    useTabs.getState().setTableChanges(closedId, changes);
+    useTabs.getState().refreshTable(closedId);
+    useTabResults.getState().setLoading(closedId, source);
+    useTabResults.getState().setLoading(keepId, source);
+
+    useTabs.getState().closeOtherTabs(keepId);
+
+    expect(useTabs.getState().tabs.map((t) => t.id)).toEqual([keepId]);
+    expect(useTabs.getState().activeId).toBe(keepId);
+    expect(useTabs.getState().closedTabs).toHaveLength(2);
+    expect(useTabs.getState().split).toBeNull();
+    expect(useTabs.getState().tableChanges[closedId]).toBeUndefined();
+    expect(useTabs.getState().refreshKeys[closedId]).toBeUndefined();
+    expect(useTabResults.getState().byTabId[closedId]).toBeUndefined();
+    expect(useTabResults.getState().byTabId[keepId]?.status).toBe("loading");
+  });
+
+  it("moves focus left when closing tabs to the right of a tab", () => {
+    const store = useTabs.getState();
+    store.openTable("conn-1", "app", "public", "orders");
+    store.openTable("conn-1", "app", "public", "customers");
+    store.openTable("conn-1", "app", "events", "devices");
+
+    useTabs.getState().closeTabsToRight("conn-1::app.public.orders");
+
+    expect(useTabs.getState().tabs.map((t) => t.id)).toEqual([
+      "conn-1::app.public.orders",
+    ]);
+    expect(useTabs.getState().activeId).toBe("conn-1::app.public.orders");
+    expect(useTabs.getState().closedTabs).toHaveLength(2);
   });
 });

--- a/apps/desktop/src/state/tabs.ts
+++ b/apps/desktop/src/state/tabs.ts
@@ -53,6 +53,8 @@ interface TabsStore {
   reopenClosedTab: () => void;
   splitActiveTab: (orientation: SplitOrientation) => void;
   clearSplit: () => void;
+  closeOtherTabs: (id: string) => void;
+  closeTabsToRight: (id: string) => void;
   setActive: (id: string) => void;
   setTableChanges: (id: string, changes: PendingChanges) => void;
   clearTableChanges: (id: string) => void;
@@ -66,6 +68,48 @@ function tableKey(
   table: string,
 ): string {
   return `${connectionId}::${database}.${schema}.${table}`;
+}
+
+function dropTabScopedState(
+  ids: string[],
+  tableChanges: Record<string, PendingChanges>,
+  refreshKeys: Record<string, number>,
+): {
+  tableChanges: Record<string, PendingChanges>;
+  refreshKeys: Record<string, number>;
+} {
+  const closed = new Set(ids);
+  return {
+    tableChanges: Object.fromEntries(
+      Object.entries(tableChanges).filter(([id]) => !closed.has(id)),
+    ),
+    refreshKeys: Object.fromEntries(
+      Object.entries(refreshKeys).filter(([id]) => !closed.has(id)),
+    ),
+  };
+}
+
+function clearTabResults(ids: string[]) {
+  const results = useTabResults.getState();
+  ids.forEach((id) => results.clearTab(id));
+}
+
+function splitForTabs(
+  tabs: WorkspaceTab[],
+  split: WorkspaceSplit | null,
+): WorkspaceSplit | null {
+  return split &&
+    tabs.some((t) => t.id === split.primaryId) &&
+    tabs.some((t) => t.id === split.secondaryId)
+    ? split
+    : null;
+}
+
+function stackClosedTabs(
+  closed: WorkspaceTab[],
+  current: WorkspaceTab[],
+): WorkspaceTab[] {
+  return [...closed, ...current].slice(0, 12);
 }
 
 export const useTabs = create<TabsStore>((set, get) => ({
@@ -137,25 +181,73 @@ export const useTabs = create<TabsStore>((set, get) => ({
       const tabs = s.tabs.filter((t) => t.id !== id);
       const activeId =
         s.activeId === id ? tabs[tabs.length - 1]?.id ?? null : s.activeId;
-      const { [id]: _changes, ...tableChanges } = s.tableChanges;
-      const { [id]: _refresh, ...refreshKeys } = s.refreshKeys;
-      const currentSplit = s.split;
-      const split =
-        currentSplit &&
-        tabs.some((t) => t.id === currentSplit.primaryId) &&
-        tabs.some((t) => t.id === currentSplit.secondaryId)
-          ? currentSplit
-          : null;
+      const { tableChanges, refreshKeys } = dropTabScopedState(
+        [id],
+        s.tableChanges,
+        s.refreshKeys,
+      );
       return {
         tabs,
         activeId,
         closedTabs: closed ? [closed, ...s.closedTabs].slice(0, 12) : s.closedTabs,
-        split,
+        split: splitForTabs(tabs, s.split),
         tableChanges,
         refreshKeys,
       };
     });
-    useTabResults.getState().clearTab(id);
+    clearTabResults([id]);
+  },
+
+  closeOtherTabs(id) {
+    if (!get().tabs.some((t) => t.id === id)) return;
+    const closedIds = get()
+      .tabs.filter((t) => t.id !== id)
+      .map((t) => t.id);
+    set((s) => {
+      const tabs = s.tabs.filter((t) => t.id === id);
+      const closed = s.tabs.filter((t) => t.id !== id);
+      const { tableChanges, refreshKeys } = dropTabScopedState(
+        closedIds,
+        s.tableChanges,
+        s.refreshKeys,
+      );
+      return {
+        tabs,
+        activeId: tabs[0]?.id ?? null,
+        closedTabs: stackClosedTabs(closed, s.closedTabs),
+        split: null,
+        tableChanges,
+        refreshKeys,
+      };
+    });
+    clearTabResults(closedIds);
+  },
+
+  closeTabsToRight(id) {
+    const tabIndex = get().tabs.findIndex((t) => t.id === id);
+    if (tabIndex < 0) return;
+    const closedIds = get()
+      .tabs.slice(tabIndex + 1)
+      .map((t) => t.id);
+    set((s) => {
+      const tabs = s.tabs.slice(0, tabIndex + 1);
+      const closed = s.tabs.slice(tabIndex + 1);
+      const activeId = closedIds.includes(s.activeId ?? "") ? id : s.activeId;
+      const { tableChanges, refreshKeys } = dropTabScopedState(
+        closedIds,
+        s.tableChanges,
+        s.refreshKeys,
+      );
+      return {
+        tabs,
+        activeId,
+        closedTabs: stackClosedTabs(closed, s.closedTabs),
+        split: splitForTabs(tabs, s.split),
+        tableChanges,
+        refreshKeys,
+      };
+    });
+    clearTabResults(closedIds);
   },
 
   reopenClosedTab() {


### PR DESCRIPTION
## Summary
- add a right-click context menu to workspace tabs using the existing `ContextMenu` component
- add tab store actions for closing other tabs and closing tabs to the right
- cover bulk-close state cleanup for tab results, refresh keys, and pending table changes

## Validation
- `pnpm typecheck`
- `pnpm --filter @cellar/desktop typecheck`
- `pnpm --filter @cellar/desktop test`
- `git diff --check`
- Browser smoke test at `http://localhost:1431/` with mock SQL tabs
