### PR TITLE
fix: repair site release downloads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,3 +171,32 @@ jobs:
           fi
 
           gh release upload "$RELEASE_TAG" "$dmg_path#$STABLE_ASSET_NAME" --clobber
+
+  publish-release:
+    name: Publish release
+    needs: build-tauri
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve release tag
+        id: release
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            release_tag="${{ inputs.version }}"
+          else
+            release_tag="${GITHUB_REF_NAME}"
+          fi
+
+          echo "tag=$release_tag" >> "$GITHUB_OUTPUT"
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          gh release edit "$RELEASE_TAG" --draft=false

--- a/apps/site/index.html
+++ b/apps/site/index.html
@@ -83,15 +83,15 @@
           data-download-trigger
         >
           <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M16.36 12.6c-.02-2.2 1.8-3.26 1.88-3.31-1.02-1.5-2.62-1.7-3.18-1.72-1.35-.14-2.64.8-3.32.8-.69 0-1.74-.78-2.86-.76-1.47.02-2.83.86-3.59 2.18-1.53 2.66-.39 6.6 1.1 8.76.73 1.06 1.6 2.25 2.74 2.2 1.1-.04 1.52-.71 2.85-.71 1.32 0 1.7.71 2.86.69 1.18-.02 1.93-1.08 2.65-2.14.84-1.23 1.18-2.42 1.2-2.48-.03-.01-2.3-.88-2.32-3.5zM14.19 5.8c.6-.74 1.01-1.76.9-2.78-.87.04-1.93.58-2.56 1.31-.56.65-1.05 1.69-.92 2.69.97.07 1.97-.49 2.58-1.22z"/></svg>
-          Download for Mac
+          <span data-download-label>View releases</span>
           <svg class="chevron" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M4 6l4 4 4-4"/></svg>
         </button>
         <div class="download-menu" role="menu" aria-label="Choose Mac download" hidden>
-          <a href="https://github.com/MRL-00/cellar/releases/latest/download/Cellar-mac-arm64.dmg" data-download="macos-arm64" role="menuitem" rel="noopener">
+          <a href="https://github.com/MRL-00/cellar/releases" data-download="macos-arm64" role="menuitem" rel="noopener">
             <span>Apple Silicon</span>
             <b>Mac with M1, M2, M3, or newer</b>
           </a>
-          <a href="https://github.com/MRL-00/cellar/releases/latest/download/Cellar-mac-x64.dmg" data-download="macos-x64" role="menuitem" rel="noopener">
+          <a href="https://github.com/MRL-00/cellar/releases" data-download="macos-x64" role="menuitem" rel="noopener">
             <span>Intel Mac</span>
             <b>Older Mac with Intel processor</b>
           </a>
@@ -105,7 +105,7 @@
     <div class="dl-meta">
       <span><b>macOS</b> · Apple Silicon or Intel</span>
       <span class="sep">·</span>
-      <span><b data-release-size>Latest DMG</b></span>
+      <span><b data-release-size>GitHub Releases</b></span>
       <span class="sep">·</span>
       <span>Intel build also available</span>
     </div>
@@ -291,7 +291,7 @@
   <div class="wrap hero-inner">
     <img class="mark" src="/assets/cellar-mark.svg" width="56" height="56" alt="" />
     <h2>Browse schemas, run SQL, review changes.</h2>
-    <p class="lede">Free, open source, and ready in a signed macOS download.</p>
+    <p class="lede">Free, open source, and distributed from GitHub Releases.</p>
     <div class="cta-row">
       <div class="download-picker">
         <button
@@ -302,15 +302,15 @@
           data-download-trigger
         >
           <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M16.36 12.6c-.02-2.2 1.8-3.26 1.88-3.31-1.02-1.5-2.62-1.7-3.18-1.72-1.35-.14-2.64.8-3.32.8-.69 0-1.74-.78-2.86-.76-1.47.02-2.83.86-3.59 2.18-1.53 2.66-.39 6.6 1.1 8.76.73 1.06 1.6 2.25 2.74 2.2 1.1-.04 1.52-.71 2.85-.71 1.32 0 1.7.71 2.86.69 1.18-.02 1.93-1.08 2.65-2.14.84-1.23 1.18-2.42 1.2-2.48-.03-.01-2.3-.88-2.32-3.5zM14.19 5.8c.6-.74 1.01-1.76.9-2.78-.87.04-1.93.58-2.56 1.31-.56.65-1.05 1.69-.92 2.69.97.07 1.97-.49 2.58-1.22z"/></svg>
