### PR TITLE
feat: add persisted grid column layout

### DIFF
--- a/apps/desktop/src/components/TabBar.tsx
+++ b/apps/desktop/src/components/TabBar.tsx
@@ -36,6 +36,8 @@ function pickQueryTarget(): { connectionId: string; database: string } | null {
 
 export function TabBar() {
   const [menu, setMenu] = useState<ContextMenuState | null>(null);
+  const [draggedTabId, setDraggedTabId] = useState<string | null>(null);
+  const [tabDropTargetId, setTabDropTargetId] = useState<string | null>(null);
   const tabs = useTabs((s) => s.tabs);
   const activeId = useTabs((s) => s.activeId);
   const split = useTabs((s) => s.split);
@@ -46,6 +48,7 @@ export function TabBar() {
   const reopenClosedTab = useTabs((s) => s.reopenClosedTab);
   const closeOtherTabs = useTabs((s) => s.closeOtherTabs);
   const closeTabsToRight = useTabs((s) => s.closeTabsToRight);
+  const reorderTab = useTabs((s) => s.reorderTab);
   const newQueryTab = useTabs((s) => s.newQueryTab);
   const setQuerySql = useTabs((s) => s.setQuerySql);
   const refreshTable = useTabs((s) => s.refreshTable);
@@ -140,13 +143,43 @@ export function TabBar() {
           return (
             <div
               key={t.id}
+              draggable
+              onDragStart={(e) => {
+                e.dataTransfer.effectAllowed = "move";
+                e.dataTransfer.setData("text/plain", t.id);
+                setDraggedTabId(t.id);
+              }}
+              onDragOver={(e) => {
+                if (!draggedTabId || draggedTabId === t.id) return;
+                e.preventDefault();
+                e.dataTransfer.dropEffect = "move";
+                setTabDropTargetId(t.id);
+              }}
+              onDragLeave={() => {
+                setTabDropTargetId((current) => (current === t.id ? null : current));
+              }}
+              onDrop={(e) => {
+                e.preventDefault();
+                const sourceId =
+                  e.dataTransfer.getData("text/plain") || draggedTabId;
+                if (sourceId) reorderTab(sourceId, t.id);
+                if (sourceId) setActive(sourceId);
+                setDraggedTabId(null);
+                setTabDropTargetId(null);
+              }}
+              onDragEnd={() => {
+                setDraggedTabId(null);
+                setTabDropTargetId(null);
+              }}
               onClick={() => setActive(t.id)}
               onContextMenu={(e) => openTabMenu(e, t)}
               className={
                 "group relative inline-flex items-center gap-1.5 h-full pl-2.5 pr-2 max-w-[260px] shrink-0 border-r border-border-default text-[11.5px] cursor-pointer transition-[background,color] duration-100 " +
                 (isActive
                   ? "bg-bg-0 text-fg-0 border-b border-bg-0 -mb-px"
-                  : "bg-bg-1 text-fg-2 hover:bg-bg-2 hover:text-fg-1")
+                  : "bg-bg-1 text-fg-2 hover:bg-bg-2 hover:text-fg-1") +
+                (draggedTabId === t.id ? " opacity-60" : "") +
+                (tabDropTargetId === t.id ? " shadow-[inset_2px_0_0_var(--accent-line)]" : "")
               }
             >
               <span
@@ -174,6 +207,7 @@ export function TabBar() {
               )}
               <button
                 type="button"
+                draggable={false}
                 onClick={(e) => {
                   e.stopPropagation();
                   closeTab(t.id);

--- a/apps/desktop/src/components/Workspace.tsx
+++ b/apps/desktop/src/components/Workspace.tsx
@@ -144,7 +144,9 @@ function TableTabPane({
 }) {
   const refreshKey = useTabs((s) => s.refreshKeys[tab.id] ?? 0);
   const changes = useTabs((s) => s.tableChanges[tab.id] ?? EMPTY_CHANGES);
+  const columnLayout = useTabs((s) => s.tableLayouts[tab.id]);
   const setTableChanges = useTabs((s) => s.setTableChanges);
+  const setTableLayout = useTabs((s) => s.setTableLayout);
   const clearTableChanges = useTabs((s) => s.clearTableChanges);
   const [pageIndex, setPageIndex] = useState(0);
   const [pageSize, setPageSize] = useState(500);
@@ -205,6 +207,8 @@ function TableTabPane({
         onFiltersChange={grid.setFilters}
         sort={grid.sort}
         onSortChange={grid.setSort}
+        columnLayout={columnLayout}
+        onColumnLayoutChange={(next) => setTableLayout(tab.id, next)}
         onCommit={onCommit}
         onRevert={() => clearTableChanges(tab.id)}
       />

--- a/apps/desktop/src/state/tabs.test.ts
+++ b/apps/desktop/src/state/tabs.test.ts
@@ -25,8 +25,10 @@ describe("tab workspace state", () => {
       closedTabs: [],
       split: null,
       tableChanges: {},
+      tableLayouts: {},
       refreshKeys: {},
     });
+    if (typeof localStorage !== "undefined") localStorage.clear();
     useTabResults.setState({ byTabId: {} });
   });
 
@@ -125,5 +127,41 @@ describe("tab workspace state", () => {
     ]);
     expect(useTabs.getState().activeId).toBe("conn-1::app.public.orders");
     expect(useTabs.getState().closedTabs).toHaveLength(2);
+  });
+
+  it("reorders tabs by id", () => {
+    const store = useTabs.getState();
+    store.openTable("conn-1", "app", "public", "orders");
+    store.openTable("conn-1", "app", "public", "customers");
+    store.openTable("conn-1", "app", "events", "devices");
+
+    useTabs
+      .getState()
+      .reorderTab("conn-1::app.events.devices", "conn-1::app.public.customers");
+
+    expect(useTabs.getState().tabs.map((t) => t.id)).toEqual([
+      "conn-1::app.public.orders",
+      "conn-1::app.events.devices",
+      "conn-1::app.public.customers",
+    ]);
+  });
+
+  it("keeps table layouts after a table tab is closed", () => {
+    const store = useTabs.getState();
+    store.openTable("conn-1", "app", "public", "orders");
+
+    useTabs.getState().setTableLayout("conn-1::app.public.orders", {
+      order: ["status", "id"],
+      widths: { status: 140 },
+    });
+    useTabs.getState().closeTab("conn-1::app.public.orders");
+
+    expect(useTabs.getState().tableLayouts["conn-1::app.public.orders"]).toEqual({
+      order: ["status", "id"],
+      widths: { status: 140 },
+    });
+    if (typeof localStorage !== "undefined") {
+      expect(localStorage.getItem("cellar.tableLayouts.v1")).toContain("status");
+    }
   });
 });

--- a/apps/desktop/src/state/tabs.ts
+++ b/apps/desktop/src/state/tabs.ts
@@ -1,6 +1,8 @@
 import { create } from "zustand";
-import type { PendingChanges } from "@cellar/data-grid";
+import type { GridColumnLayout, PendingChanges } from "@cellar/data-grid";
 import { useTabResults } from "./tabResults";
+
+const TABLE_LAYOUTS_STORAGE_KEY = "cellar.tableLayouts.v1";
 
 export interface TableTab {
   id: string;
@@ -31,6 +33,8 @@ export interface WorkspaceSplit {
   secondaryId: string;
 }
 
+export type TableLayouts = Record<string, GridColumnLayout>;
+
 let queryTabSeq = 0;
 
 interface TabsStore {
@@ -39,6 +43,7 @@ interface TabsStore {
   closedTabs: WorkspaceTab[];
   split: WorkspaceSplit | null;
   tableChanges: Record<string, PendingChanges>;
+  tableLayouts: TableLayouts;
   refreshKeys: Record<string, number>;
   openTable: (
     connectionId: string,
@@ -55,7 +60,9 @@ interface TabsStore {
   clearSplit: () => void;
   closeOtherTabs: (id: string) => void;
   closeTabsToRight: (id: string) => void;
+  reorderTab: (sourceId: string, targetId: string) => void;
   setActive: (id: string) => void;
+  setTableLayout: (id: string, layout: GridColumnLayout) => void;
   setTableChanges: (id: string, changes: PendingChanges) => void;
   clearTableChanges: (id: string) => void;
   refreshTable: (id: string) => void;
@@ -68,6 +75,46 @@ function tableKey(
   table: string,
 ): string {
   return `${connectionId}::${database}.${schema}.${table}`;
+}
+
+function loadTableLayouts(): TableLayouts {
+  if (typeof localStorage === "undefined") return {};
+  try {
+    const raw = localStorage.getItem(TABLE_LAYOUTS_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return {};
+    const layouts: TableLayouts = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (!value || typeof value !== "object") continue;
+      const item = value as Partial<GridColumnLayout>;
+      layouts[key] = {
+        order: Array.isArray(item.order)
+          ? item.order.filter(
+              (columnKey): columnKey is string =>
+                typeof columnKey === "string",
+            )
+          : [],
+        widths:
+          item.widths && typeof item.widths === "object"
+            ? Object.fromEntries(
+                Object.entries(item.widths).filter(
+                  ([columnKey, width]) =>
+                    typeof columnKey === "string" && typeof width === "number",
+                ),
+              )
+            : {},
+      };
+    }
+    return layouts;
+  } catch {
+    return {};
+  }
+}
+
+function saveTableLayouts(layouts: TableLayouts) {
+  if (typeof localStorage === "undefined") return;
+  localStorage.setItem(TABLE_LAYOUTS_STORAGE_KEY, JSON.stringify(layouts));
 }
 
 function dropTabScopedState(
@@ -118,6 +165,7 @@ export const useTabs = create<TabsStore>((set, get) => ({
   closedTabs: [],
   split: null,
   tableChanges: {},
+  tableLayouts: loadTableLayouts(),
   refreshKeys: {},
 
   openTable(connectionId, database, schema, table) {
@@ -250,6 +298,20 @@ export const useTabs = create<TabsStore>((set, get) => ({
     clearTabResults(closedIds);
   },
 
+  reorderTab(sourceId, targetId) {
+    if (sourceId === targetId) return;
+    set((s) => {
+      const sourceIndex = s.tabs.findIndex((t) => t.id === sourceId);
+      const targetIndex = s.tabs.findIndex((t) => t.id === targetId);
+      if (sourceIndex === -1 || targetIndex === -1) return {};
+      const tabs = [...s.tabs];
+      const [moved] = tabs.splice(sourceIndex, 1);
+      if (!moved) return {};
+      tabs.splice(targetIndex, 0, moved);
+      return { tabs, split: splitForTabs(tabs, s.split) };
+    });
+  },
+
   reopenClosedTab() {
     set((s) => {
       const [closed, ...closedTabs] = s.closedTabs;
@@ -305,6 +367,14 @@ export const useTabs = create<TabsStore>((set, get) => ({
           ? { ...s.split, primaryId: id }
           : s.split,
     }));
+  },
+
+  setTableLayout(id, layout) {
+    set((s) => {
+      const tableLayouts = { ...s.tableLayouts, [id]: layout };
+      saveTableLayouts(tableLayouts);
+      return { tableLayouts };
+    });
   },
 
   setTableChanges(id, changes) {

--- a/apps/desktop/src/styles/grid.css
+++ b/apps/desktop/src/styles/grid.css
@@ -317,6 +317,12 @@
 .grid-header-cell.is-sorted.frozen {
   background: color-mix(in oklab, var(--accent-soft) 42%, var(--bg-1));
 }
+.grid-header-cell.is-dragging {
+  opacity: 0.58;
+}
+.grid-header-cell.is-drop-target {
+  box-shadow: inset 2px 0 0 var(--accent-line);
+}
 .grid-header-icon { color: var(--fg-3); display: inline-flex; }
 .grid-header-name {
   overflow: hidden;
@@ -349,13 +355,16 @@
 }
 .grid-col-resize {
   position: absolute;
-  right: 0;
+  right: -2px;
   top: 0;
   bottom: 0;
-  width: 4px;
+  width: 6px;
   cursor: col-resize;
+  z-index: 5;
+  touch-action: none;
 }
-.grid-col-resize:hover { background: var(--accent-line); }
+.grid-col-resize:hover,
+.grid-col-resize.is-resizing { background: var(--accent-line); }
 
 /* ── selection + cell edit states ─────────────────────────── */
 .grid-cell.is-selected {

--- a/packages/data-grid/src/DataGrid.tsx
+++ b/packages/data-grid/src/DataGrid.tsx
@@ -1,5 +1,19 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
 import { CellEditor, CellValue } from "./Cell";
+import {
+  emptyColumnLayout,
+  layoutForColumns,
+  MIN_COLUMN_WIDTH,
+  pruneColumnLayout,
+  sameColumnLayout,
+} from "./columnLayout";
 import { FilterBar } from "./FilterBar";
 import { filterRows } from "./filters";
 import { GridIcon } from "./icons";
@@ -11,6 +25,7 @@ import type {
   CellChange,
   ColumnFilters,
   GridColumn,
+  GridColumnLayout,
   GridPagination,
   GridRow,
   PendingChange,
@@ -19,6 +34,15 @@ import type {
 } from "./types";
 
 const ROWNO_WIDTH = 36;
+const COLUMN_AUTOFIT_PADDING = 32;
+const HEADER_AUTOFIT_PADDING = 58;
+
+type ColumnResizeState = {
+  columnKey: string;
+  startX: number;
+  startWidth: number;
+  nextWidth: number;
+};
 
 export type DataGridProps = {
   columns: readonly GridColumn[];
@@ -39,6 +63,9 @@ export type DataGridProps = {
 
   sort?: SortState;
   onSortChange?: (next: SortState) => void;
+
+  columnLayout?: GridColumnLayout;
+  onColumnLayoutChange?: (next: GridColumnLayout) => void;
 
   /**
    * Number of leftmost columns to freeze. The frozen columns stick to the left
@@ -77,6 +104,8 @@ export function DataGrid({
   onFiltersChange,
   sort,
   onSortChange,
+  columnLayout,
+  onColumnLayoutChange,
   frozenCount = 2,
   totalRows,
   pagination,
@@ -85,23 +114,101 @@ export function DataGrid({
   readOnly = false,
 }: DataGridProps) {
   const [internalSort, setInternalSort] = useState<SortState>(null);
+  const [internalColumnLayout, setInternalColumnLayout] =
+    useState<GridColumnLayout>(() => emptyColumnLayout());
+  const [resizing, setResizing] = useState<ColumnResizeState | null>(null);
+  const [draggedColumnKey, setDraggedColumnKey] = useState<string | null>(null);
+  const [columnDropTargetKey, setColumnDropTargetKey] = useState<string | null>(null);
   const activeSort = sort ?? internalSort;
+  const activeColumnLayout = columnLayout ?? internalColumnLayout;
+  const isResizing = resizing !== null;
+  const resizingRef = useRef<ColumnResizeState | null>(null);
+  const suppressNextSortRef = useRef(false);
+  const measureCanvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  const renderedColumns = useMemo(
+    () => layoutForColumns(columns, activeColumnLayout),
+    [activeColumnLayout, columns],
+  );
 
   // Local search across visible page. Server-side filtering happens upstream
   // for large tables; the chips drive both.
   const filteredRows = useMemo(() => {
-    return filterRows(rows, columns, filters, changes);
-  }, [rows, columns, filters, changes]);
+    return filterRows(rows, renderedColumns, filters, changes);
+  }, [rows, renderedColumns, filters, changes]);
 
   const visibleRows = useMemo(
-    () => sortGridRows(filteredRows, columns, activeSort, changes),
-    [filteredRows, columns, activeSort, changes],
+    () => sortGridRows(filteredRows, renderedColumns, activeSort, changes),
+    [filteredRows, renderedColumns, activeSort, changes],
   );
 
   const minTableWidth = useMemo(
-    () => columns.reduce((acc, c) => acc + c.width, ROWNO_WIDTH + 8),
-    [columns],
+    () => renderedColumns.reduce((acc, c) => acc + c.width, ROWNO_WIDTH + 8),
+    [renderedColumns],
   );
+
+  const updateColumnLayout = useCallback(
+    (next: GridColumnLayout) => {
+      const pruned = pruneColumnLayout(columns, next);
+      if (columnLayout === undefined) setInternalColumnLayout(pruned);
+      onColumnLayoutChange?.(pruned);
+    },
+    [columnLayout, columns, onColumnLayoutChange],
+  );
+
+  useEffect(() => {
+    const pruned = pruneColumnLayout(columns, activeColumnLayout);
+    if (sameColumnLayout(pruned, activeColumnLayout)) return;
+    updateColumnLayout(pruned);
+  }, [activeColumnLayout, columns, updateColumnLayout]);
+
+  useEffect(() => {
+    resizingRef.current = resizing;
+  }, [resizing]);
+
+  useEffect(() => {
+    if (!isResizing) return;
+    const previousCursor = document.body.style.cursor;
+    const previousUserSelect = document.body.style.userSelect;
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+
+    const onPointerMove = (event: PointerEvent) => {
+      const active = resizingRef.current;
+      if (!active) return;
+
+      const nextWidth = Math.max(
+        MIN_COLUMN_WIDTH,
+        Math.round(active.startWidth + event.clientX - active.startX),
+      );
+      const nextState = { ...active, nextWidth };
+      resizingRef.current = nextState;
+      setResizing(nextState);
+      updateColumnLayout({
+        ...activeColumnLayout,
+        widths: {
+          ...activeColumnLayout.widths,
+          [active.columnKey]: nextWidth,
+        },
+      });
+    };
+
+    const onPointerUp = () => {
+      resizingRef.current = null;
+      setResizing(null);
+    };
+
+    window.addEventListener("pointermove", onPointerMove);
+    window.addEventListener("pointerup", onPointerUp, { once: true });
+    window.addEventListener("pointercancel", onPointerUp, { once: true });
+    return () => {
+      window.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("pointerup", onPointerUp);
+      window.removeEventListener("pointercancel", onPointerUp);
+      document.body.style.cursor = previousCursor;
+      document.body.style.userSelect = previousUserSelect;
+    };
+  }, [activeColumnLayout, isResizing, updateColumnLayout]);
 
   const applySort = useCallback(
     (next: SortState) => {
@@ -155,10 +262,91 @@ export function DataGrid({
 
   const handleSort = useCallback(
     (columnKey: string) => {
+      if (suppressNextSortRef.current) {
+        suppressNextSortRef.current = false;
+        return;
+      }
       const next = cycleSortState(activeSort, columnKey);
       applySort(next);
     },
     [activeSort, applySort],
+  );
+
+  const beginColumnResize = useCallback(
+    (event: ReactPointerEvent<HTMLSpanElement>, column: GridColumn) => {
+      event.preventDefault();
+      event.stopPropagation();
+      suppressNextSortRef.current = true;
+      const next: ColumnResizeState = {
+        columnKey: column.key,
+        startX: event.clientX,
+        startWidth: column.width,
+        nextWidth: column.width,
+      };
+      resizingRef.current = next;
+      setResizing(next);
+    },
+    [],
+  );
+
+  const measureGridText = useCallback((text: string): number => {
+    if (typeof document === "undefined") return text.length * 8;
+    const canvas =
+      measureCanvasRef.current ??
+      (measureCanvasRef.current = document.createElement("canvas"));
+    const context = canvas.getContext("2d");
+    if (!context) return text.length * 8;
+    const rootStyle = getComputedStyle(document.documentElement);
+    const monoFont = rootStyle.getPropertyValue("--font-mono").trim() || "monospace";
+    context.font = `11px ${monoFont}`;
+    return context.measureText(text).width;
+  }, []);
+
+  const autofitColumn = useCallback(
+    (column: GridColumn) => {
+      const headerWidth =
+        measureGridText(column.name) +
+        measureGridText(column.type) +
+        HEADER_AUTOFIT_PADDING;
+      const valueWidth = visibleRows.reduce((maxWidth, row) => {
+        const change = changes[row.id]?.edits?.[column.key];
+        const value = change ? change.to : row[column.key];
+        const text = value === null || value === undefined ? "NULL" : String(value);
+        const adornmentWidth = column.fk ? 24 : column.enum ? 18 : 0;
+        return Math.max(
+          maxWidth,
+          measureGridText(text) + COLUMN_AUTOFIT_PADDING + adornmentWidth,
+        );
+      }, 0);
+      const nextWidth = Math.max(
+        MIN_COLUMN_WIDTH,
+        Math.ceil(Math.max(headerWidth, valueWidth)),
+      );
+      updateColumnLayout({
+        ...activeColumnLayout,
+        widths: {
+          ...activeColumnLayout.widths,
+          [column.key]: nextWidth,
+        },
+      });
+    },
+    [activeColumnLayout, changes, measureGridText, updateColumnLayout, visibleRows],
+  );
+
+  const reorderColumn = useCallback(
+    (sourceKey: string, targetKey: string) => {
+      if (sourceKey === targetKey) return;
+      const order = renderedColumns.map((column) => column.key);
+      const sourceIndex = order.indexOf(sourceKey);
+      const targetIndex = order.indexOf(targetKey);
+      if (sourceIndex === -1 || targetIndex === -1) return;
+      const nextOrder = [...order];
+      const [moved] = nextOrder.splice(sourceIndex, 1);
+      if (!moved) return;
+      nextOrder.splice(targetIndex, 0, moved);
+      updateColumnLayout({ ...activeColumnLayout, order: nextOrder });
+    },
+    [activeColumnLayout, renderedColumns, updateColumnLayout],
   );
 
   const handleCellEdit = useCallback(
@@ -191,7 +379,7 @@ export function DataGrid({
   return (
     <div className="grid-root mono">
       <FilterBar
-        columns={columns}
+        columns={renderedColumns}
         filters={filters}
         setFilters={onFiltersChange}
         totalRows={rows.length}
@@ -205,7 +393,7 @@ export function DataGrid({
             <div className="grid-cell grid-cell-rowno">
               <GridIcon.hash size={9} stroke="var(--fg-3)" />
             </div>
-            {columns.map((c, ci) => {
+            {renderedColumns.map((c, ci) => {
               const sorted = activeSort?.columnKey === c.key ? activeSort : null;
               const ariaSort =
                 sorted?.direction === "asc"
@@ -229,7 +417,9 @@ export function DataGrid({
                   className={
                     "grid-cell grid-header-cell" +
                     (ci < frozenCount ? " frozen" : "") +
-                    (sorted ? " is-sorted" : "")
+                    (sorted ? " is-sorted" : "") +
+                    (draggedColumnKey === c.key ? " is-dragging" : "") +
+                    (columnDropTargetKey === c.key ? " is-drop-target" : "")
                   }
                   role="columnheader"
                   aria-sort={ariaSort}
@@ -237,6 +427,37 @@ export function DataGrid({
                   tabIndex={0}
                   style={{ width: c.width, flexBasis: c.width }}
                   title={nextSortLabel}
+                  draggable={!isResizing}
+                  onDragStart={(event) => {
+                    event.dataTransfer.effectAllowed = "move";
+                    event.dataTransfer.setData("text/plain", c.key);
+                    setDraggedColumnKey(c.key);
+                    suppressNextSortRef.current = true;
+                  }}
+                  onDragOver={(event) => {
+                    if (!draggedColumnKey || draggedColumnKey === c.key) return;
+                    event.preventDefault();
+                    event.dataTransfer.dropEffect = "move";
+                    setColumnDropTargetKey(c.key);
+                  }}
+                  onDragLeave={() => {
+                    setColumnDropTargetKey((current) =>
+                      current === c.key ? null : current,
+                    );
+                  }}
+                  onDrop={(event) => {
+                    event.preventDefault();
+                    const sourceKey =
+                      event.dataTransfer.getData("text/plain") || draggedColumnKey;
+                    if (sourceKey) reorderColumn(sourceKey, c.key);
+                    setDraggedColumnKey(null);
+                    setColumnDropTargetKey(null);
+                    suppressNextSortRef.current = true;
+                  }}
+                  onDragEnd={() => {
+                    setDraggedColumnKey(null);
+                    setColumnDropTargetKey(null);
+                  }}
                   onClick={() => handleSort(c.key)}
                   onKeyDown={(e) => {
                     if (e.key === "Enter" || e.key === " ") {
@@ -253,7 +474,30 @@ export function DataGrid({
                   <span className="grid-header-sort" aria-hidden="true">
                     <SortIcon size={10} />
                   </span>
-                  <span className="grid-col-resize" />
+                  <span
+                    className={
+                      "grid-col-resize" +
+                      (resizing?.columnKey === c.key ? " is-resizing" : "")
+                    }
+                    role="separator"
+                    aria-orientation="vertical"
+                    aria-label={`Resize ${c.name} column`}
+                    aria-valuemin={MIN_COLUMN_WIDTH}
+                    aria-valuenow={
+                      resizing?.columnKey === c.key ? resizing.nextWidth : c.width
+                    }
+                    tabIndex={-1}
+                    onPointerDown={(event) => beginColumnResize(event, c)}
+                    onDoubleClick={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      suppressNextSortRef.current = true;
+                      resizingRef.current = null;
+                      setResizing(null);
+                      autofitColumn(c);
+                    }}
+                    onClick={(event) => event.stopPropagation()}
+                  />
                 </div>
               );
             })}
@@ -298,7 +542,7 @@ export function DataGrid({
                     />
                   )}
                 </div>
-                {columns.map((c, ci) => {
+                {renderedColumns.map((c, ci) => {
                   const isSel =
                     selection?.row === ri && selection?.col === ci;
                   const isEdit =

--- a/packages/data-grid/src/columnLayout.ts
+++ b/packages/data-grid/src/columnLayout.ts
@@ -1,0 +1,49 @@
+import type { GridColumn, GridColumnLayout } from "./types";
+
+export const MIN_COLUMN_WIDTH = 56;
+
+export function emptyColumnLayout(): GridColumnLayout {
+  return { order: [], widths: {} };
+}
+
+export function layoutForColumns(
+  columns: readonly GridColumn[],
+  layout: GridColumnLayout,
+): GridColumn[] {
+  const byKey = new Map(columns.map((column) => [column.key, column]));
+  const orderedKeys = [
+    ...layout.order.filter((key) => byKey.has(key)),
+    ...columns
+      .map((column) => column.key)
+      .filter((key) => !layout.order.includes(key)),
+  ];
+  return orderedKeys.flatMap((key) => {
+    const column = byKey.get(key);
+    if (!column) return [];
+    return [{ ...column, width: layout.widths[key] ?? column.width }];
+  });
+}
+
+export function pruneColumnLayout(
+  columns: readonly GridColumn[],
+  layout: GridColumnLayout,
+): GridColumnLayout {
+  const keys = new Set(columns.map((column) => column.key));
+  return {
+    order: layout.order.filter((key) => keys.has(key)),
+    widths: Object.fromEntries(
+      Object.entries(layout.widths).filter(([key]) => keys.has(key)),
+    ),
+  };
+}
+
+export function sameColumnLayout(
+  left: GridColumnLayout,
+  right: GridColumnLayout,
+): boolean {
+  if (left.order.length !== right.order.length) return false;
+  if (left.order.some((key, index) => key !== right.order[index])) return false;
+  const leftWidths = Object.entries(left.widths);
+  if (leftWidths.length !== Object.keys(right.widths).length) return false;
+  return leftWidths.every(([key, width]) => right.widths[key] === width);
+}

--- a/packages/data-grid/src/index.ts
+++ b/packages/data-grid/src/index.ts
@@ -8,6 +8,7 @@ export type {
   FilterLogic,
   FilterOperator,
   GridColumn,
+  GridColumnLayout,
   GridRow,
   GridValue,
   GridPagination,

--- a/packages/data-grid/src/types.ts
+++ b/packages/data-grid/src/types.ts
@@ -21,6 +21,11 @@ export type GridColumn = {
   enum?: readonly string[];
 };
 
+export type GridColumnLayout = {
+  order: string[];
+  widths: Record<string, number>;
+};
+
 /** Row values are keyed by column key. Use `null` for SQL NULL. */
 export type GridRow = {
   id: string;


### PR DESCRIPTION
## Summary
- Add drag-based workspace tab reordering.
- Add database grid column reordering, persisted column widths, and double-click auto-fit on resize handles.
- Persist per-table column layouts in localStorage and restore them when reopening a table.

## Validation
- `pnpm --filter @cellar/data-grid test`
- `pnpm --filter @cellar/desktop test -- src/state/tabs.test.ts`
- `pnpm typecheck`
- `git merge-tree --write-tree main HEAD`