### PR TITLE
fix: set default font size to 13.5px

### DIFF
--- a/apps/desktop/src/styles/tokens.css
+++ b/apps/desktop/src/styles/tokens.css
@@ -87,8 +87,8 @@
   --font-mono: "JetBrains Mono", "Geist Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
   --fs-xs: 10.5px;
   --fs-sm: 11.5px;
-  --fs-md: 12.5px;
-  --fs-lg: 13.5px;
+  --fs-md: 13.5px;
+  --fs-lg: 14.5px;
   --fs-xl: 15px;
 }
 
@@ -132,7 +132,7 @@
   --row-h: 22px;
   --tab-h: 30px;
   --fs-sm: 11.5px;
-  --fs-md: 12.5px;
+  --fs-md: 13.5px;
 }
 [data-density="comfortable"] {
   --row-h: 28px;


### PR DESCRIPTION
## Summary
- Set Cellar's default medium font token to 13.5px.
- Keep the type scale distinct by moving the large token to 14.5px.
- Apply the same 13.5px default for compact density.

## Validation
- pnpm --filter @cellar/desktop typecheck
- Fetched latest main and checked branch mergeability with git merge-tree before creating this PR.