### PR TITLE
fix: make unsupported UI actions honest

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -11,7 +11,10 @@ import { ConnectionDialog } from "./components/modals/ConnectionDialog";
 import { CommitModal } from "./components/modals/CommitModal";
 import { CommandPalette } from "./components/modals/CommandPalette";
 import { EmptyState } from "./components/modals/EmptyState";
-import { SettingsModal } from "./components/modals/Settings";
+import {
+  SettingsModal,
+  type SettingsCatId,
+} from "./components/modals/Settings";
 
 type Panels = { left: boolean; right: boolean; bottom: boolean };
 type ModalId = "commit" | "palette" | "settings" | null;
@@ -96,6 +99,8 @@ export function App() {
   const [modal, setModal] = useState<ModalId>(null);
   const [connDialog, setConnDialog] = useState<ConnDialog>(null);
   const [empty, setEmpty] = useState(false);
+  const [settingsInitialCat, setSettingsInitialCat] =
+    useState<SettingsCatId>("appearance");
 
   const togglePanel = useCallback(
     (k: keyof Panels) => setPanels((p) => ({ ...p, [k]: !p[k] })),
@@ -104,6 +109,10 @@ export function App() {
 
   const openModal = useCallback((m: ModalId) => setModal(m), []);
   const closeModal = useCallback(() => setModal(null), []);
+  const openSettings = useCallback((initialCat: SettingsCatId = "appearance") => {
+    setSettingsInitialCat(initialCat);
+    setModal("settings");
+  }, []);
   const openNewConnection = useCallback(() => setConnDialog({ mode: "new" }), []);
   const editConnection = useCallback(
     (initial: ConnectionConfig) => setConnDialog({ mode: "edit", initial }),
@@ -153,7 +162,7 @@ export function App() {
         empty={empty}
         onToggleEmpty={() => setEmpty((v) => !v)}
         onOpenPalette={() => openModal("palette")}
-        onOpenSettings={() => openModal("settings")}
+        onOpenSettings={() => openSettings()}
       />
 
       <div className="flex flex-1 min-h-0">
@@ -232,7 +241,10 @@ export function App() {
               className="flex min-w-0 flex-col bg-bg-1"
               style={{ width: rightWidth }}
             >
-              <AIPanel onClose={() => togglePanel("right")} />
+              <AIPanel
+                onClose={() => togglePanel("right")}
+                onOpenSettings={() => openSettings("ai")}
+              />
             </div>
           </>
         )}
@@ -254,11 +266,16 @@ export function App() {
           onClose={closeModal}
           onNewConnection={openNewConnection}
           onOpenCommit={() => openModal("commit")}
-          onOpenSettings={() => openModal("settings")}
+          onOpenSettings={() => openSettings()}
           onTogglePanel={togglePanel}
         />
       )}
-      {modal === "settings" && <SettingsModal onClose={closeModal} />}
+      {modal === "settings" && (
+        <SettingsModal
+          onClose={closeModal}
+          initialCat={settingsInitialCat}
+        />
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/components/AIPanel.tsx
+++ b/apps/desktop/src/components/AIPanel.tsx
@@ -37,7 +37,18 @@ function ContextChip({ kind, value }: { kind: ChipKind; value: string }) {
   );
 }
 
-export function AIPanel({ onClose }: { onClose: () => void }) {
+const DISABLED_ICON =
+  "icon-btn cursor-not-allowed opacity-45 hover:bg-transparent hover:text-fg-2";
+const DISABLED_PILL =
+  "inline-flex h-[22px] cursor-not-allowed items-center gap-1 rounded-[4px] px-2 text-[11px] text-fg-3 opacity-60";
+
+export function AIPanel({
+  onClose,
+  onOpenSettings,
+}: {
+  onClose: () => void;
+  onOpenSettings?: () => void;
+}) {
   const [draft, setDraft] = useState("");
   return (
     <div className="flex h-full flex-col bg-bg-1 text-[12.5px]">
@@ -54,13 +65,25 @@ export function AIPanel({ onClose }: { onClose: () => void }) {
           </span>
         </div>
         <div className="flex gap-px">
-          <button className="icon-btn" title="History">
+          <button
+            className={DISABLED_ICON}
+            disabled
+            title="AI history is not wired yet"
+          >
             <Icon.history size={12} />
           </button>
-          <button className="icon-btn" title="New thread">
+          <button
+            className={DISABLED_ICON}
+            disabled
+            title="AI threads are not wired yet"
+          >
             <Icon.plus size={12} />
           </button>
-          <button className="icon-btn" title="Settings">
+          <button
+            className="icon-btn"
+            onClick={onOpenSettings}
+            title="AI settings"
+          >
             <Icon.settings size={12} />
           </button>
           <button className="icon-btn" onClick={onClose} title="Close">
@@ -77,7 +100,11 @@ export function AIPanel({ onClose }: { onClose: () => void }) {
         <div className="flex flex-1 flex-wrap gap-1">
           <ContextChip kind="schema" value="public" />
           <ContextChip kind="table" value="orders" />
-          <button className="inline-flex h-5 items-center gap-[3px] rounded-[4px] border border-dashed border-border-default px-1.5 text-[10px] text-fg-3 hover:border-border-strong hover:text-fg-0">
+          <button
+            className="inline-flex h-5 cursor-not-allowed items-center gap-[3px] rounded-[4px] border border-dashed border-border-default px-1.5 text-[10px] text-fg-3 opacity-60"
+            disabled
+            title="Context editing is not wired yet"
+          >
             <Icon.plus size={9} />
             <span>add</span>
           </button>
@@ -94,31 +121,47 @@ export function AIPanel({ onClose }: { onClose: () => void }) {
           </div>
           <div className="max-w-[280px] text-[10.5px] leading-[1.5] text-fg-3">
             Generate SQL with full schema context, explain a result, or have it
-            review a slow query. Bring your own API key — Cellar never proxies.
+            review a slow query. Bring your own API key; Cellar never proxies.
           </div>
         </div>
       </div>
 
       <div className="shrink-0 border-t border-border-default bg-bg-1">
         <div className="flex items-center gap-0.5 border-b border-border-divider px-1.5 py-[5px]">
-          <button className="inline-flex h-[22px] items-center gap-1 rounded-[4px] bg-accent-soft px-2 text-[11px] text-accent">
+          <button
+            className={DISABLED_PILL + " bg-accent-soft text-accent"}
+            disabled
+            title="AI generation is not wired yet"
+          >
             <Icon.sparkles size={10} />
             <span>generate</span>
           </button>
-          <button className="inline-flex h-[22px] items-center gap-1 rounded-[4px] px-2 text-[11px] text-fg-2 hover:bg-bg-2 hover:text-fg-0">
+          <button
+            className={DISABLED_PILL}
+            disabled
+            title="AI explanation is not wired yet"
+          >
             explain
           </button>
-          <button className="inline-flex h-[22px] items-center gap-1 rounded-[4px] px-2 text-[11px] text-fg-2 hover:bg-bg-2 hover:text-fg-0">
+          <button
+            className={DISABLED_PILL}
+            disabled
+            title="AI optimization is not wired yet"
+          >
             optimize
           </button>
-          <button className="inline-flex h-[22px] items-center gap-1 rounded-[4px] px-2 text-[11px] text-fg-2 hover:bg-bg-2 hover:text-fg-0">
+          <button
+            className={DISABLED_PILL}
+            disabled
+            title="AI migrations are not wired yet"
+          >
             migrate
           </button>
           <div className="flex-1" />
-          <button className="inline-flex h-[22px] items-center gap-1 rounded-[4px] px-2 text-[10.5px] text-fg-3 hover:bg-bg-2">
+          <span className="inline-flex h-[22px] items-center gap-1 rounded-[4px] px-2 text-[10.5px] text-fg-3">
             <span style={{ color: "var(--fg-2)" }}>ask</span>
             <span style={{ color: "var(--fg-3)" }}> · read-only</span>
-          </button>
+          </span>
         </div>
         <div className="px-1.5 py-1.5">
           <textarea
@@ -130,10 +173,18 @@ export function AIPanel({ onClose }: { onClose: () => void }) {
           />
           <div className="mt-1.5 flex items-center justify-between">
             <div className="flex items-center gap-1">
-              <button className="icon-btn" title="Attach query">
+              <button
+                className={DISABLED_ICON}
+                disabled
+                title="Query attachments are not wired yet"
+              >
                 <Icon.paperclip size={11} />
               </button>
-              <button className="icon-btn" title="Add table">
+              <button
+                className={DISABLED_ICON}
+                disabled
+                title="Table context attachments are not wired yet"
+              >
                 <Icon.table size={11} />
               </button>
               <span className="ml-1.5 inline-flex items-center gap-[3px] text-[10.5px]">

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -272,6 +272,33 @@ export function Sidebar({
     setMenu({ x: e.clientX, y: e.clientY, items });
   };
 
+  const openSidebarMenu = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const connected = connections.filter(
+      (c) => byId[c.id]?.status === "connected",
+    );
+    setMenu({
+      x: e.clientX,
+      y: e.clientY,
+      items: [
+        {
+          label: "New connection",
+          icon: <Icon.plus size={12} />,
+          onClick: () => onNewConnection?.(),
+        },
+        {
+          label: "Refresh connected schemas",
+          icon: <Icon.history size={12} />,
+          disabled: connected.length === 0,
+          onClick: () => {
+            for (const c of connected) void refreshSchema(c.id);
+          },
+        },
+      ],
+    });
+  };
+
   return (
     <div className="flex h-full flex-col text-[11.5px]">
       <div className="flex shrink-0 items-center justify-between pt-[7px] pb-[5px] pl-2.5 pr-2">
@@ -283,13 +310,19 @@ export function Sidebar({
         </div>
         <div className="flex gap-px">
           <button
+            type="button"
             className="icon-btn"
             title="New connection"
             onClick={onNewConnection}
           >
             <Icon.plus size={12} />
           </button>
-          <button className="icon-btn" title="More">
+          <button
+            type="button"
+            className="icon-btn"
+            title="Connection actions"
+            onClick={openSidebarMenu}
+          >
             <Icon.more size={12} />
           </button>
         </div>
@@ -308,6 +341,7 @@ export function Sidebar({
 
       <div className="flex-1 overflow-y-auto pb-3">
         <button
+          type="button"
           onClick={onNewConnection}
           className="mx-2 mt-1 mb-3 flex w-[calc(100%-16px)] items-center gap-1.5 rounded-[4px] border border-dashed border-border-default px-2 py-1.5 text-[11.5px] text-fg-2 transition-[border-color,color,background] duration-150 hover:border-solid hover:border-accent-line hover:bg-accent-soft hover:text-accent"
         >
@@ -398,6 +432,7 @@ function ConnectionRow({
         onContextMenu={onContextMenu}
       >
         <button
+          type="button"
           className={TWISTY}
           onClick={(e) => {
             e.stopPropagation();
@@ -425,6 +460,7 @@ function ConnectionRow({
         )}
         <StatusDot status={status} />
         <button
+          type="button"
           className="icon-btn ml-1 opacity-0 transition-opacity duration-100 group-hover:opacity-100"
           title="Actions"
           onClick={(e) => {
@@ -436,6 +472,7 @@ function ConnectionRow({
         </button>
         {status === "connected" && (
           <button
+            type="button"
             className="icon-btn opacity-0 transition-opacity duration-100 group-hover:opacity-100"
             title="Disconnect"
             onClick={(e) => {
@@ -526,7 +563,7 @@ function DatabaseRow({
         }
         title={empty ? "no accessible schemas" : undefined}
       >
-        <button className={TWISTY}>
+        <button type="button" className={TWISTY} aria-label={open ? "Collapse database" : "Expand database"}>
           {empty ? (
             <span className={TWISTY + " invisible"} />
           ) : open ? (
@@ -597,7 +634,7 @@ function SchemaRow({
           })
         }
       >
-        <button className={TWISTY}>
+        <button type="button" className={TWISTY} aria-label={open ? "Collapse schema" : "Expand schema"}>
           {open ? (
             <Icon.chevronDown size={10} />
           ) : (

--- a/apps/desktop/src/components/TabBar.tsx
+++ b/apps/desktop/src/components/TabBar.tsx
@@ -173,6 +173,7 @@ export function TabBar() {
                 />
               )}
               <button
+                type="button"
                 onClick={(e) => {
                   e.stopPropagation();
                   closeTab(t.id);
@@ -189,6 +190,7 @@ export function TabBar() {
           );
         })}
         <button
+          type="button"
           onClick={onNewQuery}
           disabled={!hasConnections}
           title={
@@ -203,6 +205,7 @@ export function TabBar() {
       </div>
       <div className="flex items-center gap-px border-l border-border-default px-1.5">
         <button
+          type="button"
           className={"icon-btn" + (split?.orientation === "horizontal" ? " active" : "")}
           onClick={() => splitActiveTab("horizontal")}
           disabled={!canSplit}
@@ -218,6 +221,7 @@ export function TabBar() {
           <Icon.splitH size={12} />
         </button>
         <button
+          type="button"
           className={"icon-btn" + (split?.orientation === "vertical" ? " active" : "")}
           onClick={() => splitActiveTab("vertical")}
           disabled={!canSplit}
@@ -233,6 +237,7 @@ export function TabBar() {
           <Icon.splitV size={12} />
         </button>
         <button
+          type="button"
           className="icon-btn"
           onClick={reopenClosedTab}
           disabled={closedCount === 0}

--- a/apps/desktop/src/components/TitleBar.tsx
+++ b/apps/desktop/src/components/TitleBar.tsx
@@ -92,30 +92,31 @@ export function TitleBar({
           <>
             <div className="mx-0.5 h-4 w-px bg-border-default" />
             <div className="flex items-center gap-0.5 max-[1080px]:[&_svg]:hidden">
-              <button className="inline-flex items-center gap-[5px] whitespace-nowrap rounded-[4px] px-1.5 py-[3px] text-[11.5px] text-fg-1 transition-[background] duration-100 hover:bg-bg-3 hover:text-fg-0">
+              <span className="inline-flex items-center gap-[5px] whitespace-nowrap rounded-[4px] px-1.5 py-[3px] text-[11.5px] text-fg-1">
                 <Icon.database size={12} />
                 <span>{activeConn?.name ?? activeTab.connectionId}</span>
-              </button>
+              </span>
               <Icon.chevronRight size={11} style={{ opacity: 0.4 }} />
-              <button className="inline-flex items-center gap-[5px] whitespace-nowrap rounded-[4px] px-1.5 py-[3px] text-[11.5px] text-fg-1 transition-[background] duration-100 hover:bg-bg-3 hover:text-fg-0 max-[1080px]:hidden">
+              <span className="inline-flex items-center gap-[5px] whitespace-nowrap rounded-[4px] px-1.5 py-[3px] text-[11.5px] text-fg-1 max-[1080px]:hidden">
                 <span style={{ color: ENGINE_META[activeConn?.engine ?? "postgres"].color }}>●</span>
                 <span>{activeTab.database}</span>
-              </button>
+              </span>
               <Icon.chevronRight size={11} style={{ opacity: 0.4 }} />
-              <button className="inline-flex items-center gap-[5px] whitespace-nowrap rounded-[4px] px-1.5 py-[3px] text-[11.5px] text-fg-1 transition-[background] duration-100 hover:bg-bg-3 hover:text-fg-0 max-[1080px]:hidden">
+              <span className="inline-flex items-center gap-[5px] whitespace-nowrap rounded-[4px] px-1.5 py-[3px] text-[11.5px] text-fg-1 max-[1080px]:hidden">
                 {activeTab.kind === "query" ? (
                   <Icon.terminal size={11} />
                 ) : (
                   <Icon.schema size={11} />
                 )}
                 <span>{activeTab.kind === "query" ? activeTab.title : activeTab.schema}</span>
-              </button>
+              </span>
             </div>
           </>
         )}
       </div>
 
       <button
+        type="button"
         onClick={onOpenPalette}
         className="absolute left-1/2 top-1/2 flex h-[22px] min-w-0 w-[320px] max-w-[320px] -translate-x-1/2 -translate-y-1/2 items-center gap-2 rounded-[5px] border border-border-default bg-bg-inset px-2 text-[11px] text-fg-3 transition-[border-color] duration-150 hover:border-border-strong"
       >
@@ -133,6 +134,7 @@ export function TitleBar({
         {!empty && (
           <>
             <button
+              type="button"
               className={"icon-btn" + (panels.left ? " active" : "")}
               onClick={() => onTogglePanel("left")}
               title="Toggle connections panel"
@@ -140,6 +142,7 @@ export function TitleBar({
               <Icon.panelLeft size={13} />
             </button>
             <button
+              type="button"
               className={"icon-btn" + (panels.bottom ? " active" : "")}
               onClick={() => onTogglePanel("bottom")}
               title="Toggle output panel"
@@ -147,6 +150,7 @@ export function TitleBar({
               <Icon.panelBottom size={13} />
             </button>
             <button
+              type="button"
               className={"icon-btn" + (panels.right ? " active" : "")}
               onClick={() => onTogglePanel("right")}
               title="Toggle AI panel"
@@ -158,6 +162,7 @@ export function TitleBar({
         )}
         {onToggleEmpty && (
           <button
+            type="button"
             className={"icon-btn" + (empty ? " active" : "")}
             onClick={onToggleEmpty}
             title={empty ? "Show workspace" : "Show empty state"}
@@ -166,6 +171,7 @@ export function TitleBar({
           </button>
         )}
         <button
+          type="button"
           className="icon-btn"
           onClick={onOpenSettings}
           title="Settings (⌘,)"

--- a/apps/desktop/src/components/modals/EmptyState.tsx
+++ b/apps/desktop/src/components/modals/EmptyState.tsx
@@ -71,11 +71,19 @@ export function EmptyState({ onNew }: { onNew: () => void }) {
             <Icon.plus size={12} />
             <span>New connection</span>
           </button>
-          <button className="flex h-8 items-center justify-center gap-2 whitespace-nowrap rounded-[6px] border border-border-default bg-bg-2 px-3 text-xs text-fg-0 transition-[background,border-color] duration-[120ms] hover:border-border-strong hover:bg-bg-3">
+          <button
+            disabled
+            title="Connection import is not wired yet"
+            className="flex h-8 cursor-not-allowed items-center justify-center gap-2 whitespace-nowrap rounded-[6px] border border-border-default bg-bg-2 px-3 text-xs text-fg-2 opacity-55"
+          >
             <Icon.fileText size={12} />
             <span>Import from DataGrip / DBeaver</span>
           </button>
-          <button className="flex h-8 items-center justify-center gap-2 whitespace-nowrap rounded-[6px] border border-border-default bg-bg-2 px-3 text-xs text-fg-0 transition-[background,border-color] duration-[120ms] hover:border-border-strong hover:bg-bg-3">
+          <button
+            disabled
+            title="Demo database provisioning is not wired yet"
+            className="flex h-8 cursor-not-allowed items-center justify-center gap-2 whitespace-nowrap rounded-[6px] border border-border-default bg-bg-2 px-3 text-xs text-fg-2 opacity-55"
+          >
             <Icon.cloud size={12} />
             <span>Connect to demo database</span>
           </button>
@@ -88,12 +96,19 @@ export function EmptyState({ onNew }: { onNew: () => void }) {
           {ENGINE_ORDER.map((e) => {
             const m = ENGINE_META[e];
             const hex = ENGINE_HEX[e];
+            const available = e === "postgres";
             return (
               <button
                 key={e}
-                onClick={onNew}
-                title={m.label}
-                className="flex flex-col items-center gap-1.5 rounded-[6px] border border-border-default bg-bg-2 px-1.5 pt-2.5 pb-2 transition-all duration-150 hover:-translate-y-px hover:border-border-strong"
+                onClick={available ? onNew : undefined}
+                disabled={!available}
+                title={available ? m.label : `${m.label} support is coming soon`}
+                className={
+                  "flex flex-col items-center gap-1.5 rounded-[6px] border border-border-default bg-bg-2 px-1.5 pt-2.5 pb-2 transition-all duration-150 " +
+                  (available
+                    ? "hover:-translate-y-px hover:border-border-strong"
+                    : "cursor-not-allowed opacity-45")
+                }
               >
                 <span
                   className="inline-flex h-[26px] w-[26px] items-center justify-center rounded-[5px] border font-mono text-xs font-semibold"
@@ -134,11 +149,19 @@ export function EmptyState({ onNew }: { onNew: () => void }) {
         <div className="border-t border-border-divider pt-4 text-[10.5px] text-fg-3">
           <span>
             v0.1.0 · MIT licensed ·{" "}
-            <button className="bg-transparent text-[10.5px] text-accent underline underline-offset-2">
+            <button
+              disabled
+              title="Documentation links are not wired in the desktop shell yet"
+              className="cursor-not-allowed bg-transparent text-[10.5px] text-fg-3 underline underline-offset-2 opacity-70"
+            >
               docs
             </button>{" "}
             ·{" "}
-            <button className="bg-transparent text-[10.5px] text-accent underline underline-offset-2">
+            <button
+              disabled
+              title="External links are not wired in the desktop shell yet"
+              className="cursor-not-allowed bg-transparent text-[10.5px] text-fg-3 underline underline-offset-2 opacity-70"
+            >
               github
             </button>
           </span>

--- a/apps/desktop/src/components/modals/Settings.tsx
+++ b/apps/desktop/src/components/modals/Settings.tsx
@@ -24,7 +24,7 @@ import {
   ED_RUN_SUBTLE,
 } from "./settingsPrimitives";
 
-type CatId =
+export type SettingsCatId =
   | "general"
   | "appearance"
   | "editor"
@@ -38,7 +38,7 @@ type CatId =
   | "updates"
   | "about";
 
-type CatItem = { id: CatId; label: string; icon: IconName; badge?: string };
+type CatItem = { id: SettingsCatId; label: string; icon: IconName; badge?: string };
 type CatGroup = { group: string; items: CatItem[] };
 
 const SETTINGS_CATS: CatGroup[] = [
@@ -81,9 +81,9 @@ export function SettingsModal({
   initialCat = "appearance",
 }: {
   onClose: () => void;
-  initialCat?: CatId;
+  initialCat?: SettingsCatId;
 }) {
-  const [cat, setCat] = useState<CatId>(initialCat);
+  const [cat, setCat] = useState<SettingsCatId>(initialCat);
   const [q, setQ] = useState("");
   const searchRef = useRef<HTMLInputElement>(null);
 
@@ -193,8 +193,8 @@ function SettingsNav({
   setCat,
   q,
 }: {
-  cat: CatId;
-  setCat: (c: CatId) => void;
+  cat: SettingsCatId;
+  setCat: (c: SettingsCatId) => void;
   q: string;
 }) {
   const filter = q.toLowerCase().trim();
@@ -255,7 +255,12 @@ function SettingsNav({
       <div className="mt-auto flex items-center gap-1.5 border-t border-border-divider px-[14px] py-2.5 text-[10px]">
         <span className="font-mono text-fg-3">v0.1.0-alpha</span>
         <span className="text-fg-3">·</span>
-        <button type="button" className="text-[10px] text-accent underline underline-offset-2">
+        <button
+          type="button"
+          disabled
+          className="cursor-not-allowed text-[10px] text-fg-3 underline underline-offset-2 opacity-70"
+          title="Documentation links are not wired in the desktop shell yet"
+        >
           docs
         </button>
       </div>

--- a/apps/desktop/src/components/modals/settingsSystemPanels.tsx
+++ b/apps/desktop/src/components/modals/settingsSystemPanels.tsx
@@ -135,19 +135,39 @@ export function SettingsAbout() {
               <span>commit unavailable</span>
             </div>
             <div className="flex gap-1.5 text-[11px]">
-              <button type="button" className="text-accent underline underline-offset-2">
+              <button
+                type="button"
+                disabled
+                className="cursor-not-allowed text-fg-3 underline underline-offset-2 opacity-70"
+                title="Documentation links are not wired in the desktop shell yet"
+              >
                 docs
               </button>
               <span className="text-fg-3">·</span>
-              <button type="button" className="text-accent underline underline-offset-2">
+              <button
+                type="button"
+                disabled
+                className="cursor-not-allowed text-fg-3 underline underline-offset-2 opacity-70"
+                title="External links are not wired in the desktop shell yet"
+              >
                 github
               </button>
               <span className="text-fg-3">·</span>
-              <button type="button" className="text-accent underline underline-offset-2">
+              <button
+                type="button"
+                disabled
+                className="cursor-not-allowed text-fg-3 underline underline-offset-2 opacity-70"
+                title="Changelog links are not wired in the desktop shell yet"
+              >
                 changelog
               </button>
               <span className="text-fg-3">·</span>
-              <button type="button" className="text-accent underline underline-offset-2">
+              <button
+                type="button"
+                disabled
+                className="cursor-not-allowed text-fg-3 underline underline-offset-2 opacity-70"
+                title="Acknowledgements links are not wired in the desktop shell yet"
+              >
                 acknowledgements
               </button>
             </div>

--- a/apps/desktop/src/styles/grid.css
+++ b/apps/desktop/src/styles/grid.css
@@ -410,7 +410,6 @@
   transition: opacity 0.1s;
 }
 .grid-cell:hover .cell-fk-jump { opacity: 1; }
-.cell-fk-jump:hover { background: var(--accent-soft); }
 
 .cell-edit-input {
   width: 100%;

--- a/packages/data-grid/src/Cell.tsx
+++ b/packages/data-grid/src/Cell.tsx
@@ -22,9 +22,9 @@ export function CellValue({ col, value }: { col: GridColumn; value: Value }) {
     return (
       <span className="cell-fk">
         <span className={col.mono ? "mono" : ""}>{String(value)}</span>
-        <button className="cell-fk-jump" title={`Jump to ${col.fk}`}>
+        <span className="cell-fk-jump" title={`Foreign key: ${col.fk}`}>
           <GridIcon.link2 size={9} />
-        </button>
+        </span>
       </span>
     );
   }


### PR DESCRIPTION
## Summary

- disables or demotes UI controls that imply unsupported workflows, including AI chat actions, welcome-screen import/demo paths, non-Postgres engine shortcuts, tab split/reopen controls, and placeholder external links
- wires the AI panel settings button directly to the AI settings section
- makes the sidebar actions menu useful with existing connection actions and removes the fake foreign-key jump button from grid cells

## Why

The UI had several false affordances: enabled controls that looked ready but had no backing behavior in the current pre-alpha slice. This makes the interface more honest and easier to trust while keeping future features visible as unavailable.

## Validation

- `pnpm typecheck`
- `pnpm --filter @cellar/desktop build`
- Browser smoke check for AI settings routing, welcome disabled states, and sidebar menu behavior
