### PR TITLE
fix: search all settings options

### DIFF
--- a/apps/desktop/src/components/modals/Settings.tsx
+++ b/apps/desktop/src/components/modals/Settings.tsx
@@ -23,6 +23,10 @@ import {
   ED_RUN_PRIMARY,
   ED_RUN_SUBTLE,
 } from "./settingsPrimitives";
+import {
+  searchSettings,
+  type SettingsSearchResult,
+} from "./settingsSearch";
 
 export type SettingsCatId =
   | "general"
@@ -86,6 +90,8 @@ export function SettingsModal({
   const [cat, setCat] = useState<SettingsCatId>(initialCat);
   const [q, setQ] = useState("");
   const searchRef = useRef<HTMLInputElement>(null);
+  const searchResults = searchSettings(q);
+  const isSearching = q.trim().length > 0;
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -133,20 +139,38 @@ export function SettingsModal({
       </div>
 
       <div className="grid min-h-0 flex-1 overflow-hidden grid-cols-[200px_1fr]">
-        <SettingsNav cat={cat} setCat={setCat} q={q} />
+        <SettingsNav
+          cat={cat}
+          setCat={setCat}
+          q={q}
+          searchResults={searchResults}
+        />
         <div className="flex min-h-0 min-w-0 flex-col bg-bg-1">
-          {cat === "appearance" && <SettingsAppearance />}
-          {cat === "general" && <SettingsGeneral />}
-          {cat === "editor" && <SettingsEditor />}
-          {cat === "grid" && <SettingsGrid />}
-          {cat === "keymap" && <SettingsKeymap />}
-          {cat === "connections" && <SettingsConnections />}
-          {cat === "history" && <SettingsHistory />}
-          {cat === "backups" && <SettingsBackups />}
-          {cat === "ai" && <SettingsAI />}
-          {cat === "privacy" && <SettingsPrivacy />}
-          {cat === "updates" && <SettingsUpdates />}
-          {cat === "about" && <SettingsAbout />}
+          {isSearching ? (
+            <SettingsSearchResults
+              q={q}
+              results={searchResults}
+              onOpen={(nextCat) => {
+                setCat(nextCat);
+                setQ("");
+              }}
+            />
+          ) : (
+            <>
+              {cat === "appearance" && <SettingsAppearance />}
+              {cat === "general" && <SettingsGeneral />}
+              {cat === "editor" && <SettingsEditor />}
+              {cat === "grid" && <SettingsGrid />}
+              {cat === "keymap" && <SettingsKeymap />}
+              {cat === "connections" && <SettingsConnections />}
+              {cat === "history" && <SettingsHistory />}
+              {cat === "backups" && <SettingsBackups />}
+              {cat === "ai" && <SettingsAI />}
+              {cat === "privacy" && <SettingsPrivacy />}
+              {cat === "updates" && <SettingsUpdates />}
+              {cat === "about" && <SettingsAbout />}
+            </>
+          )}
         </div>
       </div>
 
@@ -192,18 +216,35 @@ function SettingsNav({
   cat,
   setCat,
   q,
+  searchResults,
 }: {
   cat: SettingsCatId;
   setCat: (c: SettingsCatId) => void;
   q: string;
+  searchResults: SettingsSearchResult[];
 }) {
   const filter = q.toLowerCase().trim();
+  const matchingCats = new Set(searchResults.map((result) => result.cat));
+  const counts = searchResults.reduce<Partial<Record<SettingsCatId, number>>>(
+    (acc, result) => {
+      acc[result.cat] = (acc[result.cat] ?? 0) + 1;
+      return acc;
+    },
+    {},
+  );
+
   return (
     <nav className="flex min-h-0 flex-col overflow-y-auto border-r border-border-default bg-bg-0 py-2">
       {SETTINGS_CATS.map((g) => {
-        const items = g.items.filter(
-          (i) => !filter || i.label.toLowerCase().includes(filter),
-        );
+        const groupMatches = filter && g.group.toLowerCase().includes(filter);
+        const items = g.items.filter((i) => {
+          if (!filter) return true;
+          return (
+            groupMatches ||
+            i.label.toLowerCase().includes(filter) ||
+            matchingCats.has(i.id)
+          );
+        });
         if (!items.length) return null;
         return (
           <div key={g.group} className="py-1">
@@ -234,7 +275,16 @@ function SettingsNav({
                     <IconCmp size={12} />
                   </span>
                   <span className="flex-1 whitespace-nowrap">{i.label}</span>
-                  {i.badge && (
+                  {filter && counts[i.id] ? (
+                    <span
+                      className={
+                        "font-mono text-[10px] " +
+                        (active ? "text-accent" : "text-fg-3")
+                      }
+                    >
+                      {counts[i.id]}
+                    </span>
+                  ) : i.badge ? (
                     <span
                       className={
                         "rounded-[3px] border px-1 py-[1px] font-mono text-[9px] uppercase tracking-[0.04em] " +
@@ -245,7 +295,7 @@ function SettingsNav({
                     >
                       {i.badge}
                     </span>
-                  )}
+                  ) : null}
                 </button>
               );
             })}
@@ -265,5 +315,80 @@ function SettingsNav({
         </button>
       </div>
     </nav>
+  );
+}
+
+function SettingsSearchResults({
+  q,
+  results,
+  onOpen,
+}: {
+  q: string;
+  results: SettingsSearchResult[];
+  onOpen: (cat: SettingsCatId) => void;
+}) {
+  return (
+    <div className="flex-1 overflow-y-auto pb-6 pt-1">
+      <section className="px-6 pb-1 pt-[18px]">
+        <header className="mb-3 flex items-end justify-between gap-3">
+          <div>
+            <h2 className="m-0 text-[13px] font-semibold tracking-[-0.005em] text-fg-0">
+              Search results
+            </h2>
+            <p className="m-0 mt-px max-w-[60ch] text-[11.5px] text-fg-2 text-pretty">
+              {results.length
+                ? `${results.length} match${results.length === 1 ? "" : "es"} for "${q.trim()}"`
+                : `No settings match "${q.trim()}"`}
+            </p>
+          </div>
+          <span className="font-mono text-[10.5px] text-fg-3">
+            labels, sections, values
+          </span>
+        </header>
+
+        {results.length ? (
+          <div className="overflow-hidden rounded-[5px] border border-border-default">
+            {results.map((result, idx) => (
+              <button
+                type="button"
+                key={`${result.cat}:${result.section}:${result.label}`}
+                onClick={() => onOpen(result.cat)}
+                className={
+                  "grid w-full grid-cols-[150px_1fr_auto] items-center gap-3 bg-bg-2 px-3 py-2 text-left hover:bg-bg-3 " +
+                  (idx !== results.length - 1
+                    ? "border-b border-border-divider"
+                    : "")
+                }
+              >
+                <span className="min-w-0">
+                  <span className="block truncate text-[11.5px] font-medium text-fg-0">
+                    {result.label}
+                  </span>
+                  <span className="block truncate text-[10.5px] text-fg-3">
+                    {result.section}
+                  </span>
+                </span>
+                <span className="min-w-0 truncate font-mono text-[11px] text-fg-2">
+                  {result.category}
+                </span>
+                <span className="inline-flex items-center gap-1 text-[10.5px] text-fg-3">
+                  <span>open</span>
+                  <Icon.chevronRight size={10} />
+                </span>
+              </button>
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-[5px] border border-dashed border-border-default bg-bg-inset px-3 py-6 text-center">
+            <div className="text-[12px] font-medium text-fg-1">
+              No matching settings
+            </div>
+            <div className="mt-1 text-[11px] text-fg-3">
+              Try a label, category, provider, shortcut, or stored value.
+            </div>
+          </div>
+        )}
+      </section>
+    </div>
   );
 }

--- a/apps/desktop/src/components/modals/settingsSearch.ts
+++ b/apps/desktop/src/components/modals/settingsSearch.ts
@@ -1,0 +1,586 @@
+import type { SettingsCatId } from "./Settings";
+
+export type SettingsSearchEntry = {
+  cat: SettingsCatId;
+  category: string;
+  group: string;
+  section: string;
+  label: string;
+  terms?: string[];
+};
+
+export type SettingsSearchResult = SettingsSearchEntry & {
+  score: number;
+};
+
+const ENTRIES: SettingsSearchEntry[] = [
+  {
+    cat: "general",
+    group: "Workspace",
+    category: "General",
+    section: "General",
+    label: "Startup",
+    terms: ["Restore last session", "Empty workspace", "Show welcome"],
+  },
+  {
+    cat: "general",
+    group: "Workspace",
+    category: "General",
+    section: "General",
+    label: "Default schema search path",
+    terms: ["public", "audit", "analytics"],
+  },
+  {
+    cat: "general",
+    group: "Workspace",
+    category: "General",
+    section: "General",
+    label: "Confirm before quitting",
+  },
+  {
+    cat: "general",
+    group: "Workspace",
+    category: "General",
+    section: "General",
+    label: "Allow background queries",
+  },
+  {
+    cat: "general",
+    group: "Workspace",
+    category: "General",
+    section: "Updates",
+    label: "Channel",
+    terms: ["stable", "beta", "nightly"],
+  },
+  {
+    cat: "general",
+    group: "Workspace",
+    category: "General",
+    section: "Updates",
+    label: "Auto-install on quit",
+  },
+  {
+    cat: "appearance",
+    group: "Workspace",
+    category: "Appearance",
+    section: "Theme",
+    label: "Theme",
+    terms: ["system", "dark", "light"],
+  },
+  {
+    cat: "appearance",
+    group: "Workspace",
+    category: "Appearance",
+    section: "Theme",
+    label: "Accent",
+    terms: ["color", "swatch", "palette"],
+  },
+  {
+    cat: "appearance",
+    group: "Workspace",
+    category: "Appearance",
+    section: "Theme",
+    label: "Density",
+    terms: ["compact", "comfortable"],
+  },
+  {
+    cat: "appearance",
+    group: "Workspace",
+    category: "Appearance",
+    section: "Type",
+    label: "Interface font",
+    terms: ["sans", "typeface"],
+  },
+  {
+    cat: "appearance",
+    group: "Workspace",
+    category: "Appearance",
+    section: "Type",
+    label: "Editor / mono font",
+    terms: ["monospace", "sql", "typeface"],
+  },
+  {
+    cat: "appearance",
+    group: "Workspace",
+    category: "Appearance",
+    section: "Type",
+    label: "Font size",
+    terms: ["scales the entire interface", "px"],
+  },
+  {
+    cat: "appearance",
+    group: "Workspace",
+    category: "Appearance",
+    section: "Window",
+    label: "Show traffic lights",
+  },
+  {
+    cat: "appearance",
+    group: "Workspace",
+    category: "Appearance",
+    section: "Window",
+    label: "Native window controls",
+  },
+  {
+    cat: "editor",
+    group: "Workspace",
+    category: "Editor",
+    section: "SQL editor",
+    label: "Tab size",
+    terms: ["2", "4", "8"],
+  },
+  {
+    cat: "editor",
+    group: "Workspace",
+    category: "Editor",
+    section: "SQL editor",
+    label: "Indent with",
+    terms: ["spaces", "tabs"],
+  },
+  {
+    cat: "editor",
+    group: "Workspace",
+    category: "Editor",
+    section: "SQL editor",
+    label: "Auto-format on save",
+    terms: ["format"],
+  },
+  {
+    cat: "editor",
+    group: "Workspace",
+    category: "Editor",
+    section: "SQL editor",
+    label: "Keyword case",
+    terms: ["UPPER", "lower", "Preserve"],
+  },
+  {
+    cat: "editor",
+    group: "Workspace",
+    category: "Editor",
+    section: "SQL editor",
+    label: "Show line numbers",
+  },
+  {
+    cat: "editor",
+    group: "Workspace",
+    category: "Editor",
+    section: "SQL editor",
+    label: "Soft wrap",
+  },
+  {
+    cat: "editor",
+    group: "Workspace",
+    category: "Editor",
+    section: "SQL editor",
+    label: "Bracket matching",
+  },
+  {
+    cat: "editor",
+    group: "Workspace",
+    category: "Editor",
+    section: "Execution",
+    label: "Statement at cursor runs",
+    terms: ["current statement", "selection", "whole file", "run"],
+  },
+  {
+    cat: "editor",
+    group: "Workspace",
+    category: "Editor",
+    section: "Execution",
+    label: "LIMIT applied to SELECT *",
+    terms: ["row limit", "select"],
+  },
+  {
+    cat: "grid",
+    group: "Workspace",
+    category: "Data grid",
+    section: "Data grid",
+    label: "Row height",
+    terms: ["20px", "22px", "28px", "36px"],
+  },
+  {
+    cat: "grid",
+    group: "Workspace",
+    category: "Data grid",
+    section: "Data grid",
+    label: "NULL display",
+    terms: ["dim italic", "strong"],
+  },
+  {
+    cat: "grid",
+    group: "Workspace",
+    category: "Data grid",
+    section: "Data grid",
+    label: "Number alignment",
+    terms: ["left", "right"],
+  },
+  {
+    cat: "grid",
+    group: "Workspace",
+    category: "Data grid",
+    section: "Data grid",
+    label: "Stripe alternating rows",
+  },
+  {
+    cat: "grid",
+    group: "Workspace",
+    category: "Data grid",
+    section: "Data grid",
+    label: "Sticky pkey column",
+    terms: ["primary key", "frozen"],
+  },
+  {
+    cat: "grid",
+    group: "Workspace",
+    category: "Data grid",
+    section: "Data grid",
+    label: "Truncate cells over",
+    terms: ["max cell preview length", "characters"],
+  },
+  {
+    cat: "keymap",
+    group: "Workspace",
+    category: "Keymap",
+    section: "Keymap",
+    label: "Preset",
+    terms: ["Cellar", "DataGrip", "VS Code", "Linear"],
+  },
+  {
+    cat: "keymap",
+    group: "Workspace",
+    category: "Keymap",
+    section: "Workspace",
+    label: "Command palette",
+    terms: ["New connection", "New SQL tab", "Close tab", "Settings"],
+  },
+  {
+    cat: "keymap",
+    group: "Workspace",
+    category: "Keymap",
+    section: "Editor",
+    label: "Run statement",
+    terms: ["Run selection", "Format", "Accept ghost text", "Show schema"],
+  },
+  {
+    cat: "keymap",
+    group: "Workspace",
+    category: "Keymap",
+    section: "Grid",
+    label: "Edit cell",
+    terms: ["Revert cell", "Commit changes", "Set NULL"],
+  },
+  {
+    cat: "connections",
+    group: "Data",
+    category: "Connections",
+    section: "Defaults for new connections",
+    label: "Read-only by default",
+  },
+  {
+    cat: "connections",
+    group: "Data",
+    category: "Connections",
+    section: "Defaults for new connections",
+    label: "Connection timeout",
+    terms: ["seconds"],
+  },
+  {
+    cat: "connections",
+    group: "Data",
+    category: "Connections",
+    section: "Defaults for new connections",
+    label: "Keep-alive interval",
+    terms: ["seconds"],
+  },
+  {
+    cat: "connections",
+    group: "Data",
+    category: "Connections",
+    section: "Defaults for new connections",
+    label: "Application name",
+    terms: ["cellar", "client"],
+  },
+  {
+    cat: "connections",
+    group: "Data",
+    category: "Connections",
+    section: "Production safety",
+    label: "Confirm DML on prod",
+    terms: ["production", "destructive"],
+  },
+  {
+    cat: "connections",
+    group: "Data",
+    category: "Connections",
+    section: "Production safety",
+    label: "Confirm DROP / TRUNCATE on prod",
+    terms: ["production", "destructive"],
+  },
+  {
+    cat: "connections",
+    group: "Data",
+    category: "Connections",
+    section: "Production safety",
+    label: "Block UPDATE without WHERE",
+  },
+  {
+    cat: "connections",
+    group: "Data",
+    category: "Connections",
+    section: "Production safety",
+    label: "Block DELETE without WHERE",
+  },
+  {
+    cat: "connections",
+    group: "Data",
+    category: "Connections",
+    section: "Production safety",
+    label: "Max rows affected before warn",
+  },
+  {
+    cat: "history",
+    group: "Data",
+    category: "Query history",
+    section: "Query history",
+    label: "Retain history for",
+    terms: ["7 days", "30 days", "90 days", "forever"],
+  },
+  {
+    cat: "history",
+    group: "Data",
+    category: "Query history",
+    section: "Query history",
+    label: "Store query results",
+  },
+  {
+    cat: "history",
+    group: "Data",
+    category: "Query history",
+    section: "Query history",
+    label: "Storage summary",
+    terms: ["queries", "last cleared", "MB"],
+  },
+  {
+    cat: "backups",
+    group: "Data",
+    category: "Backups & exports",
+    section: "Backups",
+    label: "Auto-snapshot before commits",
+    terms: ["pg_dump", "schema-only", "affected rows"],
+  },
+  {
+    cat: "backups",
+    group: "Data",
+    category: "Backups & exports",
+    section: "Backups",
+    label: "Snapshot location",
+    terms: ["~/.cellar/snapshots"],
+  },
+  {
+    cat: "backups",
+    group: "Data",
+    category: "Backups & exports",
+    section: "Backups",
+    label: "Retain snapshots for",
+    terms: ["days"],
+  },
+  {
+    cat: "backups",
+    group: "Data",
+    category: "Backups & exports",
+    section: "Export defaults",
+    label: "Format",
+    terms: ["CSV", "JSON", "Parquet", "SQL INSERT"],
+  },
+  {
+    cat: "backups",
+    group: "Data",
+    category: "Backups & exports",
+    section: "Export defaults",
+    label: "NULL as",
+    terms: ["\\N"],
+  },
+  {
+    cat: "backups",
+    group: "Data",
+    category: "Backups & exports",
+    section: "Export defaults",
+    label: "Include headers",
+  },
+  {
+    cat: "ai",
+    group: "Intelligence",
+    category: "AI Assistant",
+    section: "AI Assistant",
+    label: "Bring-your-own-key",
+    terms: ["schema", "queries", "results", "provider", "privacy"],
+  },
+  {
+    cat: "ai",
+    group: "Intelligence",
+    category: "AI Assistant",
+    section: "Provider",
+    label: "Provider",
+    terms: ["Anthropic", "OpenAI", "Google", "Local", "Custom", "Ollama", "LM Studio"],
+  },
+  {
+    cat: "ai",
+    group: "Intelligence",
+    category: "AI Assistant",
+    section: "Provider",
+    label: "Model",
+    terms: [
+      "claude",
+      "gpt",
+      "gemini",
+      "local-default",
+      "balanced",
+      "fast",
+      "max",
+    ],
+  },
+  {
+    cat: "ai",
+    group: "Intelligence",
+    category: "AI Assistant",
+    section: "Provider",
+    label: "API key",
+    terms: ["keychain", "stored", "secret"],
+  },
+  {
+    cat: "ai",
+    group: "Intelligence",
+    category: "AI Assistant",
+    section: "Provider",
+    label: "Endpoint",
+    terms: ["proxy", "custom router", "OpenAI-compatible"],
+  },
+  {
+    cat: "ai",
+    group: "Intelligence",
+    category: "AI Assistant",
+    section: "Danger zone",
+    label: "Clear AI conversation history",
+    terms: ["local", "delete"],
+  },
+  {
+    cat: "ai",
+    group: "Intelligence",
+    category: "AI Assistant",
+    section: "Danger zone",
+    label: "Revoke API key",
+    terms: ["remove from keychain", "provider"],
+  },
+  {
+    cat: "privacy",
+    group: "System",
+    category: "Privacy & telemetry",
+    section: "Telemetry",
+    label: "Send anonymous usage stats",
+    terms: ["counts of feature use", "no query content"],
+  },
+  {
+    cat: "privacy",
+    group: "System",
+    category: "Privacy & telemetry",
+    section: "Telemetry",
+    label: "Send crash reports",
+    terms: ["stack traces", "never DB contents"],
+  },
+  {
+    cat: "privacy",
+    group: "System",
+    category: "Privacy & telemetry",
+    section: "Stored locally only",
+    label: "Local data",
+    terms: [
+      "connections.toml",
+      "history.sqlite",
+      "AI conversations",
+      "snapshots",
+      "cached schemas",
+      "~/.cellar",
+    ],
+  },
+  {
+    cat: "updates",
+    group: "System",
+    category: "Updates",
+    section: "Updates",
+    label: "Version",
+    terms: ["v0.1.0-alpha", "updater", "last checked", "check now"],
+  },
+  {
+    cat: "updates",
+    group: "System",
+    category: "Updates",
+    section: "Updates",
+    label: "Channel",
+    terms: ["stable", "beta", "nightly"],
+  },
+  {
+    cat: "updates",
+    group: "System",
+    category: "Updates",
+    section: "Updates",
+    label: "Auto-install on quit",
+  },
+  {
+    cat: "about",
+    group: "System",
+    category: "About",
+    section: "About",
+    label: "Cellar",
+    terms: ["database client", "AI", "development build", "MIT licensed"],
+  },
+  {
+    cat: "about",
+    group: "System",
+    category: "About",
+    section: "About",
+    label: "Links",
+    terms: ["docs", "github", "changelog", "acknowledgements"],
+  },
+];
+
+const CATEGORY_SCORE = 8;
+const SECTION_SCORE = 4;
+const LABEL_SCORE = 6;
+const TERM_SCORE = 2;
+
+function normalize(value: string) {
+  return value.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function tokens(query: string) {
+  return normalize(query).split(" ").filter(Boolean);
+}
+
+function scoreEntry(entry: SettingsSearchEntry, queryTokens: string[]) {
+  const fields = [
+    entry.group,
+    entry.category,
+    entry.section,
+    entry.label,
+    ...(entry.terms ?? []),
+  ].map(normalize);
+  const haystack = fields.join(" ");
+
+  if (!queryTokens.every((token) => haystack.includes(token))) return 0;
+
+  return queryTokens.reduce((score, token) => {
+    if (normalize(entry.category).includes(token)) return score + CATEGORY_SCORE;
+    if (normalize(entry.label).includes(token)) return score + LABEL_SCORE;
+    if (normalize(entry.section).includes(token)) return score + SECTION_SCORE;
+    return score + TERM_SCORE;
+  }, 0);
+}
+
+export function searchSettings(query: string): SettingsSearchResult[] {
+  const queryTokens = tokens(query);
+  if (!queryTokens.length) return [];
+
+  return ENTRIES.map((entry) => ({ ...entry, score: scoreEntry(entry, queryTokens) }))
+    .filter((entry) => entry.score > 0)
+    .sort((a, b) => b.score - a.score || a.category.localeCompare(b.category));
+}


### PR DESCRIPTION
## Summary

- Add a settings search index covering category names, section titles, row labels, hints, option values, providers, shortcuts, and stored-value rows.
- Replace the settings modal's menu-only filtering with a search results pane.
- Keep the left nav useful during search by showing categories with matches and per-category counts.

## Why

Settings search previously filtered only the left-hand category menu, so searches like `api key` or `font` could miss actual settings rows unless the category name itself matched.

## Validation

- `pnpm typecheck`
- Browser smoke test on the Vite web shell at `http://localhost:1431/`
- Verified `api key` finds AI settings rows and opens the AI category
- Verified `font` finds Appearance font rows