### PR TITLE
feat: track Cellar download counts via GitHub releases

### DIFF
--- a/apps/site/index.html
+++ b/apps/site/index.html
@@ -108,6 +108,8 @@
       <span><b data-release-size>GitHub Releases</b></span>
       <span class="sep">·</span>
       <span>Intel build also available</span>
+      <span class="sep" data-download-count-sep hidden>·</span>
+      <span data-download-count hidden></span>
     </div>
 
     <div class="shot-wrap">
@@ -321,6 +323,8 @@
       <span>Apple Silicon or Intel · macOS 13+</span>
       <span class="sep">·</span>
       <span>Other platforms coming soon</span>
+      <span class="sep" data-download-count-sep hidden>·</span>
+      <span data-download-count hidden></span>
     </div>
   </div>
 </section>

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -8,6 +8,7 @@
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
+    "downloads:stats": "node scripts/download-stats.mjs",
     "lint": "tsc --noEmit",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests"

--- a/apps/site/scripts/download-stats.mjs
+++ b/apps/site/scripts/download-stats.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * Report Cellar download counts straight from the GitHub Releases API.
+ *
+ * GitHub counts every download of a release asset for free, so this needs no
+ * tracking on the site itself. Run it anytime:
+ *
+ *   pnpm --filter @cellar/site downloads:stats        # human-readable table
+ *   pnpm --filter @cellar/site downloads:stats --json # machine-readable JSON
+ *
+ * Set GITHUB_TOKEN to raise the API rate limit (60→5000/hr) and include drafts.
+ */
+
+const REPO = process.env.CELLAR_REPO ?? "MRL-00/cellar";
+const API = `https://api.github.com/repos/${REPO}/releases?per_page=100`;
+const asJson = process.argv.includes("--json");
+
+/** Installer asset filename → counts as a real download (skips checksums/sigs). */
+function isInstaller(name) {
+  return /\.(dmg|pkg|exe|msi|appimage|deb|rpm)$/i.test(name);
+}
+
+function formatBytes(bytes) {
+  const mb = bytes / 1024 / 1024;
+  return `${mb.toFixed(mb >= 10 ? 0 : 1)} MB`;
+}
+
+function downloadsLabel(count) {
+  return `${count.toLocaleString("en-US")} download${count === 1 ? "" : "s"}`;
+}
+
+async function fetchReleases() {
+  const headers = { Accept: "application/vnd.github+json" };
+  if (process.env.GITHUB_TOKEN) headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+
+  const res = await fetch(API, { headers });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`GitHub API ${res.status} ${res.statusText}\n${body}`);
+  }
+  return res.json();
+}
+
+function summarize(releases) {
+  const perRelease = releases.map((release) => {
+    const assets = release.assets
+      .filter((asset) => isInstaller(asset.name))
+      .map((asset) => ({ name: asset.name, downloads: asset.download_count ?? 0, size: asset.size }));
+    const downloads = assets.reduce((sum, asset) => sum + asset.downloads, 0);
+    return {
+      tag: release.tag_name,
+      name: release.name,
+      published_at: release.published_at,
+      prerelease: release.prerelease,
+      downloads,
+      assets,
+    };
+  });
+  const total = perRelease.reduce((sum, release) => sum + release.downloads, 0);
+  return { repo: REPO, total, releases: perRelease };
+}
+
+function printReport({ repo, total, releases }) {
+  if (releases.length === 0) {
+    console.log(`No releases published yet for ${repo}.`);
+    console.log("Download counts will start accruing once a release with installer assets is published.");
+    return;
+  }
+
+  console.log(`\nCellar downloads — ${repo}\n`);
+  for (const release of releases) {
+    const tag = release.prerelease ? `${release.tag} (prerelease)` : release.tag;
+    const when = release.published_at ? release.published_at.slice(0, 10) : "unpublished";
+    console.log(`${tag}  ·  ${when}  ·  ${downloadsLabel(release.downloads)}`);
+    for (const asset of release.assets) {
+      const downloads = String(asset.downloads).padStart(7);
+      console.log(`   ${downloads}  ${asset.name}  (${formatBytes(asset.size)})`);
+    }
+    if (release.assets.length === 0) console.log("   (no installer assets)");
+    console.log("");
+  }
+  console.log(`TOTAL: ${downloadsLabel(total)} across ${releases.length} release(s)\n`);
+}
+
+try {
+  const summary = summarize(await fetchReleases());
+  if (asJson) {
+    console.log(JSON.stringify(summary, null, 2));
+  } else {
+    printReport(summary);
+  }
+} catch (error) {
+  console.error(`Failed to fetch download stats: ${error.message}`);
+  process.exit(1);
+}

