### PR TITLE
build: add release packaging workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,85 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "cellar-v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build-tauri:
+    name: Build ${{ matrix.label }}
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: macOS Apple Silicon
+            platform: macos-latest
+            args: --target aarch64-apple-darwin
+            rust-targets: aarch64-apple-darwin
+          - label: macOS Intel
+            platform: macos-latest
+            args: --target x86_64-apple-darwin
+            rust-targets: x86_64-apple-darwin
+          - label: Windows
+            platform: windows-latest
+            args: ""
+            rust-targets: ""
+          - label: Linux
+            platform: ubuntu-22.04
+            args: ""
+            rust-targets: ""
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Linux dependencies
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust-targets }}
+
+      - name: Cache Rust
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            . -> target
+            apps/desktop/src-tauri -> apps/desktop/src-tauri/target
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build and upload installers
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          projectPath: apps/desktop
+          tagName: cellar-v__VERSION__
+          releaseName: Cellar v__VERSION__
+          releaseBody: See the assets below to download Cellar for your platform.
+          releaseDraft: true
+          prerelease: true
+          args: ${{ matrix.args }}

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Cellar",
-  "version": "0.1.0",
+  "version": "0.1.0-alpha",
   "identifier": "com.cellar.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev:web",

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,43 @@
+# Release packaging
+
+Cellar is packaged with Tauri and published through GitHub Releases.
+
+## Local builds
+
+From the repository root:
+
+```bash
+pnpm install
+pnpm --filter @cellar/desktop build:tauri
+```
+
+Tauri writes installers and bundles under:
+
+```text
+apps/desktop/src-tauri/target/release/bundle/
+```
+
+The exact formats depend on the host platform. For example, macOS builds produce app/dmg artifacts, Windows builds produce installer artifacts, and Linux builds produce Linux package formats.
+
+## GitHub release builds
+
+Push a version tag to build release artifacts for macOS, Windows, and Linux:
+
+```bash
+git tag cellar-v0.1.0-alpha
+git push origin cellar-v0.1.0-alpha
+```
+
+The `Release` workflow creates a draft prerelease and uploads the Tauri installers. Review the draft, edit release notes, then publish it.
+
+The website download button should link to the latest GitHub Release or to a small platform-detection page that redirects to the right release asset for macOS, Windows, or Linux.
+
+## Before public distribution
+
+Unsigned builds are useful for early testers, but public downloads need platform signing:
+
+- macOS: Apple Developer ID signing and notarization.
+- Windows: code-signing certificate.
+- Linux: package metadata review for AppImage/deb/rpm outputs.
+
+Do not enable Tauri auto-update until release signing keys and updater metadata are deliberately configured.


### PR DESCRIPTION
## Summary

- add a GitHub Actions release workflow for Tauri desktop artifacts across macOS, Windows, and Linux
- document local and GitHub release packaging steps
- align the Tauri app version with the existing `0.1.0-alpha` workspace version

## Validation

- `pnpm typecheck`
- `pnpm --filter @cellar/desktop build`
- `pnpm --filter @cellar/desktop tauri info`

## Notes

This creates draft prereleases and leaves platform signing/notarization as a deliberate follow-up before broad public distribution.
