### PR TITLE
docs: clarify Cellar site positioning

### DIFF
--- a/apps/desktop/src/components/modals/EmptyState.tsx
+++ b/apps/desktop/src/components/modals/EmptyState.tsx
@@ -57,7 +57,7 @@ export function EmptyState({ onNew }: { onNew: () => void }) {
           className="m-0 mb-[22px] text-[12.5px] text-fg-2"
           style={{ textWrap: "pretty" }}
         >
-          A fast, native database client with AI built in. Open-source, BYO key.
+          Connect to Postgres, inspect schemas, run SQL, and browse table data.
         </p>
 
         <div className="mb-[22px] flex flex-col gap-1.5">

--- a/apps/site/index.html
+++ b/apps/site/index.html
@@ -3,14 +3,14 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Cellar — An open-source database client with first-class AI</title>
-  <meta name="description" content="Cellar is an open-source database client with first-class AI. DataGrip density, Linear feel, bring-your-own key. Download for macOS." />
+  <title>Cellar — Open-source desktop database client</title>
+  <meta name="description" content="Cellar is a desktop database client for PostgreSQL, SQL Server, Azure SQL, and Firestore, with MySQL and SQLite coming soon. Browse schemas, run SQL, and review changes before committing." />
 
   <link rel="icon" type="image/png" sizes="128x128" href="/assets/favicon-128.png" />
   <link rel="icon" type="image/svg+xml" href="/assets/cellar-mark.svg" />
 
   <meta property="og:title" content="Cellar" />
-  <meta property="og:description" content="An open-source database client with first-class AI. DataGrip density, Linear feel, bring-your-own key." />
+  <meta property="og:description" content="Cellar is a desktop database client for PostgreSQL, SQL Server, Azure SQL, and Firestore, with MySQL and SQLite coming soon." />
   <meta property="og:type" content="website" />
   <meta property="og:image" content="/assets/main.png" />
   <meta name="twitter:card" content="summary_large_image" />
@@ -67,10 +67,10 @@
 <header class="hero" id="download">
   <div class="hero-grid" aria-hidden="true"></div>
   <div class="wrap hero-inner">
-    <span class="eyebrow"><span class="tick"></span>Open source · MIT · early access</span>
-    <h1>The database client that <span class="accent">thinks in SQL</span>.</h1>
+    <span class="eyebrow"><span class="tick"></span>Open-source desktop database client</span>
+    <h1>Cellar is a desktop <span class="accent">database client</span>.</h1>
     <p class="lede">
-      Cellar pairs DataGrip-grade density with first-class, bring-your-own-key AI, so you can query, edit, and understand any database at the speed of thought. Native, keyboard-driven, and yours to inspect.
+      Use it to connect to PostgreSQL, SQL Server, Azure SQL, and Firestore; browse schemas and table data; run SQL; inspect execution plans; and review edits before they are committed. MySQL, SQLite, and AI assistance are coming soon.
     </p>
     <div class="cta-row">
       <div class="download-picker">
@@ -117,7 +117,7 @@
     </div>
 
     <div class="trust">
-      <div class="lbl">Connects to every engine you run</div>
+      <div class="lbl">Supported today, with more engines coming soon</div>
       <div class="trust-row" id="engRow"></div>
     </div>
   </div>
@@ -129,13 +129,13 @@
     <div class="section-head center">
       <span class="eyebrow"><span class="tick"></span>Why Cellar</span>
       <h2>A modern client, without the bloat.</h2>
-      <p>Three things most database tools get wrong, and how Cellar gets them right.</p>
+      <p>A focused workspace for the loop database users repeat all day: connect, query, inspect, edit, review.</p>
     </div>
     <div class="feat-grid">
       <article class="feat">
         <div class="ic" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l2 5 5 2-5 2-2 5-2-5-5-2 5-2 2-5z"/></svg></div>
-        <h3>First-class AI, your key</h3>
-        <p>Generate, explain, optimize, and migrate SQL inline, with full schema context. Bring your own Anthropic or OpenAI key. Nothing routes through us.</p>
+        <h3>SQL-aware assistance, coming soon</h3>
+        <p>AI work is coming soon, built around inspectable SQL, explicit schema context, and bring-your-own provider keys. Nothing should route through a hosted Cellar service.</p>
       </article>
       <article class="feat">
         <div class="ic" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M3 9h18M3 14h18M9 4v16"/></svg></div>
@@ -144,8 +144,8 @@
       </article>
       <article class="feat">
         <div class="ic" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="8" ry="3"/><path d="M4 5v6c0 1.66 3.58 3 8 3s8-1.34 8-3V5M4 11v6c0 1.66 3.58 3 8 3s8-1.34 8-3v-6"/></svg></div>
-        <h3>Every engine, one app</h3>
-        <p>Postgres, MySQL, SQL Server, Azure SQL, and SQLite, each with engine-aware fields, SSH tunneling, and SSL. One muscle memory across all of them.</p>
+        <h3>Postgres, SQL Server, Azure SQL, and Firestore</h3>
+        <p>Those engines are supported today. MySQL and SQLite are coming soon, shaped behind the same connection and query workflow.</p>
       </article>
     </div>
   </div>
@@ -157,17 +157,17 @@
 
     <div class="split">
       <div class="split-copy">
-        <span class="eyebrow"><span class="tick"></span>AI Assistant</span>
-        <h3>Ask in English. Ship real SQL.</h3>
-        <p>Pin tables, queries, and selections as context, then ask. Cellar drafts SQL you can read, run, and insert. Never a black box. Every answer cites the columns and joins it reasoned about.</p>
+        <span class="eyebrow"><span class="tick"></span>AI assistance · coming soon</span>
+        <h3>Ask in English. Review the SQL.</h3>
+        <p>Cellar’s coming-soon AI work is being built around visible schema context, BYO provider keys, and generated SQL you can inspect before it runs. The goal is assistance inside the database workflow, not a black box beside it.</p>
         <ul class="mini-list">
-          <li><span class="ck" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg></span>Generate, explain, optimize, and migrate from one bar</li>
-          <li><span class="ck" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg></span>Read-only mode and a hard spend cap, always on</li>
-          <li><span class="ck" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg></span>Inline ghost-text completions as you type</li>
+          <li><span class="ck" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg></span>Coming soon: schema-aware generation and explanation</li>
+          <li><span class="ck" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg></span>Coming soon: review gates before generated SQL runs</li>
+          <li><span class="ck" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg></span>Coming soon: provider keys used directly from your machine</li>
         </ul>
       </div>
       <div class="window">
-        <img src="/assets/main.png" alt="AI Assistant drafting SQL with pinned schema context" width="924" height="540" loading="lazy" decoding="async" data-theme-swap />
+        <img src="/assets/main.png" alt="Planned AI assistant drafting SQL with pinned schema context" width="924" height="540" loading="lazy" decoding="async" data-theme-swap />
       </div>
     </div>
 
@@ -197,13 +197,13 @@
       <div class="split-copy">
         <span class="eyebrow"><span class="tick"></span>Built for the keyboard</span>
         <h3>Your hands never leave home row.</h3>
-        <p>Everything is one fuzzy <span class="kbd">⌘</span> <span class="kbd">K</span> away: tables, columns, commands, even AI prompts. Rebind anything; ship with Cellar, VS Code, or DataGrip keymaps out of the box.</p>
+        <p>Everything is one fuzzy <span class="kbd">⌘</span> <span class="kbd">K</span> away: tables, columns, commands, and workspace actions. Rebind anything; ship with Cellar, VS Code, or DataGrip keymaps out of the box.</p>
         <div class="kb-grid">
           <div class="kb-row"><span class="lab">Command palette</span><span class="keys"><span class="kbd">⌘</span><span class="kbd">K</span></span></div>
           <div class="kb-row"><span class="lab">Run statement</span><span class="keys"><span class="kbd">⌘</span><span class="kbd">↵</span></span></div>
           <div class="kb-row"><span class="lab">Commit changes</span><span class="keys"><span class="kbd">⌘</span><span class="kbd">S</span></span></div>
           <div class="kb-row"><span class="lab">Revert staged</span><span class="keys"><span class="kbd">⌘</span><span class="kbd">Z</span></span></div>
-          <div class="kb-row"><span class="lab">Ask AI on selection</span><span class="keys"><span class="kbd">⌘</span><span class="kbd">L</span></span></div>
+          <div class="kb-row"><span class="lab">Focus editor</span><span class="keys"><span class="kbd">⌘</span><span class="kbd">L</span></span></div>
           <div class="kb-row"><span class="lab">Switch connection</span><span class="keys"><span class="kbd">⌘</span><span class="kbd">K</span><span class="kbd">C</span></span></div>
         </div>
       </div>
@@ -219,8 +219,8 @@
   <div class="wrap">
     <div class="section-head center">
       <span class="eyebrow"><span class="tick"></span>Supported engines</span>
-      <h2>One client. All your databases.</h2>
-      <p>Engine-aware down to the field. Add the next one without learning a new tool.</p>
+      <h2>One client shape for every database.</h2>
+      <p>PostgreSQL, SQL Server, Azure SQL, and Firestore are supported today. MySQL and SQLite are coming soon.</p>
     </div>
     <div class="trust-row" id="engRow2" style="margin-top:48px;"></div>
   </div>
@@ -238,11 +238,11 @@
       <ul class="priv-list">
         <li>
           <span class="ic" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="10" width="16" height="11" rx="2"/><path d="M8 10V7a4 4 0 0 1 8 0v3"/></svg></span>
-          <span><b>BYO key.</b> Your AI key is stored in the OS keychain and used directly. We never see a token or a prompt.</span>
+          <span><b>BYO key, coming soon.</b> AI provider keys are designed to be stored in the OS keychain and used directly. Cellar must not proxy your prompts through a hosted service.</span>
         </li>
         <li>
           <span class="ic" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2l8 4v6c0 5-3.5 8-8 10-4.5-2-8-5-8-10V6l8-4z"/></svg></span>
-          <span><b>Redaction.</b> Mask column values before they’re ever sent as AI context.</span>
+          <span><b>Inspectable context, coming soon.</b> AI context should be visible and controllable before it leaves your machine.</span>
         </li>
         <li>
           <span class="ic" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6L6 18M6 6l12 12"/></svg></span>
@@ -290,8 +290,8 @@
 <section class="final">
   <div class="wrap hero-inner">
     <img class="mark" src="/assets/cellar-mark.svg" width="56" height="56" alt="" />
-    <h2>Stop fighting your database client.</h2>
-    <p class="lede">Free, open source, and ready in a tiny signed download.</p>
+    <h2>Browse schemas, run SQL, review changes.</h2>
+    <p class="lede">Free, open source, and ready in a signed macOS download.</p>
     <div class="cta-row">
       <div class="download-picker">
         <button
@@ -331,7 +331,7 @@
     <div class="foot-grid">
       <div class="foot-brand">
         <a class="brand" href="#top"><img src="/assets/cellar-mark.svg" width="24" height="24" alt="" /> Cellar</a>
-        <p>An open-source database client with first-class AI. DataGrip density, Linear feel, bring-your-own key.</p>
+        <p>Cellar is a desktop database client for PostgreSQL, SQL Server, Azure SQL, and Firestore, with MySQL and SQLite coming soon.</p>
       </div>
       <div class="foot-col">
         <h4>Product</h4>

--- a/apps/site/src/main.ts
+++ b/apps/site/src/main.ts
@@ -87,14 +87,15 @@ initImageSwap();
 
 /* ───────────── engine chips ───────────── */
 
-type Engine = { name: string; color: string };
+type Engine = { name: string; color: string; status: "supported" | "soon" };
 
 const engines: ReadonlyArray<Engine> = [
-  { name: "PostgreSQL", color: "var(--eng-postgres)" },
-  { name: "MySQL", color: "var(--eng-mysql)" },
-  { name: "SQL Server", color: "var(--eng-mssql)" },
-  { name: "Azure SQL", color: "var(--eng-azure)" },
-  { name: "SQLite", color: "var(--eng-sqlite)" },
+  { name: "PostgreSQL", color: "var(--eng-postgres)", status: "supported" },
+  { name: "SQL Server", color: "var(--eng-mssql)", status: "supported" },
+  { name: "Azure SQL", color: "var(--eng-azure)", status: "supported" },
+  { name: "Firestore", color: "var(--eng-firestore)", status: "supported" },
+  { name: "MySQL", color: "var(--eng-mysql)", status: "soon" },
+  { name: "SQLite", color: "var(--eng-sqlite)", status: "soon" },
 ];
 
 function renderEngineChips(el: HTMLElement | null) {
@@ -108,6 +109,12 @@ function renderEngineChips(el: HTMLElement | null) {
       dot.style.background = engine.color;
       chip.appendChild(dot);
       chip.append(engine.name);
+      if (engine.status === "soon") {
+        const status = document.createElement("span");
+        status.className = "eng-status soon";
+        status.textContent = "coming soon";
+        chip.appendChild(status);
+      }
       return chip;
     }),
   );