-          Download for Mac
+          <span data-download-label>View releases</span>
           <svg class="chevron" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M4 6l4 4 4-4"/></svg>
         </button>
         <div class="download-menu" role="menu" aria-label="Choose Mac download" hidden>
-          <a href="https://github.com/MRL-00/cellar/releases/latest/download/Cellar-mac-arm64.dmg" data-download="macos-arm64" role="menuitem" rel="noopener">
+          <a href="https://github.com/MRL-00/cellar/releases" data-download="macos-arm64" role="menuitem" rel="noopener">
             <span>Apple Silicon</span>
             <b>Mac with M1, M2, M3, or newer</b>
           </a>
-          <a href="https://github.com/MRL-00/cellar/releases/latest/download/Cellar-mac-x64.dmg" data-download="macos-x64" role="menuitem" rel="noopener">
+          <a href="https://github.com/MRL-00/cellar/releases" data-download="macos-x64" role="menuitem" rel="noopener">
             <span>Intel Mac</span>
             <b>Older Mac with Intel processor</b>
           </a>

--- a/apps/site/src/main.ts
+++ b/apps/site/src/main.ts
@@ -180,17 +180,20 @@ document.addEventListener("keydown", (event) => {
 
 /* ───────────── release download ───────────── */
 
-const GITHUB_RELEASE_API = "https://api.github.com/repos/MRL-00/cellar/releases/latest";
+const GITHUB_RELEASES_URL = "https://github.com/MRL-00/cellar/releases";
+const GITHUB_RELEASE_API = "https://api.github.com/repos/MRL-00/cellar/releases";
 
 const downloads = {
   "macos-arm64": {
-    assetName: "Cellar-mac-arm64.dmg",
-    fallbackUrl: "https://github.com/MRL-00/cellar/releases/latest/download/Cellar-mac-arm64.dmg",
+    assetNames: ["Cellar-mac-arm64.dmg"],
+    assetPattern: /^Cellar_.+_aarch64\.dmg$/,
+    fallbackUrl: GITHUB_RELEASES_URL,
     label: "Apple Silicon Macs",
   },
   "macos-x64": {
-    assetName: "Cellar-mac-x64.dmg",
-    fallbackUrl: "https://github.com/MRL-00/cellar/releases/latest/download/Cellar-mac-x64.dmg",
+    assetNames: ["Cellar-mac-x64.dmg"],
+    assetPattern: /^Cellar_.+_x64\.dmg$/,
+    fallbackUrl: GITHUB_RELEASES_URL,
     label: "Intel Macs",
   },
 } as const;
@@ -205,6 +208,7 @@ type ReleaseAsset = {
 
 type GitHubRelease = {
   tag_name: string;
+  draft?: boolean;
   assets: ReleaseAsset[];
 };
 
@@ -222,9 +226,26 @@ function setDownloadLink(key: DownloadKey, url: string, label?: string) {
   }
 }
 
+function setDownloadButtonLabel(label: string) {
+  const labels = document.querySelectorAll<HTMLElement>("[data-download-label]");
+  for (const el of labels) el.textContent = label;
+}
+
+function findDownloadAsset(releases: GitHubRelease[], key: DownloadKey) {
+  const download = downloads[key];
+  for (const release of releases) {
+    if (release.draft) continue;
+    const asset = release.assets.find((candidate) => {
+      return download.assetNames.some((name) => name === candidate.name) || download.assetPattern.test(candidate.name);
+    });
+    if (asset) return { release, asset };
+  }
+  return null;
+}
+
 async function initDownloadLink() {
   for (const [key, download] of Object.entries(downloads) as [DownloadKey, (typeof downloads)[DownloadKey]][]) {
-    setDownloadLink(key, download.fallbackUrl, `Download the latest Cellar release for ${download.label}`);
+    setDownloadLink(key, download.fallbackUrl, `View Cellar releases for ${download.label}`);
   }
 
   try {
@@ -233,28 +254,30 @@ async function initDownloadLink() {
     });
     if (!res.ok) return;
 
-    const release = (await res.json()) as GitHubRelease;
+    const releases = (await res.json()) as GitHubRelease[];
+    const availableSizes: number[] = [];
+
     for (const [key, download] of Object.entries(downloads) as [DownloadKey, (typeof downloads)[DownloadKey]][]) {
-      const asset = release.assets.find((candidate) => candidate.name === download.assetName);
-      if (!asset) continue;
+      const match = findDownloadAsset(releases, key);
+      if (!match) continue;
 
       setDownloadLink(
         key,
-        asset.browser_download_url,
-        `Download Cellar ${release.tag_name} for ${download.label}`,
+        match.asset.browser_download_url,
+        `Download Cellar ${match.release.tag_name} for ${download.label}`,
       );
+      availableSizes.push(match.asset.size);
     }
 
-    const sizeEls = document.querySelectorAll<HTMLElement>("[data-release-size]");
-    const sizes = release.assets
-      .filter((asset) => Object.values(downloads).some((download) => download.assetName === asset.name))
-      .map((asset) => asset.size);
-    if (sizes.length === 0) return;
+    if (availableSizes.length === 0) return;
 
-    const largestSize = Math.max(...sizes);
+    setDownloadButtonLabel("Download for Mac");
+
+    const sizeEls = document.querySelectorAll<HTMLElement>("[data-release-size]");
+    const largestSize = Math.max(...availableSizes);
     for (const el of sizeEls) el.textContent = formatBytes(largestSize);
   } catch {
-    /* Keep the direct latest/download fallback links. */
+    /* Keep the GitHub Releases fallback links. */
   }
 }
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -36,9 +36,15 @@ Before tagging, make sure the package metadata in `package.json`,
 
 The `Release` workflow currently builds macOS Apple Silicon and macOS Intel
 artifacts only. It signs and notarizes the app with Developer ID, creates a
-draft GitHub Release, and uploads the Tauri installers. Tags with prerelease
-suffixes, such as `0.1.0-alpha.1`, are marked as prereleases. Review the draft,
-edit release notes, then publish it.
+draft GitHub Release while the matrix jobs upload installers, then publishes
+the release after both macOS jobs finish successfully. Tags with prerelease
+suffixes, such as `0.1.0-alpha.1`, are marked as prereleases.
+
+To publish an already-created draft manually:
+
+```bash
+gh release edit 0.1.0 --draft=false
+```
 
 Release signing and notarization require these GitHub Actions secrets:
 
@@ -52,23 +58,23 @@ Release signing and notarization require these GitHub Actions secrets:
 - `APP_STORE_CONNECT_KEY_ID` - App Store Connect API key ID.
 - `APP_STORE_CONNECT_ISSUER_ID` - App Store Connect issuer ID.
 
-## Website links
+## Website downloads
 
-The website download buttons link directly to stable macOS release assets:
+The website presents separate Apple Silicon and Intel Mac buttons instead of
+assuming the visitor's CPU architecture. It falls back to the GitHub Releases
+page, then upgrades the buttons to direct DMG links when the public GitHub
+Releases API returns matching assets.
 
-```text
-https://github.com/MRL-00/cellar/releases/latest/download/Cellar-mac-arm64.dmg
-https://github.com/MRL-00/cellar/releases/latest/download/Cellar-mac-x64.dmg
-```
-
-GitHub redirects those URLs to the matching assets on the latest published
-release. The site presents separate Apple Silicon and Intel Mac buttons instead
-of assuming the visitor's CPU architecture. The release workflow uploads stable
-aliases for the Tauri-generated DMGs so the website does not need to know the
-versioned installer filenames:
+The release workflow attempts to upload stable aliases for the Tauri-generated
+DMGs:
 
 - `Cellar-mac-arm64.dmg` for Apple Silicon.
 - `Cellar-mac-x64.dmg` for Intel.
+
+The website also recognizes Tauri's versioned DMG names, such as
+`Cellar_0.1.0_aarch64.dmg` and `Cellar_0.1.0_x64.dmg`. This keeps downloads
+working for prereleases and early releases where GitHub's `/releases/latest`
+endpoint may not resolve.
 
 ## Before public distribution
 


### PR DESCRIPTION
## Summary

Fixes the marketing site download flow for early-access GitHub releases.

## What changed

- Fall back download choices to the GitHub Releases page instead of dead `/releases/latest/download` URLs.
- Query the public releases list and resolve direct DMG links for prereleases.
- Recognize both stable alias names and Tauri versioned DMG asset names.
- Publish GitHub Releases automatically after both macOS release jobs upload artifacts.
- Update release docs to describe the automated publish flow and prerelease download behavior.

## User impact

Visitors no longer hit 404s from the download menu, and published prerelease DMGs resolve to direct Apple Silicon / Intel downloads.

## Validation

- `pnpm --filter @cellar/site build`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "workflow yaml ok"'`\n- Local browser check confirmed the CTA upgrades to `Download for Mac` and direct DMG links once the public release API returns assets.\n\n## Known notes\n\n- GitHub `/releases/latest` does not resolve prereleases, so the site intentionally uses `/releases` for early-access downloads.