### PR TITLE
feat: persist workspace panel layout

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -15,8 +15,8 @@ import {
   SettingsModal,
   type SettingsCatId,
 } from "./components/modals/Settings";
+import { useLayout } from "./state/layout";
 
-type Panels = { left: boolean; right: boolean; bottom: boolean };
 type ModalId = "commit" | "palette" | "settings" | null;
 type ConnDialog = { mode: "new" | "edit"; initial?: ConnectionConfig } | null;
 
@@ -88,24 +88,19 @@ function ResizeHandle({
 }
 
 export function App() {
-  const [panels, setPanels] = useState<Panels>({
-    left: true,
-    right: true,
-    bottom: true,
-  });
-  const [leftWidth, setLeftWidth] = useState(256);
-  const [rightWidth, setRightWidth] = useState(380);
-  const [bottomHeight, setBottomHeight] = useState(280);
+  const panels = useLayout((s) => s.panels);
+  const togglePanel = useLayout((s) => s.togglePanel);
+  const leftWidth = useLayout((s) => s.leftWidth);
+  const setLeftWidth = useLayout((s) => s.setLeftWidth);
+  const rightWidth = useLayout((s) => s.rightWidth);
+  const setRightWidth = useLayout((s) => s.setRightWidth);
+  const bottomHeight = useLayout((s) => s.bottomHeight);
+  const setBottomHeight = useLayout((s) => s.setBottomHeight);
   const [modal, setModal] = useState<ModalId>(null);
   const [connDialog, setConnDialog] = useState<ConnDialog>(null);
   const [empty, setEmpty] = useState(false);
   const [settingsInitialCat, setSettingsInitialCat] =
     useState<SettingsCatId>("appearance");
-
-  const togglePanel = useCallback(
-    (k: keyof Panels) => setPanels((p) => ({ ...p, [k]: !p[k] })),
-    [],
-  );
 
   const openModal = useCallback((m: ModalId) => setModal(m), []);
   const closeModal = useCallback(() => setModal(null), []);

--- a/apps/desktop/src/components/TitleBar.tsx
+++ b/apps/desktop/src/components/TitleBar.tsx
@@ -3,8 +3,7 @@ import { Icon } from "./icons";
 import { useTabs } from "../state/tabs";
 import { useConnections } from "../state/connections";
 import { ENGINE_META } from "./EngineBadge";
-
-type Panels = { left: boolean; right: boolean; bottom: boolean };
+import type { PanelId, Panels } from "../state/layout";
 
 // WKWebView ignores Electron's `-webkit-app-region`, so window dragging and
 // double-click-to-maximize are driven manually. The catch: calling
@@ -36,7 +35,7 @@ export function TitleBar({
   onOpenSettings,
 }: {
   panels: Panels;
-  onTogglePanel: (k: keyof Panels) => void;
+  onTogglePanel: (k: PanelId) => void;
   empty?: boolean;
   onToggleEmpty?: () => void;
   onOpenPalette?: () => void;

--- a/apps/desktop/src/components/modals/CommandPalette.tsx
+++ b/apps/desktop/src/components/modals/CommandPalette.tsx
@@ -3,10 +3,10 @@ import { useEffect, useMemo, useState, type ReactNode } from "react";
 
 import { useBottomPanel, type BottomTabId } from "../../state/bottomPanel";
 import { useConnections } from "../../state/connections";
+import type { PanelId, Panels } from "../../state/layout";
 import { useTabs, type WorkspaceTab } from "../../state/tabs";
 import { Icon } from "../icons";
 
-type Panels = { left: boolean; right: boolean; bottom: boolean };
 type Group = "Actions" | "Tabs" | "Connections" | "Catalog" | "Columns" | "View";
 
 type Entry = {
@@ -25,7 +25,7 @@ type CommandPaletteProps = {
   onNewConnection: () => void;
   onOpenCommit: () => void;
   onOpenSettings: () => void;
-  onTogglePanel: (k: keyof Panels) => void;
+  onTogglePanel: (k: PanelId) => void;
 };
 
 const GROUP_ORDER: Group[] = [
@@ -215,7 +215,10 @@ export function CommandPalette({
         grp: "View",
         label: `Show ${titleCase(id)}`,
         hint: bottomTab === id ? "active" : "output panel",
-        action: () => setBottomTab(id),
+        action: () => {
+          setBottomTab(id);
+          if (!panels.bottom) onTogglePanel("bottom");
+        },
       });
     }
 

--- a/apps/desktop/src/state/bottomPanel.ts
+++ b/apps/desktop/src/state/bottomPanel.ts
@@ -1,4 +1,6 @@
 import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+import { deferredLocalStorage } from "./deferredStorage";
 
 export type BottomTabId =
   | "results"
@@ -21,10 +23,19 @@ interface BottomPanelStore {
  * the Results tab when a query runs and to drive the Plan tab's "Explain plan"
  * toolbar action without lifting the panel's whole tab state into App.
  */
-export const useBottomPanel = create<BottomPanelStore>((set) => ({
-  active: "results",
-  explainNonce: 0,
-  setActive: (active) => set({ active }),
-  requestExplain: () =>
-    set((s) => ({ active: "plan", explainNonce: s.explainNonce + 1 })),
-}));
+export const useBottomPanel = create<BottomPanelStore>()(
+  persist(
+    (set) => ({
+      active: "results",
+      explainNonce: 0,
+      setActive: (active) => set({ active }),
+      requestExplain: () =>
+        set((s) => ({ active: "plan", explainNonce: s.explainNonce + 1 })),
+    }),
+    {
+      name: "cellar.bottomPanel.v1",
+      storage: createJSONStorage(deferredLocalStorage),
+      partialize: (s) => ({ active: s.active }),
+    },
+  ),
+);

--- a/apps/desktop/src/state/deferredStorage.ts
+++ b/apps/desktop/src/state/deferredStorage.ts
@@ -1,0 +1,43 @@
+import type { StateStorage } from "zustand/middleware";
+
+const WRITE_DELAY_MS = 50;
+
+/**
+ * Synchronous reads keep persisted stores available during app startup, while
+ * deferred writes avoid blocking UI paint in the click handler that changed
+ * the store.
+ */
+export function deferredLocalStorage(): StateStorage {
+  const pending = new Map<string, string>();
+  let timer: number | null = null;
+
+  const flush = () => {
+    if (timer != null) {
+      window.clearTimeout(timer);
+      timer = null;
+    }
+    for (const [name, value] of pending) {
+      window.localStorage.setItem(name, value);
+    }
+    pending.clear();
+  };
+
+  const schedule = () => {
+    if (timer != null) return;
+    timer = window.setTimeout(flush, WRITE_DELAY_MS);
+  };
+
+  window.addEventListener("beforeunload", flush);
+
+  return {
+    getItem: (name) => window.localStorage.getItem(name),
+    setItem: (name, value) => {
+      pending.set(name, value);
+      schedule();
+    },
+    removeItem: (name) => {
+      pending.delete(name);
+      window.localStorage.removeItem(name);
+    },
+  };
+}

--- a/apps/desktop/src/state/layout.ts
+++ b/apps/desktop/src/state/layout.ts
@@ -1,0 +1,52 @@
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+import { deferredLocalStorage } from "./deferredStorage";
+
+export type Panels = { left: boolean; right: boolean; bottom: boolean };
+export type PanelId = keyof Panels;
+
+type LayoutStore = {
+  panels: Panels;
+  leftWidth: number;
+  rightWidth: number;
+  bottomHeight: number;
+  togglePanel: (id: PanelId) => void;
+  setPanel: (id: PanelId, open: boolean) => void;
+  setLeftWidth: (width: number) => void;
+  setRightWidth: (width: number) => void;
+  setBottomHeight: (height: number) => void;
+};
+
+export const DEFAULT_PANELS: Panels = {
+  left: true,
+  right: false,
+  bottom: false,
+};
+
+export const useLayout = create<LayoutStore>()(
+  persist(
+    (set) => ({
+      panels: DEFAULT_PANELS,
+      leftWidth: 256,
+      rightWidth: 380,
+      bottomHeight: 280,
+      togglePanel: (id) =>
+        set((s) => ({ panels: { ...s.panels, [id]: !s.panels[id] } })),
+      setPanel: (id, open) =>
+        set((s) => ({ panels: { ...s.panels, [id]: open } })),
+      setLeftWidth: (leftWidth) => set({ leftWidth }),
+      setRightWidth: (rightWidth) => set({ rightWidth }),
+      setBottomHeight: (bottomHeight) => set({ bottomHeight }),
+    }),
+    {
+      name: "cellar.layout.v1",
+      storage: createJSONStorage(deferredLocalStorage),
+      partialize: (s) => ({
+        panels: s.panels,
+        leftWidth: s.leftWidth,
+        rightWidth: s.rightWidth,
+        bottomHeight: s.bottomHeight,
+      }),
+    },
+  ),
+);


### PR DESCRIPTION
## Summary

- hide the bottom output panel and right AI panel by default for first-time launches
- persist workspace panel visibility, panel sizes, and the selected bottom panel tab
- defer persisted layout writes until after the click event yields, so slow desktop storage cannot delay panel paint
- make command-palette bottom-tab actions reopen the panel when hidden

## Validation

- `pnpm --filter @cellar/desktop typecheck`
- Playwright sanity check: panel becomes visible immediately and persisted storage updates after the deferred flush

## Merge Readiness

- fetched latest `origin/main`
- updated local `main` to `origin/main`
- checked `codex/persist-panel-layout` against latest `main` with `git merge-tree --write-tree HEAD main`; no conflicts reported