@@ -259,20 +266,24 @@ type Qa = readonly [question: string, answer: string];
 
 const qas: ReadonlyArray<Qa> = [
   [
+    "What is Cellar?",
+    "Cellar is a desktop database client for developers, DBAs, and analysts. Use it to connect to PostgreSQL, SQL Server, Azure SQL, and Firestore; browse schemas and table data; run SQL; inspect execution plans; and review edits before they are committed.",
+  ],
+  [
     "Is Cellar really free?",
-    "Yes. Cellar is free and open source under the MIT license. There is no paid tier, no account, and no usage limit. If you use the AI features, you pay your AI provider directly for tokens, and Cellar never marks that up.",
+    "Yes. Cellar is free and open source under the MIT license. There is no paid tier, no account, and no usage limit. AI provider support is coming soon, and will use your own provider key directly.",
   ],
   [
     "Do I need an AI key to use it?",
-    "No. Everything except the AI Assistant works with zero configuration. The AI features are optional and activate only when you add your own Anthropic or OpenAI key in Settings.",
+    "No. The core database workflow does not need AI. The AI features are coming soon and are being designed around bring-your-own provider keys.",
   ],
   [
     "Where do my credentials and AI key live?",
-    "In your operating system’s keychain, never in a plaintext config file and never synced to a server. Cellar is local-first: the only outbound connections are to your databases and, if enabled, your AI provider.",
+    "Database credentials live in your operating system’s keychain, never in a plaintext config file and never synced to a server. Cellar is local-first: the only required outbound connections are to your databases.",
   ],
   [
     "Which databases are supported?",
-    "PostgreSQL, MySQL, SQL Server, Azure SQL, and SQLite, each with engine-specific connection fields, SSH tunneling, and SSL/TLS. More engines are on the roadmap.",
+    "PostgreSQL, SQL Server, Azure SQL, and Firestore are supported today. MySQL and SQLite are coming soon.",
   ],
   [
     "What about Windows and Linux?",
@@ -280,7 +291,7 @@ const qas: ReadonlyArray<Qa> = [
   ],
   [
     "Can I trust the AI not to touch production?",
-    "Yes. Read-only mode and a hard spend cap are on by default, generated SQL is shown as a reviewable diff before it runs, and you can redact column values before they’re sent as context.",
+    "That is the design goal for the coming-soon AI work: generated SQL should be visible, gated, and reviewable before execution, with production connections clearly marked and easy to keep read-only.",
   ],
 ];
 

--- a/apps/site/src/styles.css
+++ b/apps/site/src/styles.css
@@ -36,6 +36,7 @@
   --eng-mssql: #d97a5a;
   --eng-azure: #5bb8e0;
   --eng-sqlite: #a78bfa;
+  --eng-firestore: #f4c542;
 
   --glow: radial-gradient(60% 60% at 50% 0%, rgba(167, 139, 250, 0.22), transparent 70%);
   --shadow-lg: 0 24px 80px rgba(0, 0, 0, 0.6), 0 2px 8px rgba(0, 0, 0, 0.45);
@@ -400,6 +401,14 @@ h1 .accent {
   color: var(--fg-1);
 }
 .eng-dot { width: 9px; height: 9px; border-radius: 3px; }
+.eng-status {
+  margin-left: 2px;
+  font-size: 10.5px;
+  color: var(--fg-3);
+}
+.eng-status.soon {
+  color: var(--fg-2);
+}
 
 /* ───────────── section scaffolding ───────────── */
 section { position: relative; }


### PR DESCRIPTION
## Summary
Clarifies the Cellar marketing site so first-time visitors immediately understand what the product is, which engines are supported today, and which features are coming soon.

## What changed
- Reworked the hero, metadata, footer, and FAQ copy around a plain definition of Cellar as a desktop database client.
- Updated supported-engine messaging to list PostgreSQL, SQL Server, Azure SQL, and Firestore as supported today, with MySQL and SQLite coming soon.
- Marked AI assistance as coming soon across the feature card, showcase, privacy copy, and FAQ.
- Added a "What is Cellar?" FAQ item and tightened the desktop welcome tagline.

## User impact
Visitors no longer have to infer the product from screenshots or AI-focused positioning. The page now states the product category, current engine support, and upcoming work directly.

## Validation
- pnpm --filter @cellar/site build
- pnpm typecheck
- git diff --check
- Reloaded http://localhost:5180 and verified the updated FAQ/hero content in the in-app browser.

## Notes
- Existing local autostash from the earlier main pull was left untouched.