### PR TITLE
feat: add Firestore support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,6 +397,7 @@ dependencies = [
  "async-trait",
  "cellar-core",
  "cellar-diff",
+ "cellar-driver-firestore",
  "cellar-driver-postgres",
  "cellar-secrets",
  "dirs 5.0.1",
@@ -420,6 +421,19 @@ dependencies = [
  "serde",
  "specta",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cellar-driver-firestore"
+version = "0.1.0-alpha"
+dependencies = [
+ "async-trait",
+ "cellar-core",
+ "jsonwebtoken",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -494,6 +508,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -1387,8 +1407,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1398,9 +1420,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1745,6 +1769,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2080,6 +2105,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2226,6 +2266,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2360,7 +2406,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -2722,6 +2768,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2979,6 +3035,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3006,8 +3117,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3017,7 +3138,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3027,6 +3158,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3135,6 +3275,44 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -3194,7 +3372,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
@@ -3270,6 +3448,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3651,7 +3830,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3659,6 +3838,18 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "siphasher"
@@ -3926,7 +4117,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "sha1",
@@ -3968,7 +4159,7 @@ dependencies = [
  "memchr",
  "num-bigint",
  "once_cell",
- "rand",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2",
@@ -4235,7 +4426,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "serde_repr",
@@ -5247,6 +5438,16 @@ name = "web-sys"
 version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "apps/desktop/src-tauri",
     "crates/cellar-core",
     "crates/cellar-drivers",
+    "crates/cellar-drivers/firestore",
     "crates/cellar-drivers/postgres",
     "crates/cellar-sql",
     "crates/cellar-diff",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -37,6 +37,7 @@ specta = { version = "=2.0.0-rc.22", features = ["derive", "chrono", "uuid", "se
 specta-typescript = "=0.0.9"
 tauri-specta = { version = "=2.0.0-rc.21", features = ["derive", "typescript"] }
 cellar-core = { path = "../../../crates/cellar-core" }
+cellar-driver-firestore = { path = "../../../crates/cellar-drivers/firestore" }
 cellar-driver-postgres = { path = "../../../crates/cellar-drivers/postgres" }
 cellar-diff = { path = "../../../crates/cellar-diff" }
 cellar-secrets = { path = "../../../crates/cellar-secrets" }

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -7,6 +7,7 @@ use cellar_core::error::{CellarError, CellarResult};
 use cellar_core::query::{PlanMode, Query, QueryPlan, QueryResult, TableBrowseRequest};
 use cellar_core::schema::{Database, Table};
 use cellar_diff::{TableChangeRequest, TableCommitResult};
+use cellar_driver_firestore::FirestoreDriver;
 use cellar_driver_postgres::PostgresDriver;
 use tokio::fs;
 use tokio::sync::RwLock;
@@ -238,6 +239,10 @@ impl ConnectionRegistry {
         };
 
         match engine {
+            Engine::Firestore => {
+                cellar_driver_firestore::browse_collection(connection.as_ref(), &request, &table)
+                    .await
+            }
             Engine::Postgres => {
                 match cellar_driver_postgres::browse_table(connection.as_ref(), &request, &table)
                     .await
@@ -413,6 +418,7 @@ fn find_table(dbs: &[Database], database: &str, schema: &str, table: &str) -> Ce
 
 fn driver_for(engine: Engine) -> CellarResult<Box<dyn Driver>> {
     match engine {
+        Engine::Firestore => Ok(Box::new(FirestoreDriver::new())),
         Engine::Postgres => Ok(Box::new(PostgresDriver::new())),
         other => Err(CellarError::invalid_config(format!(
             "engine {} is not supported in this build",

--- a/apps/desktop/src/components/EngineBadge.tsx
+++ b/apps/desktop/src/components/EngineBadge.tsx
@@ -1,4 +1,4 @@
-export type Engine = "postgres" | "mysql" | "mssql" | "azure" | "sqlite";
+export type Engine = "postgres" | "mysql" | "mssql" | "azure" | "sqlite" | "firestore";
 
 export const ENGINE_META: Record<
   Engine,
@@ -9,6 +9,7 @@ export const ENGINE_META: Record<
   mssql: { label: "SQL Server", color: "var(--eng-mssql)", letter: "S" },
   azure: { label: "Azure SQL", color: "var(--eng-azure)", letter: "A" },
   sqlite: { label: "SQLite", color: "var(--eng-sqlite)", letter: "L" },
+  firestore: { label: "Firestore", color: "var(--eng-firestore)", letter: "F" },
 };
 
 export function EngineBadge({

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -796,5 +796,7 @@ function engineDefaultColor(engine: Engine): string {
       return "var(--eng-azure)";
     case "sqlite":
       return "var(--eng-sqlite)";
+    case "firestore":
+      return "var(--eng-firestore)";
   }
 }

--- a/apps/desktop/src/components/SqlEditor.tsx
+++ b/apps/desktop/src/components/SqlEditor.tsx
@@ -25,6 +25,7 @@ const DIALECTS: Record<Engine, string> = {
   sqlite: "SQLite",
   mssql: "SQL Server",
   azure: "Azure SQL",
+  firestore: "Firestore",
 };
 
 const PLACEHOLDER =
@@ -53,6 +54,7 @@ export function SqlEditor({ tab }: { tab: QueryTab }) {
   const sql = tab.sql;
   const connected = status === "connected";
   const isPostgres = engine === "postgres" || engine === undefined;
+  const supportsSql = engine !== "firestore";
 
   const statements = useMemo(() => splitStatements(sql), [sql]);
   const current = useMemo(
@@ -97,17 +99,20 @@ export function SqlEditor({ tab }: { tab: QueryTab }) {
     tab.connectionId,
   ]);
 
-  const canRunStatement = connected && !running && current != null;
-  const canRunAll = connected && !running && statements.length > 0;
+  const canRunStatement = connected && supportsSql && !running && current != null;
+  const canRunAll = connected && supportsSql && !running && statements.length > 0;
   const canExplain = connected && !running && current != null && isPostgres;
   const runTitle = !connected
     ? "Connect this tab's database to run SQL"
+    : !supportsSql
+      ? "Firestore query execution is not supported yet"
     : current
       ? "Run the statement under the cursor"
       : "Place the cursor in a statement to run it";
 
   const dialect = engine ? DIALECTS[engine] : "PostgreSQL";
   const dotEngine: Engine = engine ?? "postgres";
+  const sqlEditorEngine = supportsSql ? engine : undefined;
   const preview = current ? firstLine(current.text) : "—";
 
   return (
@@ -128,7 +133,13 @@ export function SqlEditor({ tab }: { tab: QueryTab }) {
             className="ed-run subtle"
             onClick={runAll}
             disabled={!canRunAll}
-            title={connected ? "Run the entire editor buffer" : "Connect to run SQL"}
+            title={
+              !connected
+                ? "Connect to run SQL"
+                : supportsSql
+                  ? "Run the entire editor buffer"
+                  : "Firestore query execution is not supported yet"
+            }
           >
             <Icon.play size={11} />
             <span>Run all</span>
@@ -191,7 +202,7 @@ export function SqlEditor({ tab }: { tab: QueryTab }) {
       <div className="ed-scroll">
         <SqlCodeEditor
           value={sql}
-          engine={engine}
+          engine={sqlEditorEngine}
           databases={databases}
           database={tab.database}
           placeholder={PLACEHOLDER}

--- a/apps/desktop/src/components/modals/ConnectionDialog.tsx
+++ b/apps/desktop/src/components/modals/ConnectionDialog.tsx
@@ -7,7 +7,7 @@ import { ENGINE_META, type Engine } from "../EngineBadge";
 import { Modal } from "./Modal";
 import { useConnections } from "../../state/connections";
 
-const ENGINE_ORDER: Engine[] = ["postgres", "mssql", "azure", "mysql", "sqlite"];
+const ENGINE_ORDER: Engine[] = ["postgres", "firestore", "mssql", "azure", "mysql", "sqlite"];
 
 const ENGINE_HEX: Record<Engine, string> = {
   postgres: "#4f8ff7",
@@ -15,6 +15,7 @@ const ENGINE_HEX: Record<Engine, string> = {
   mssql: "#d97a5a",
   azure: "#5bb8e0",
   sqlite: "#a78bfa",
+  firestore: "#f4c542",
 };
 
 const SWATCH_COLORS = ["#4f8ff7", "#f6a44a", "#d97a5a", "#5bb8e0", "#a78bfa", "#4ade80", "#f87171"];
@@ -25,6 +26,7 @@ const DEFAULT_PORT: Record<Engine, number> = {
   mssql: 1433,
   azure: 1433,
   sqlite: 0,
+  firestore: 443,
 };
 
 type Tab = "general" | "ssh" | "ssl" | "options";
@@ -85,7 +87,7 @@ export function ConnectionDialog({
     initial && initial.ssl_mode !== "disable" ? initial.ssl_mode : "prefer",
   );
   const [swatch, setSwatch] = useState<string>(
-    initial?.color ?? ENGINE_HEX.postgres,
+    initial?.color ?? ENGINE_HEX[(initial?.engine as Engine | undefined) ?? "postgres"],
   );
   const [envTag, setEnvTag] = useState<EnvTag>(initial?.env_tag ?? "local");
 
@@ -108,6 +110,13 @@ export function ConnectionDialog({
     if (!userPickedEngine.current) return;
     setPort(DEFAULT_PORT[engine] || 5432);
     setSwatch(ENGINE_HEX[engine]);
+    if (engine === "firestore") {
+      setHost("firestore.googleapis.com");
+      setDatabase("");
+      setUser("(default)");
+      setSsl(true);
+      setSslMode("require");
+    }
   }, [engine]);
 
   const derivedId = useMemo(
@@ -160,6 +169,19 @@ export function ConnectionDialog({
   };
 
   const sqliteOnly = engine === "sqlite";
+  const isFirestore = engine === "firestore";
+  const hostLabel = isFirestore ? "API host" : "Host";
+  const databaseLabel = isFirestore ? "Project ID" : "Database";
+  const userLabel = isFirestore ? "Database ID" : "User";
+  const passwordLabel = isFirestore ? "Credentials" : "Password";
+  const passwordHint = isFirestore
+    ? isEdit
+      ? "Leave blank to keep saved JSON/token"
+      : "Leave blank for emulator; JSON/token is stored in OS keychain"
+    : isEdit
+      ? "Leave blank to keep the saved password"
+      : "Stored in OS keychain";
+  const canSave = Boolean(host && database && (isFirestore || user));
 
   return (
     <Modal onClose={onClose} width={760}>
@@ -178,12 +200,12 @@ export function ConnectionDialog({
       </div>
 
       <div className="flex-1 overflow-y-auto px-4 pt-3 pb-4">
-        <div className="mb-3.5 grid grid-cols-5 gap-1.5">
+        <div className="mb-3.5 grid grid-cols-6 gap-1.5">
           {ENGINE_ORDER.map((e) => {
             const m = ENGINE_META[e];
             const hex = ENGINE_HEX[e];
             const active = engine === e;
-            const disabled = e !== "postgres";
+            const disabled = e !== "postgres" && e !== "firestore";
             return (
               <button
                 key={e}
@@ -266,11 +288,11 @@ export function ConnectionDialog({
                 className={CD_INPUT}
                 value={name}
                 onChange={(e) => setName(e.target.value)}
-                placeholder="local-postgres"
+                placeholder={isFirestore ? "prod-firestore" : "local-postgres"}
               />
             </FormRow>
 
-            <FormRow label="Host">
+            <FormRow label={hostLabel}>
               <input
                 className={CD_INPUT + " font-mono"}
                 value={host}
@@ -287,38 +309,42 @@ export function ConnectionDialog({
             </FormRow>
 
             {!sqliteOnly && (
-              <FormRow label="Database">
+              <FormRow label={databaseLabel}>
                 <input
                   className={CD_INPUT + " font-mono"}
                   value={database}
                   onChange={(e) => setDatabase(e.target.value)}
+                  placeholder={isFirestore ? "my-gcp-project" : undefined}
                 />
               </FormRow>
             )}
 
-            <FormRow label="User">
+            <FormRow label={userLabel}>
               <input
                 className={CD_INPUT + " font-mono"}
                 value={user}
                 onChange={(e) => setUser(e.target.value)}
                 autoComplete="off"
+                placeholder={isFirestore ? "(default)" : undefined}
               />
             </FormRow>
 
             <FormRow
-              label="Password"
-              hint={
-                isEdit
-                  ? "Leave blank to keep the saved password"
-                  : "Stored in OS keychain"
-              }
+              label={passwordLabel}
+              hint={passwordHint}
             >
               <input
                 className={CD_INPUT + " font-mono"}
                 type="password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                placeholder={isEdit ? "•••••••• (unchanged)" : ""}
+                placeholder={
+                  isEdit
+                    ? "•••••••• (unchanged)"
+                    : isFirestore
+                      ? "{ service_account_json }"
+                      : ""
+                }
                 style={{ flex: 1 }}
                 autoComplete="new-password"
               />
@@ -431,7 +457,7 @@ export function ConnectionDialog({
           </button>
           <button
             className={ED_RUN_PRIMARY}
-            disabled={saving || !user || !host || !database}
+            disabled={saving || !canSave}
             onClick={() => void onSave()}
             style={{
               borderColor: "color-mix(in oklab, var(--accent) 30%, black)",

--- a/apps/desktop/src/components/modals/EmptyState.tsx
+++ b/apps/desktop/src/components/modals/EmptyState.tsx
@@ -1,7 +1,7 @@
 import { Icon } from "../icons";
 import { ENGINE_META, type Engine } from "../EngineBadge";
 
-const ENGINE_ORDER: Engine[] = ["postgres", "mssql", "azure", "mysql", "sqlite"];
+const ENGINE_ORDER: Engine[] = ["postgres", "firestore", "mssql", "azure", "mysql", "sqlite"];
 
 const ENGINE_HEX: Record<Engine, string> = {
   postgres: "#4f8ff7",
@@ -9,6 +9,7 @@ const ENGINE_HEX: Record<Engine, string> = {
   mssql: "#d97a5a",
   azure: "#5bb8e0",
   sqlite: "#a78bfa",
+  firestore: "#f4c542",
 };
 
 const SHORT: Record<Engine, string> = {
@@ -17,6 +18,7 @@ const SHORT: Record<Engine, string> = {
   mssql: "MSSQL",
   azure: "Azure",
   sqlite: "SQLite",
+  firestore: "Firestore",
 };
 
 export function EmptyState({ onNew }: { onNew: () => void }) {
@@ -92,7 +94,7 @@ export function EmptyState({ onNew }: { onNew: () => void }) {
         <div className="mb-2 text-[10px] uppercase tracking-[0.06em] text-fg-3">
           or pick an engine to start
         </div>
-        <div className="mb-[22px] grid grid-cols-5 gap-1.5">
+        <div className="mb-[22px] grid grid-cols-6 gap-1.5">
           {ENGINE_ORDER.map((e) => {
             const m = ENGINE_META[e];
             const hex = ENGINE_HEX[e];

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -57,6 +57,7 @@
   --color-eng-mssql: var(--eng-mssql);
   --color-eng-azure: var(--eng-azure);
   --color-eng-sqlite: var(--eng-sqlite);
+  --color-eng-firestore: var(--eng-firestore);
 
   /* Syntax (SQL) */
   --color-syn-kw: var(--syn-kw);

--- a/apps/desktop/src/styles/tokens.css
+++ b/apps/desktop/src/styles/tokens.css
@@ -49,6 +49,7 @@
   --eng-mssql: #d97a5a;
   --eng-azure: #5bb8e0;
   --eng-sqlite: #a78bfa;
+  --eng-firestore: #f4c542;
 
   /* Syntax (SQL) */
   --syn-kw: #b794f6;

--- a/crates/cellar-core/src/driver.rs
+++ b/crates/cellar-core/src/driver.rs
@@ -18,6 +18,7 @@ pub enum Engine {
     Sqlite,
     Mssql,
     Azure,
+    Firestore,
 }
 
 impl Engine {
@@ -28,6 +29,7 @@ impl Engine {
             Self::Sqlite => "sqlite",
             Self::Mssql => "mssql",
             Self::Azure => "azure",
+            Self::Firestore => "firestore",
         }
     }
 }

--- a/crates/cellar-drivers/firestore/Cargo.toml
+++ b/crates/cellar-drivers/firestore/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "cellar-driver-firestore"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Cellar — Google Cloud Firestore driver built on the Firestore REST API"
+publish = false
+
+[dependencies]
+cellar-core = { path = "../../cellar-core" }
+async-trait = "0.1"
+jsonwebtoken = "9"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+

--- a/crates/cellar-drivers/firestore/src/lib.rs
+++ b/crates/cellar-drivers/firestore/src/lib.rs
@@ -1,0 +1,733 @@
+//! Firestore driver for Cellar, backed by the Google Cloud Firestore REST API.
+//!
+//! This first slice treats root collections as read-only tables under a
+//! `documents` schema. It infers columns from a small document sample and maps
+//! document values into Cellar's existing grid result contract.
+
+use std::any::Any;
+use std::collections::{BTreeMap, BTreeSet};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+use async_trait::async_trait;
+use cellar_core::driver::{Connection, ConnectionConfig, Driver, DriverInfo, Engine, SslMode};
+use cellar_core::error::{CellarError, CellarResult};
+use cellar_core::query::{
+    NoticeCapture, PlanMode, Query, QueryPlan, QueryResult, TableBrowseRequest,
+};
+use cellar_core::schema::{Column, Database, Index, Schema, Table};
+use cellar_core::value::{CellValue, ColumnMeta, Row};
+use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+use reqwest::{Client, Method, Url};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+const SCHEMA_NAME: &str = "documents";
+const DEFAULT_DATABASE_ID: &str = "(default)";
+const DEFAULT_SAMPLE_SIZE: u32 = 25;
+const DEFAULT_BROWSE_LIMIT: u32 = 500;
+const DATASTORE_SCOPE: &str = "https://www.googleapis.com/auth/datastore";
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct FirestoreDriver;
+
+impl FirestoreDriver {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+pub async fn browse_collection(
+    conn: &dyn Connection,
+    request: &TableBrowseRequest,
+    table: &Table,
+) -> CellarResult<QueryResult> {
+    let fs = as_firestore(conn)?;
+    fs.browse_collection(request, table).await
+}
+
+#[async_trait]
+impl Driver for FirestoreDriver {
+    fn engine(&self) -> Engine {
+        Engine::Firestore
+    }
+
+    async fn connect(
+        &self,
+        config: &ConnectionConfig,
+        secret: Option<&str>,
+    ) -> CellarResult<Box<dyn Connection>> {
+        let connection = FirestoreConnection::open(config, secret).await?;
+        Ok(Box::new(connection))
+    }
+
+    async fn introspect(&self, conn: &dyn Connection) -> CellarResult<Vec<Database>> {
+        let fs = as_firestore(conn)?;
+        fs.introspect().await
+    }
+
+    async fn execute_query(
+        &self,
+        _conn: &dyn Connection,
+        _query: &Query,
+    ) -> CellarResult<QueryResult> {
+        Err(CellarError::query(
+            "Firestore SQL/query execution is not supported yet; browse root collections from the sidebar",
+        ))
+    }
+
+    async fn explain_query(
+        &self,
+        _conn: &dyn Connection,
+        _query: &Query,
+        _mode: PlanMode,
+    ) -> CellarResult<QueryPlan> {
+        Err(CellarError::invalid_config(
+            "Firestore does not expose SQL execution plans through Cellar yet",
+        ))
+    }
+}
+
+pub struct FirestoreConnection {
+    info: DriverInfo,
+    client: Client,
+    base_url: Url,
+    project_id: String,
+    database_id: String,
+    auth: AuthMode,
+}
+
+impl FirestoreConnection {
+    async fn open(config: &ConnectionConfig, secret: Option<&str>) -> CellarResult<Self> {
+        if config.database.trim().is_empty() {
+            return Err(CellarError::invalid_config(
+                "Firestore project ID is required",
+            ));
+        }
+        let project_id = config.database.trim().to_string();
+        let database_id = firestore_database_id(config);
+        let client = Client::builder()
+            .user_agent(user_agent(config))
+            .build()
+            .map_err(|e| CellarError::connection(e.to_string()))?;
+        let base_url = firestore_base_url(config)?;
+        let auth = AuthMode::from_secret(secret).await?;
+        let connection = Self {
+            info: DriverInfo {
+                engine: Engine::Firestore,
+                version: "Cloud Firestore REST v1".into(),
+            },
+            client,
+            base_url,
+            project_id,
+            database_id,
+            auth,
+        };
+        connection.list_collection_ids(None, 1).await?;
+        Ok(connection)
+    }
+
+    async fn introspect(&self) -> CellarResult<Vec<Database>> {
+        let collection_ids = self.list_collection_ids(None, 1000).await?;
+        let mut tables = Vec::with_capacity(collection_ids.len());
+
+        for collection_id in collection_ids {
+            let documents = self
+                .list_documents(&collection_id, DEFAULT_SAMPLE_SIZE)
+                .await
+                .unwrap_or_default();
+            let columns = infer_columns(&documents);
+            tables.push(Table {
+                name: collection_id,
+                schema: SCHEMA_NAME.into(),
+                row_count: None,
+                columns,
+                primary_key: vec!["__name__".into()],
+                foreign_keys: vec![],
+                indexes: vec![Index {
+                    name: "__name__".into(),
+                    columns: vec!["__name__".into()],
+                    unique: true,
+                    primary: true,
+                }],
+            });
+        }
+
+        Ok(vec![Database {
+            name: self.project_id.clone(),
+            is_default: true,
+            schemas: vec![Schema {
+                name: SCHEMA_NAME.into(),
+                tables,
+                views: vec![],
+            }],
+        }])
+    }
+
+    async fn browse_collection(
+        &self,
+        request: &TableBrowseRequest,
+        table: &Table,
+    ) -> CellarResult<QueryResult> {
+        if request.schema != SCHEMA_NAME {
+            return Err(CellarError::invalid_config(format!(
+                "Firestore collection schema must be {SCHEMA_NAME}"
+            )));
+        }
+        if !request.sorts.is_empty() || !request.filters.is_empty() {
+            return Err(CellarError::query(
+                "Firestore server-side grid sorting and filtering are not supported yet",
+            ));
+        }
+
+        let started = Instant::now();
+        let limit = request.limit.unwrap_or(DEFAULT_BROWSE_LIMIT);
+        let documents = self.list_documents(&request.table, limit).await?;
+        let columns = columns_for_browse(table, &documents);
+        let rows = documents
+            .iter()
+            .map(|doc| row_for_document(doc, &columns))
+            .collect::<Vec<_>>();
+
+        Ok(QueryResult {
+            columns: columns
+                .into_iter()
+                .map(|column| ColumnMeta {
+                    name: column.name,
+                    data_type: column.data_type,
+                    nullable: column.nullable,
+                })
+                .collect(),
+            rows,
+            notices: vec![],
+            notice_capture: NoticeCapture::unsupported(
+                "Firestore REST responses do not include database notice frames",
+            ),
+            rows_affected: None,
+            duration_ms: started.elapsed().as_millis() as u64,
+            truncated: documents.len() as u32 >= limit,
+        })
+    }
+
+    async fn list_collection_ids(
+        &self,
+        parent_document: Option<&str>,
+        page_size: u32,
+    ) -> CellarResult<Vec<String>> {
+        let mut url = self.documents_url(parent_document, Some("listCollectionIds"))?;
+        let mut out = Vec::new();
+        let mut page_token: Option<String> = None;
+
+        loop {
+            let mut body = json!({ "pageSize": page_size });
+            if let Some(token) = page_token.as_deref() {
+                body["pageToken"] = json!(token);
+            }
+            let response: ListCollectionIdsResponse = self
+                .send_json(Method::POST, url.clone(), Some(body))
+                .await?;
+            out.extend(response.collection_ids);
+            page_token = response.next_page_token;
+            if page_token.as_deref().unwrap_or("").is_empty() {
+                break;
+            }
+            url = self.documents_url(parent_document, Some("listCollectionIds"))?;
+        }
+
+        Ok(out)
+    }
+
+    async fn list_documents(
+        &self,
+        collection_id: &str,
+        page_size: u32,
+    ) -> CellarResult<Vec<Document>> {
+        let mut url = self.documents_url(Some(collection_id), None)?;
+        url.query_pairs_mut()
+            .append_pair("pageSize", &page_size.to_string());
+        let response: ListDocumentsResponse = self.send_json(Method::GET, url, None).await?;
+        Ok(response.documents)
+    }
+
+    fn documents_url(
+        &self,
+        child_path: Option<&str>,
+        rpc_suffix: Option<&str>,
+    ) -> CellarResult<Url> {
+        let mut url = self.base_url.clone();
+        {
+            let mut segments = url
+                .path_segments_mut()
+                .map_err(|_| CellarError::invalid_config("invalid Firestore API base URL"))?;
+            segments.clear();
+            segments.extend([
+                "v1",
+                "projects",
+                &self.project_id,
+                "databases",
+                &self.database_id,
+            ]);
+            if let Some(path) = child_path {
+                segments.push("documents");
+                for part in path.split('/').filter(|p| !p.is_empty()) {
+                    segments.push(part);
+                }
+            } else {
+                segments.push("documents");
+            }
+        }
+        if let Some(suffix) = rpc_suffix {
+            let path = url.path().trim_end_matches('/').to_string();
+            url.set_path(&format!("{path}:{suffix}"));
+        }
+        Ok(url)
+    }
+
+    async fn send_json<T: for<'de> Deserialize<'de>>(
+        &self,
+        method: Method,
+        url: Url,
+        body: Option<Value>,
+    ) -> CellarResult<T> {
+        let mut request = self.client.request(method, url);
+        if let Some(token) = self.auth.bearer_token().await? {
+            request = request.bearer_auth(token);
+        }
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+        let response = request
+            .send()
+            .await
+            .map_err(|e| CellarError::connection(e.to_string()))?;
+        let status = response.status();
+        if !status.is_success() {
+            let text = response.text().await.unwrap_or_default();
+            return Err(map_firestore_status(status.as_u16(), text));
+        }
+        response
+            .json::<T>()
+            .await
+            .map_err(|e| CellarError::decode(e.to_string()))
+    }
+}
+
+#[async_trait]
+impl Connection for FirestoreConnection {
+    fn info(&self) -> &DriverInfo {
+        &self.info
+    }
+
+    async fn ping(&self) -> CellarResult<()> {
+        self.list_collection_ids(None, 1).await.map(|_| ())
+    }
+
+    async fn close(&self) -> CellarResult<()> {
+        Ok(())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+#[derive(Clone)]
+enum AuthMode {
+    None,
+    Bearer(String),
+    ServiceAccount(ServiceAccountKey),
+}
+
+impl AuthMode {
+    async fn from_secret(secret: Option<&str>) -> CellarResult<Self> {
+        let Some(secret) = secret.map(str::trim).filter(|s| !s.is_empty()) else {
+            return Ok(Self::None);
+        };
+        if secret.starts_with('{') {
+            let key: ServiceAccountKey = serde_json::from_str(secret).map_err(|e| {
+                CellarError::invalid_config(format!("invalid service account JSON: {e}"))
+            })?;
+            if key.client_email.trim().is_empty() || key.private_key.trim().is_empty() {
+                return Err(CellarError::invalid_config(
+                    "service account JSON must include client_email and private_key",
+                ));
+            }
+            return Ok(Self::ServiceAccount(key));
+        }
+        Ok(Self::Bearer(secret.to_string()))
+    }
+
+    async fn bearer_token(&self) -> CellarResult<Option<String>> {
+        match self {
+            Self::None => Ok(None),
+            Self::Bearer(token) => Ok(Some(token.clone())),
+            Self::ServiceAccount(key) => mint_service_account_token(key).await.map(Some),
+        }
+    }
+}
+
+#[derive(Clone, Deserialize)]
+struct ServiceAccountKey {
+    client_email: String,
+    private_key: String,
+    #[serde(default = "default_token_uri")]
+    token_uri: String,
+}
+
+#[derive(Serialize)]
+struct JwtClaims<'a> {
+    iss: &'a str,
+    scope: &'a str,
+    aud: &'a str,
+    iat: usize,
+    exp: usize,
+}
+
+#[derive(Deserialize)]
+struct TokenResponse {
+    access_token: String,
+}
+
+async fn mint_service_account_token(key: &ServiceAccountKey) -> CellarResult<String> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| CellarError::Internal(e.to_string()))?
+        .as_secs() as usize;
+    let claims = JwtClaims {
+        iss: &key.client_email,
+        scope: DATASTORE_SCOPE,
+        aud: &key.token_uri,
+        iat: now,
+        exp: now + 3600,
+    };
+    let assertion = encode(
+        &Header::new(Algorithm::RS256),
+        &claims,
+        &EncodingKey::from_rsa_pem(key.private_key.as_bytes())
+            .map_err(|e| CellarError::Authentication(e.to_string()))?,
+    )
+    .map_err(|e| CellarError::Authentication(e.to_string()))?;
+
+    let client = Client::new();
+    let response = client
+        .post(&key.token_uri)
+        .form(&[
+            ("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"),
+            ("assertion", assertion.as_str()),
+        ])
+        .send()
+        .await
+        .map_err(|e| CellarError::Authentication(e.to_string()))?;
+    let status = response.status();
+    if !status.is_success() {
+        let text = response.text().await.unwrap_or_default();
+        return Err(CellarError::Authentication(text));
+    }
+    let token = response
+        .json::<TokenResponse>()
+        .await
+        .map_err(|e| CellarError::Authentication(e.to_string()))?;
+    Ok(token.access_token)
+}
+
+fn default_token_uri() -> String {
+    "https://oauth2.googleapis.com/token".into()
+}
+
+#[derive(Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ListCollectionIdsResponse {
+    #[serde(default)]
+    collection_ids: Vec<String>,
+    next_page_token: Option<String>,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ListDocumentsResponse {
+    #[serde(default)]
+    documents: Vec<Document>,
+}
+
+#[derive(Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Document {
+    name: String,
+    #[serde(default)]
+    fields: BTreeMap<String, FirestoreValue>,
+    create_time: Option<String>,
+    update_time: Option<String>,
+}
+
+#[derive(Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+enum FirestoreValue {
+    NullValue(Value),
+    BooleanValue(bool),
+    IntegerValue(String),
+    DoubleValue(f64),
+    TimestampValue(String),
+    StringValue(String),
+    BytesValue(String),
+    ReferenceValue(String),
+    GeoPointValue(Value),
+    ArrayValue(Value),
+    MapValue(Value),
+}
+
+fn infer_columns(documents: &[Document]) -> Vec<Column> {
+    let mut fields: BTreeMap<String, BTreeSet<&'static str>> = BTreeMap::new();
+    for doc in documents {
+        for (name, value) in &doc.fields {
+            fields
+                .entry(name.clone())
+                .or_default()
+                .insert(value.type_name());
+        }
+    }
+
+    let mut columns = vec![
+        column("__name__", "string", false, true, 1),
+        column("__create_time__", "timestamp", true, false, 2),
+        column("__update_time__", "timestamp", true, false, 3),
+    ];
+    for (idx, (name, types)) in fields.into_iter().enumerate() {
+        let data_type = if types.len() == 1 {
+            types.into_iter().next().unwrap_or("unknown")
+        } else {
+            "mixed"
+        };
+        columns.push(column(&name, data_type, true, false, idx as u32 + 4));
+    }
+    columns
+}
+
+fn columns_for_browse(table: &Table, documents: &[Document]) -> Vec<Column> {
+    let mut columns = table.columns.clone();
+    let existing = columns
+        .iter()
+        .map(|c| c.name.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut extra = BTreeMap::new();
+    for doc in documents {
+        for (name, value) in &doc.fields {
+            if !existing.contains(name.as_str()) {
+                extra.entry(name.clone()).or_insert(value.type_name());
+            }
+        }
+    }
+    let start = columns.len() as u32 + 1;
+    for (idx, (name, data_type)) in extra.into_iter().enumerate() {
+        columns.push(column(&name, data_type, true, false, start + idx as u32));
+    }
+    columns
+}
+
+fn column(
+    name: &str,
+    data_type: &str,
+    nullable: bool,
+    is_primary_key: bool,
+    ordinal: u32,
+) -> Column {
+    Column {
+        name: name.into(),
+        data_type: data_type.into(),
+        nullable,
+        default: None,
+        is_primary_key,
+        ordinal,
+        comment: None,
+    }
+}
+
+fn row_for_document(document: &Document, columns: &[Column]) -> Row {
+    columns
+        .iter()
+        .map(|column| match column.name.as_str() {
+            "__name__" => CellValue::Text(short_document_name(&document.name).to_string()),
+            "__create_time__" => optional_text(document.create_time.as_deref()),
+            "__update_time__" => optional_text(document.update_time.as_deref()),
+            other => document
+                .fields
+                .get(other)
+                .map(FirestoreValue::to_cell_value)
+                .unwrap_or(CellValue::Null),
+        })
+        .collect()
+}
+
+impl FirestoreValue {
+    fn type_name(&self) -> &'static str {
+        match self {
+            Self::NullValue(_) => "null",
+            Self::BooleanValue(_) => "boolean",
+            Self::IntegerValue(_) => "integer",
+            Self::DoubleValue(_) => "double",
+            Self::TimestampValue(_) => "timestamp",
+            Self::StringValue(_) => "string",
+            Self::BytesValue(_) => "bytes",
+            Self::ReferenceValue(_) => "reference",
+            Self::GeoPointValue(_) => "geopoint",
+            Self::ArrayValue(_) => "array",
+            Self::MapValue(_) => "map",
+        }
+    }
+
+    fn to_cell_value(&self) -> CellValue {
+        match self {
+            Self::NullValue(_) => CellValue::Null,
+            Self::BooleanValue(v) => CellValue::Bool(*v),
+            Self::IntegerValue(v) => v
+                .parse::<i64>()
+                .map(CellValue::Int)
+                .unwrap_or_else(|_| CellValue::Numeric(v.clone())),
+            Self::DoubleValue(v) => CellValue::Float(*v),
+            Self::TimestampValue(v)
+            | Self::StringValue(v)
+            | Self::BytesValue(v)
+            | Self::ReferenceValue(v) => CellValue::Text(v.clone()),
+            Self::GeoPointValue(v) | Self::ArrayValue(v) | Self::MapValue(v) => {
+                CellValue::Json(v.clone())
+            }
+        }
+    }
+}
+
+fn optional_text(value: Option<&str>) -> CellValue {
+    value
+        .map(|v| CellValue::Text(v.to_string()))
+        .unwrap_or(CellValue::Null)
+}
+
+fn short_document_name(name: &str) -> &str {
+    name.rsplit('/').next().unwrap_or(name)
+}
+
+fn firestore_base_url(config: &ConnectionConfig) -> CellarResult<Url> {
+    let host = if config.host.trim().is_empty() {
+        "firestore.googleapis.com"
+    } else {
+        config.host.trim()
+    };
+    let scheme = if config.ssl_mode == SslMode::Disable {
+        "http"
+    } else {
+        "https"
+    };
+    let default_port = (scheme == "https" && config.port == 443)
+        || (scheme == "http" && config.port == 80)
+        || config.port == 0;
+    let base = if default_port {
+        format!("{scheme}://{host}")
+    } else {
+        format!("{scheme}://{host}:{}", config.port)
+    };
+    Url::parse(&base).map_err(|e| CellarError::invalid_config(e.to_string()))
+}
+
+fn firestore_database_id(config: &ConnectionConfig) -> String {
+    let value = config.user.trim();
+    if value.is_empty() {
+        DEFAULT_DATABASE_ID.into()
+    } else {
+        value.into()
+    }
+}
+
+fn user_agent(config: &ConnectionConfig) -> String {
+    config
+        .application_name
+        .as_deref()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or("cellar")
+        .to_string()
+}
+
+fn map_firestore_status(status: u16, body: String) -> CellarError {
+    let message = firestore_error_message(&body).unwrap_or(body);
+    match status {
+        401 | 403 => CellarError::Authentication(message),
+        408 | 429 | 500..=599 => CellarError::Timeout(message),
+        _ => CellarError::connection(message),
+    }
+}
+
+fn firestore_error_message(body: &str) -> Option<String> {
+    let value: Value = serde_json::from_str(body).ok()?;
+    value
+        .get("error")
+        .and_then(|e| e.get("message"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+fn as_firestore<'a>(conn: &'a dyn Connection) -> CellarResult<&'a FirestoreConnection> {
+    conn.as_any()
+        .downcast_ref::<FirestoreConnection>()
+        .ok_or_else(|| {
+            CellarError::NotConnected(format!(
+                "expected firestore connection, got {}",
+                conn.info().engine.as_str()
+            ))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config() -> ConnectionConfig {
+        ConnectionConfig {
+            id: "fs".into(),
+            name: "Firestore".into(),
+            engine: Engine::Firestore,
+            host: "localhost".into(),
+            port: 8080,
+            database: "demo-project".into(),
+            user: "".into(),
+            ssl_mode: SslMode::Disable,
+            env_tag: None,
+            application_name: Some("cellar-test".into()),
+            color: None,
+        }
+    }
+
+    #[test]
+    fn builds_emulator_base_url() {
+        let url = firestore_base_url(&config()).expect("base url");
+        assert_eq!(url.as_str(), "http://localhost:8080/");
+    }
+
+    #[test]
+    fn infers_columns_and_maps_rows_from_documents() {
+        let document: Document = serde_json::from_value(json!({
+            "name": "projects/demo/databases/(default)/documents/users/ada",
+            "createTime": "2026-01-01T00:00:00Z",
+            "updateTime": "2026-01-02T00:00:00Z",
+            "fields": {
+                "active": { "booleanValue": true },
+                "age": { "integerValue": "37" },
+                "name": { "stringValue": "Ada" },
+                "prefs": { "mapValue": { "fields": { "theme": { "stringValue": "dark" } } } }
+            }
+        }))
+        .expect("document");
+
+        let columns = infer_columns(std::slice::from_ref(&document));
+        assert!(columns
+            .iter()
+            .any(|c| c.name == "__name__" && c.is_primary_key));
+        assert!(columns
+            .iter()
+            .any(|c| c.name == "active" && c.data_type == "boolean"));
+        assert!(columns
+            .iter()
+            .any(|c| c.name == "age" && c.data_type == "integer"));
+
+        let row = row_for_document(&document, &columns);
+        assert_eq!(row[0], CellValue::Text("ada".into()));
+        let name_pos = columns.iter().position(|c| c.name == "name").unwrap();
+        assert_eq!(row[name_pos], CellValue::Text("Ada".into()));
+    }
+}

--- a/packages/ipc/src/generated.ts
+++ b/packages/ipc/src/generated.ts
@@ -225,7 +225,7 @@ version: string }
  * User-facing identifier for which driver to load. Lives in connection
  * configs and crosses IPC, so it has to be serializable.
  */
-export type Engine = "postgres" | "mysql" | "sqlite" | "mssql" | "azure"
+export type Engine = "postgres" | "mysql" | "sqlite" | "mssql" | "azure" | "firestore"
 /**
  * Environment tag, per SPEC §6.1. Production-tagged connections get red
  * styling and confirmation guardrails — this PR wires the data, not the UX.


### PR DESCRIPTION
## Summary

Adds a first-party Firestore driver slice for Cellar. Firestore root collections are exposed as read-only tables under a `documents` schema, with columns inferred from sampled documents and rows mapped into the existing grid result contract.

## Details

- Adds `Engine::Firestore` and regenerates the IPC TypeScript bindings.
- Adds `cellar-driver-firestore` using the Firestore REST API.
- Supports service-account JSON or bearer-token auth through the existing keychain-backed secret path, with blank credentials available for emulator-style connections.
- Wires Firestore into the desktop connection registry and table browse flow.
- Enables Firestore in the connection dialog with project/database-specific labels.
- Disables SQL run/explain affordances for Firestore because query execution is not supported in this slice.

## Validation

- `cargo check --workspace`
- `cargo test --workspace`
- `pnpm typecheck`
- `pnpm test`

## Notes

This is intentionally read-only for now. Firestore query execution, grid commits, server-side sorting/filtering, and nested subcollection browsing are left for follow-up work.