### PR TITLE
docs: shorten Cellar site hero copy

### DIFF
--- a/apps/site/index.html
+++ b/apps/site/index.html
@@ -4,13 +4,13 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Cellar — Open-source desktop database client</title>
-  <meta name="description" content="Cellar is a desktop database client for PostgreSQL, SQL Server, Azure SQL, and Firestore, with MySQL and SQLite coming soon. Browse schemas, run SQL, and review changes before committing." />
+  <meta name="description" content="Cellar is a local-first desktop database client for browsing schemas, running SQL, and reviewing data changes. Supports PostgreSQL, SQL Server, Azure SQL, and Firestore." />
 
   <link rel="icon" type="image/png" sizes="128x128" href="/assets/favicon-128.png" />
   <link rel="icon" type="image/svg+xml" href="/assets/cellar-mark.svg" />
 
   <meta property="og:title" content="Cellar" />
-  <meta property="og:description" content="Cellar is a desktop database client for PostgreSQL, SQL Server, Azure SQL, and Firestore, with MySQL and SQLite coming soon." />
+  <meta property="og:description" content="Cellar is a local-first desktop database client for browsing schemas, running SQL, and reviewing data changes." />
   <meta property="og:type" content="website" />
   <meta property="og:image" content="/assets/main.png" />
   <meta name="twitter:card" content="summary_large_image" />
@@ -68,9 +68,9 @@
   <div class="hero-grid" aria-hidden="true"></div>
   <div class="wrap hero-inner">
     <span class="eyebrow"><span class="tick"></span>Open-source desktop database client</span>
-    <h1>Cellar is a desktop <span class="accent">database client</span>.</h1>
+    <h1>Cellar is the database client for <span class="accent">fast SQL work</span>.</h1>
     <p class="lede">
-      Use it to connect to PostgreSQL, SQL Server, Azure SQL, and Firestore; browse schemas and table data; run SQL; inspect execution plans; and review edits before they are committed. MySQL, SQLite, and AI assistance are coming soon.
+      Browse schemas, run queries, and review data changes in a local-first desktop app.
     </p>
     <div class="cta-row">
       <div class="download-picker">
@@ -331,7 +331,7 @@
     <div class="foot-grid">
       <div class="foot-brand">
         <a class="brand" href="#top"><img src="/assets/cellar-mark.svg" width="24" height="24" alt="" /> Cellar</a>
-        <p>Cellar is a desktop database client for PostgreSQL, SQL Server, Azure SQL, and Firestore, with MySQL and SQLite coming soon.</p>
+        <p>Cellar is a local-first desktop database client for browsing schemas, running SQL, and reviewing data changes.</p>
       </div>
       <div class="foot-col">
         <h4>Product</h4>

--- a/apps/site/src/main.ts
+++ b/apps/site/src/main.ts
@@ -267,7 +267,7 @@ type Qa = readonly [question: string, answer: string];
 const qas: ReadonlyArray<Qa> = [
   [
     "What is Cellar?",
-    "Cellar is a desktop database client for developers, DBAs, and analysts. Use it to connect to PostgreSQL, SQL Server, Azure SQL, and Firestore; browse schemas and table data; run SQL; inspect execution plans; and review edits before they are committed.",
+    "Cellar is a desktop database client for developers, DBAs, and analysts. It helps you browse schemas, run SQL, inspect execution plans, and review data changes before committing.",
   ],
   [
     "Is Cellar really free?",


### PR DESCRIPTION
## Summary
Shortens the Cellar site hero and related explanatory copy based on feedback that the previous version was clear but too long.

## What changed
- Replaced the long hero explanation with a concise headline and one-sentence lede.
- Moved engine/support detail out of the hero, keeping it in the supported engines section and FAQ.
- Tightened meta, footer, and "What is Cellar?" FAQ copy to match the shorter positioning.

## User impact
First-time visitors still learn what Cellar is immediately, but the first viewport reads less wordy and closer to the Cursor/Slack examples shared in feedback.

## Validation
- pnpm --filter @cellar/site build
- pnpm typecheck
- git diff --check