--- a/apps/site/src/main.ts
+++ b/apps/site/src/main.ts
@@ -183,6 +183,12 @@ document.addEventListener("keydown", (event) => {
 const GITHUB_RELEASES_URL = "https://github.com/MRL-00/cellar/releases";
 const GITHUB_RELEASE_API = "https://api.github.com/repos/MRL-00/cellar/releases";
 
+/* Installer asset filename → counts as a "download". Excludes checksum and
+   signature sidecar files that ship alongside the real installers. */
+function isInstaller(name: string): boolean {
+  return /\.(dmg|pkg|exe|msi|appimage|deb|rpm)$/i.test(name);
+}
+
 const downloads = {
   "macos-arm64": {
     assetNames: ["Cellar-mac-arm64.dmg"],
@@ -204,6 +210,7 @@ type ReleaseAsset = {
   name: string;
   size: number;
   browser_download_url: string;
+  download_count: number;
 };
 
 type GitHubRelease = {
@@ -243,6 +250,19 @@ function findDownloadAsset(releases: GitHubRelease[], key: DownloadKey) {
   return null;
 }
 
+/* Reveal the live download counter. Hidden by default so the site shows
+   nothing (rather than a bare "0") until real downloads have accrued. */
+function setDownloadCount(total: number) {
+  const text = `${total.toLocaleString("en-US")} download${total === 1 ? "" : "s"}`;
+  for (const el of document.querySelectorAll<HTMLElement>("[data-download-count]")) {
+    el.textContent = text;
+    el.hidden = false;
+  }
+  for (const sep of document.querySelectorAll<HTMLElement>("[data-download-count-sep]")) {
+    sep.hidden = false;
+  }
+}
+
 async function initDownloadLink() {
   for (const [key, download] of Object.entries(downloads) as [DownloadKey, (typeof downloads)[DownloadKey]][]) {
     setDownloadLink(key, download.fallbackUrl, `View Cellar releases for ${download.label}`);
@@ -255,6 +275,22 @@ async function initDownloadLink() {
     if (!res.ok) return;
 
     const releases = (await res.json()) as GitHubRelease[];
+    if (!Array.isArray(releases)) return;
+
+    /* Total downloads across every published release, so the counter
+       reflects the full history rather than just the current build. */
+    const totalDownloads = releases.reduce(
+      (sum, release) =>
+        release.draft
+          ? sum
+          : sum +
+            release.assets
+              .filter((asset) => isInstaller(asset.name))
+              .reduce((assetSum, asset) => assetSum + (asset.download_count ?? 0), 0),
+      0,
+    );
+    if (totalDownloads > 0) setDownloadCount(totalDownloads);
+
     const availableSizes: number[] = [];
 
     for (const [key, download] of Object.entries(downloads) as [DownloadKey, (typeof downloads)[DownloadKey]][]) {


### PR DESCRIPTION
## Summary

Adds a way to track and see how many times Cellar has been downloaded, using GitHub's built-in per-asset `download_count` — no third-party analytics, cookies, or tracking scripts, keeping the site's "telemetry off" positioning intact.

Rebased on top of #48 (`fix: repair site release downloads`); the counter is layered onto that PR's asset-pattern matching and draft-skipping.

## What changed

- **Live downloads counter on the site** (`apps/site/src/main.ts`, `apps/site/index.html`): the existing release fetch now reads `download_count` and sums downloads across all non-draft releases, rendering e.g. `1 download` / `1,234 downloads` in the meta row under both download buttons. It stays hidden until a real count exists (no bare "0"), and pluralizes correctly.
- **Stats script** (`apps/site/scripts/download-stats.mjs`, wired as `downloads:stats`): on-demand per-release / per-asset / total breakdown. Supports `--json` and `GITHUB_TOKEN`.
  - `pnpm --filter @cellar/site downloads:stats`
  - `pnpm --filter @cellar/site downloads:stats --json`

## User impact

- A public "X downloads" number appears on the site, updating automatically as downloads accrue.
- Maintainers can pull exact download stats anytime via the script.

## Validation

- `pnpm --filter @cellar/site build` (includes `tsc --noEmit`) passes after the rebase.
- Verified end-to-end against the **live** API now that the `0.1.0` prerelease is published: the script reports `Cellar_0.1.0_aarch64.dmg` at 1 download, and the site's hero/footer meta rows render `1 download` in-browser. Empty-release and no-match paths also confirmed to keep the counter hidden.

## Follow-ups

- The `--json` output is a clean building block if a scheduled report (GitHub Action → committed history / Discord) is wanted later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)