### PR TITLE
feat: add setup import/export for sharing connections and settings

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -15,9 +15,17 @@ import {
   SettingsModal,
   type SettingsCatId,
 } from "./components/modals/Settings";
+import { ExportSetupModal } from "./components/modals/ExportSetupModal";
+import { ImportSetupModal } from "./components/modals/ImportSetupModal";
 import { useLayout } from "./state/layout";
 
-type ModalId = "commit" | "palette" | "settings" | null;
+type ModalId =
+  | "commit"
+  | "palette"
+  | "settings"
+  | "exportSetup"
+  | "importSetup"
+  | null;
 type ConnDialog = { mode: "new" | "edit"; initial?: ConnectionConfig } | null;
 
 const LEFT_MIN = 200;
@@ -263,14 +271,20 @@ export function App() {
           onOpenCommit={() => openModal("commit")}
           onOpenSettings={() => openSettings()}
           onTogglePanel={togglePanel}
+          onExportSetup={() => openModal("exportSetup")}
+          onImportSetup={() => openModal("importSetup")}
         />
       )}
       {modal === "settings" && (
         <SettingsModal
           onClose={closeModal}
           initialCat={settingsInitialCat}
+          onExportSetup={() => openModal("exportSetup")}
+          onImportSetup={() => openModal("importSetup")}
         />
       )}
+      {modal === "exportSetup" && <ExportSetupModal onClose={closeModal} />}
+      {modal === "importSetup" && <ImportSetupModal onClose={closeModal} />}
     </div>
   );
 }

--- a/apps/desktop/src/components/icons.tsx
+++ b/apps/desktop/src/components/icons.tsx
@@ -216,6 +216,20 @@ export const Icon = {
       <path d="M12 3v18M9 6L6 9l3 3M15 18l3-3-3-3" />
     </I>
   ),
+  download: (p: IconProps) => (
+    <I {...p}>
+      <path d="M12 3v12" />
+      <path d="M7 10l5 5 5-5" />
+      <path d="M5 21h14" />
+    </I>
+  ),
+  upload: (p: IconProps) => (
+    <I {...p}>
+      <path d="M12 21V9" />
+      <path d="M7 14l5-5 5 5" />
+      <path d="M5 3h14" />
+    </I>
+  ),
   commit: (p: IconProps) => (
     <I {...p}>
       <circle cx="12" cy="12" r="4" />

--- a/apps/desktop/src/components/modals/CommandPalette.tsx
+++ b/apps/desktop/src/components/modals/CommandPalette.tsx
@@ -26,6 +26,8 @@ type CommandPaletteProps = {
   onOpenCommit: () => void;
   onOpenSettings: () => void;
   onTogglePanel: (k: PanelId) => void;
+  onExportSetup: () => void;
+  onImportSetup: () => void;
 };
 
 const GROUP_ORDER: Group[] = [
@@ -44,6 +46,8 @@ export function CommandPalette({
   onOpenCommit,
   onOpenSettings,
   onTogglePanel,
+  onExportSetup,
+  onImportSetup,
 }: CommandPaletteProps) {
   const [q, setQ] = useState("");
   const [active, setActive] = useState(0);
@@ -113,6 +117,24 @@ export function CommandPalette({
       hint: pending > 0 ? `${pending} pending` : "no pending changes",
       kbd: ["⌘", "S"],
       action: onOpenCommit,
+    });
+
+    add({
+      id: "export-setup",
+      grp: "Actions",
+      label: "Export setup…",
+      hint: "share connections, settings, layouts",
+      search: "backup transfer share download",
+      action: onExportSetup,
+    });
+
+    add({
+      id: "import-setup",
+      grp: "Actions",
+      label: "Import setup…",
+      hint: "load a shared setup file",
+      search: "restore transfer upload merge",
+      action: onImportSetup,
     });
 
     if (pending > 0) {
@@ -240,6 +262,8 @@ export function CommandPalette({
     connections,
     disconnect,
     newQueryTab,
+    onExportSetup,
+    onImportSetup,
     onNewConnection,
     onOpenCommit,
     onOpenSettings,

--- a/apps/desktop/src/components/modals/ExportSetupModal.tsx
+++ b/apps/desktop/src/components/modals/ExportSetupModal.tsx
@@ -1,0 +1,214 @@
+import { useMemo, useState } from "react";
+
+import { useConnections } from "../../state/connections";
+import { useTabs } from "../../state/tabs";
+import { useSettings } from "../../lib/settings";
+import {
+  buildBundle,
+  sectionCounts,
+  serializeBundle,
+  type SetupSectionKey,
+  type SetupSelection,
+} from "../../lib/setupTransfer";
+import { Icon } from "../icons";
+import { ED_RUN_PRIMARY, ED_RUN_SUBTLE } from "./settingsPrimitives";
+import { Modal } from "./Modal";
+
+const APP_VERSION = "0.1.0";
+
+type SectionMeta = {
+  key: SetupSectionKey;
+  label: string;
+  describe: (count: number) => string;
+};
+
+const SECTIONS: SectionMeta[] = [
+  {
+    key: "settings",
+    label: "Appearance & settings",
+    describe: () => "Theme, accent, density, fonts, font size",
+  },
+  {
+    key: "connections",
+    label: "Connections",
+    describe: (n) =>
+      `${n} saved ${n === 1 ? "connection" : "connections"} — passwords excluded`,
+  },
+  {
+    key: "tableLayouts",
+    label: "Table grid layouts",
+    describe: (n) =>
+      `${n} saved ${n === 1 ? "layout" : "layouts"} (column order & widths)`,
+  },
+];
+
+function todayStamp(): string {
+  const d = new Date();
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+export function ExportSetupModal({ onClose }: { onClose: () => void }) {
+  const { settings } = useSettings();
+  const connections = useConnections((s) => s.connections);
+  const tableLayouts = useTabs((s) => s.tableLayouts);
+  const [selection, setSelection] = useState<SetupSelection>({
+    settings: true,
+    connections: true,
+    tableLayouts: true,
+  });
+  const [copied, setCopied] = useState(false);
+
+  const sources = useMemo(
+    () => ({ settings, connections, tableLayouts }),
+    [settings, connections, tableLayouts],
+  );
+  const counts = useMemo(() => sectionCounts(sources), [sources]);
+
+  const anySelected =
+    selection.settings || selection.connections || selection.tableLayouts;
+
+  const json = useMemo(() => {
+    if (!anySelected) return "";
+    return serializeBundle(
+      buildBundle(selection, sources, {
+        app: APP_VERSION,
+        exportedAt: new Date().toISOString(),
+      }),
+    );
+  }, [anySelected, selection, sources]);
+
+  const toggle = (key: SetupSectionKey) =>
+    setSelection((s) => ({ ...s, [key]: !s[key] }));
+
+  const onDownload = () => {
+    if (!json) return;
+    const blob = new Blob([json], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `cellar-setup-${todayStamp()}.json`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    // Revoke on the next tick so the download has time to start.
+    setTimeout(() => URL.revokeObjectURL(url), 0);
+  };
+
+  const onCopy = async () => {
+    if (!json) return;
+    try {
+      await navigator.clipboard.writeText(json);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  return (
+    <Modal onClose={onClose} width={560}>
+      <div className="flex h-[38px] shrink-0 items-center justify-between border-b border-border-default pl-3.5 pr-2">
+        <div className="flex items-center gap-2">
+          <span className="inline-flex text-accent">
+            <Icon.download size={14} />
+          </span>
+          <span className="whitespace-nowrap text-[12.5px] font-semibold text-fg-0">
+            Export setup
+          </span>
+        </div>
+        <button className="icon-btn" onClick={onClose} title="Close">
+          <Icon.close size={13} />
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-4 py-3.5">
+        <p className="m-0 mb-3 max-w-[52ch] text-[11.5px] text-fg-2 text-pretty">
+          Pick what to include, then download a <code>.json</code> file you can
+          share or move to another machine.
+        </p>
+
+        <div className="flex flex-col gap-1.5">
+          {SECTIONS.map((section) => {
+            const count = counts[section.key];
+            const on = selection[section.key];
+            const empty = count === 0;
+            return (
+              <button
+                key={section.key}
+                type="button"
+                onClick={() => !empty && toggle(section.key)}
+                disabled={empty}
+                className={
+                  "flex items-start gap-2.5 rounded-[5px] border px-3 py-2 text-left transition-colors " +
+                  (empty
+                    ? "cursor-not-allowed border-border-default bg-bg-inset opacity-60"
+                    : on
+                      ? "border-accent-line bg-accent-soft"
+                      : "border-border-default bg-bg-2 hover:border-border-strong")
+                }
+              >
+                <span
+                  className={
+                    "mt-px inline-flex h-[15px] w-[15px] shrink-0 items-center justify-center rounded-[4px] border " +
+                    (on && !empty
+                      ? "border-accent bg-accent text-accent-fg"
+                      : "border-border-strong bg-bg-inset")
+                  }
+                >
+                  {on && !empty && <Icon.check size={10} />}
+                </span>
+                <span className="min-w-0">
+                  <span className="flex items-center gap-1.5 text-[12px] font-medium text-fg-0">
+                    {section.label}
+                    <span className="font-mono text-[10px] text-fg-3">
+                      {empty ? "none saved" : `×${count}`}
+                    </span>
+                  </span>
+                  <span className="block text-[10.5px] text-fg-3">
+                    {section.describe(count)}
+                  </span>
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="mt-3 flex items-center gap-1.5 rounded-[4px] border border-dashed border-border-default bg-bg-inset px-3 py-2 text-[11px] text-fg-2">
+          <Icon.lock size={12} stroke="var(--fg-3)" />
+          <span>
+            Passwords and API keys are never exported — recipients re-enter their
+            own.
+          </span>
+        </div>
+      </div>
+
+      <div className="flex h-11 shrink-0 items-center justify-between gap-3 border-t border-border-default bg-bg-2 px-3">
+        <span className="font-mono text-[10.5px] text-fg-3">
+          {anySelected ? `${json.length.toLocaleString()} bytes` : "nothing selected"}
+        </span>
+        <div className="flex items-center gap-2">
+          <button className={ED_RUN_SUBTLE} onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            className={ED_RUN_SUBTLE + " disabled:cursor-not-allowed disabled:opacity-40"}
+            onClick={() => void onCopy()}
+            disabled={!anySelected}
+          >
+            <Icon.copy size={11} />
+            <span>{copied ? "Copied" : "Copy JSON"}</span>
+          </button>
+          <button
+            className={ED_RUN_PRIMARY + " disabled:cursor-not-allowed disabled:opacity-40"}
+            onClick={onDownload}
+            disabled={!anySelected}
+          >
+            <Icon.download size={11} />
+            <span>Download .json</span>
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/desktop/src/components/modals/ImportSetupModal.tsx
+++ b/apps/desktop/src/components/modals/ImportSetupModal.tsx
@@ -1,0 +1,609 @@
+import { useRef, useState } from "react";
+import type { ConnectionConfig } from "@cellar/ipc";
+
+import { useConnections } from "../../state/connections";
+import { useTabs } from "../../state/tabs";
+import { useSettings } from "../../lib/settings";
+import {
+  applyImportPlan,
+  computeImportPlan,
+  parseBundle,
+  type ConnDecision,
+  type ConnImportItem,
+  type ImportPlan,
+  type ImportResult,
+  type LayoutDecision,
+  type LayoutImportItem,
+} from "../../lib/setupTransfer";
+import { Icon } from "../icons";
+import { ED_RUN_PRIMARY, ED_RUN_SUBTLE, Section } from "./settingsPrimitives";
+import { Modal } from "./Modal";
+
+export function ImportSetupModal({ onClose }: { onClose: () => void }) {
+  const connections = useConnections((s) => s.connections);
+  const saveConnection = useConnections((s) => s.saveConnection);
+  const tableLayouts = useTabs((s) => s.tableLayouts);
+  const importTableLayouts = useTabs((s) => s.importTableLayouts);
+  const { importSettings } = useSettings();
+
+  const [raw, setRaw] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [fileName, setFileName] = useState<string | null>(null);
+  const [plan, setPlan] = useState<ImportPlan | null>(null);
+  const [applying, setApplying] = useState(false);
+  const [result, setResult] = useState<ImportResult | null>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const tryParse = (text: string) => {
+    const parsed = parseBundle(text);
+    if (!parsed.ok) {
+      setError(parsed.error);
+      setPlan(null);
+      return;
+    }
+    setError(null);
+    setPlan(
+      computeImportPlan(parsed.bundle, {
+        connections,
+        tableLayouts,
+      }),
+    );
+  };
+
+  const onFile = async (file: File | undefined) => {
+    if (!file) return;
+    setFileName(file.name);
+    try {
+      const text = await file.text();
+      setRaw(text);
+      tryParse(text);
+    } catch {
+      setError("Could not read that file.");
+    }
+  };
+
+  const setConnDecision = (idx: number, decision: ConnDecision) =>
+    setPlan((p) =>
+      p
+        ? {
+            ...p,
+            connections: p.connections.map((c, i) =>
+              i === idx ? { ...c, decision } : c,
+            ),
+          }
+        : p,
+    );
+
+  const setLayoutDecision = (idx: number, decision: LayoutDecision) =>
+    setPlan((p) =>
+      p
+        ? {
+            ...p,
+            layouts: p.layouts.map((l, i) =>
+              i === idx ? { ...l, decision } : l,
+            ),
+          }
+        : p,
+    );
+
+  const bulkConn = (fn: (c: ConnImportItem) => ConnDecision) =>
+    setPlan((p) =>
+      p
+        ? { ...p, connections: p.connections.map((c) => ({ ...c, decision: fn(c) })) }
+        : p,
+    );
+
+  const bulkLayout = (fn: (l: LayoutImportItem) => LayoutDecision) =>
+    setPlan((p) =>
+      p ? { ...p, layouts: p.layouts.map((l) => ({ ...l, decision: fn(l) })) } : p,
+    );
+
+  const setSettingsApply = (apply: boolean) =>
+    setPlan((p) =>
+      p && p.settings ? { ...p, settings: { ...p.settings, apply } } : p,
+    );
+
+  const hasActions = Boolean(
+    plan &&
+      (plan.connections.some((c) => c.decision !== "skip") ||
+        plan.layouts.some((l) => l.decision !== "skip") ||
+        plan.settings?.apply),
+  );
+
+  const onApply = async () => {
+    if (!plan) return;
+    setApplying(true);
+    try {
+      const res = await applyImportPlan(plan, {
+        existingConnectionIds: connections.map((c) => c.id),
+        saveConnection,
+        importSettings,
+        importTableLayouts,
+      });
+      setResult(res);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setApplying(false);
+    }
+  };
+
+  return (
+    <Modal onClose={onClose} width={620} height={result ? undefined : 600}>
+      <div className="flex h-[38px] shrink-0 items-center justify-between border-b border-border-default pl-3.5 pr-2">
+        <div className="flex items-center gap-2">
+          <span className="inline-flex text-accent">
+            <Icon.upload size={14} />
+          </span>
+          <span className="whitespace-nowrap text-[12.5px] font-semibold text-fg-0">
+            Import setup
+          </span>
+        </div>
+        <button className="icon-btn" onClick={onClose} title="Close">
+          <Icon.close size={13} />
+        </button>
+      </div>
+
+      {result ? (
+        <ResultView result={result} />
+      ) : plan ? (
+        <ReviewView
+          plan={plan}
+          setConnDecision={setConnDecision}
+          setLayoutDecision={setLayoutDecision}
+          bulkConn={bulkConn}
+          bulkLayout={bulkLayout}
+          setSettingsApply={setSettingsApply}
+        />
+      ) : (
+        <SourceView
+          raw={raw}
+          setRaw={setRaw}
+          error={error}
+          fileName={fileName}
+          fileRef={fileRef}
+          onFile={onFile}
+          onReview={() => tryParse(raw)}
+        />
+      )}
+
+      <div className="flex h-11 shrink-0 items-center justify-between gap-3 border-t border-border-default bg-bg-2 px-3">
+        {result ? (
+          <>
+            <span className="text-[11px] text-fg-2">Import complete.</span>
+            <button className={ED_RUN_PRIMARY} onClick={onClose}>
+              <Icon.check size={11} />
+              <span>Done</span>
+            </button>
+          </>
+        ) : plan ? (
+          <>
+            <button
+              className={ED_RUN_SUBTLE}
+              onClick={() => {
+                setPlan(null);
+                setError(null);
+              }}
+            >
+              <Icon.chevronLeft size={11} />
+              <span>Back</span>
+            </button>
+            <button
+              className={ED_RUN_PRIMARY + " disabled:cursor-not-allowed disabled:opacity-40"}
+              onClick={() => void onApply()}
+              disabled={!hasActions || applying}
+            >
+              <Icon.check size={11} />
+              <span>{applying ? "Applying…" : "Apply import"}</span>
+            </button>
+          </>
+        ) : (
+          <>
+            <span className="font-mono text-[10.5px] text-fg-3">
+              {fileName ?? "no file selected"}
+            </span>
+            <button
+              className={ED_RUN_PRIMARY + " disabled:cursor-not-allowed disabled:opacity-40"}
+              onClick={() => tryParse(raw)}
+              disabled={!raw.trim()}
+            >
+              <span>Review</span>
+              <Icon.chevronRight size={11} />
+            </button>
+          </>
+        )}
+      </div>
+    </Modal>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step 1 — source
+// ---------------------------------------------------------------------------
+
+function SourceView({
+  raw,
+  setRaw,
+  error,
+  fileName,
+  fileRef,
+  onFile,
+  onReview,
+}: {
+  raw: string;
+  setRaw: (v: string) => void;
+  error: string | null;
+  fileName: string | null;
+  fileRef: React.RefObject<HTMLInputElement>;
+  onFile: (file: File | undefined) => void;
+  onReview: () => void;
+}) {
+  return (
+    <div className="flex-1 overflow-y-auto px-4 py-3.5">
+      <p className="m-0 mb-3 max-w-[56ch] text-[11.5px] text-fg-2 text-pretty">
+        Load a Cellar setup file someone shared with you. You'll review each item
+        before anything changes.
+      </p>
+
+      <input
+        ref={fileRef}
+        type="file"
+        accept=".json,application/json"
+        className="hidden"
+        onChange={(e) => onFile(e.target.files?.[0])}
+      />
+      <button
+        type="button"
+        onClick={() => fileRef.current?.click()}
+        className="flex w-full items-center justify-center gap-2 rounded-[6px] border border-dashed border-border-strong bg-bg-2 px-3 py-5 text-[12px] text-fg-1 hover:border-accent-line hover:bg-accent-soft"
+      >
+        <Icon.fileText size={14} stroke="var(--fg-2)" />
+        <span>{fileName ? `Loaded ${fileName} — choose another` : "Choose a .json file"}</span>
+      </button>
+
+      <div className="my-3 flex items-center gap-2 text-[10.5px] text-fg-3">
+        <span className="h-px flex-1 bg-border-divider" />
+        <span>or paste JSON</span>
+        <span className="h-px flex-1 bg-border-divider" />
+      </div>
+
+      <textarea
+        value={raw}
+        onChange={(e) => setRaw(e.target.value)}
+        onBlur={() => raw.trim() && onReview()}
+        spellCheck={false}
+        placeholder={'{\n  "format": "cellar.setup",\n  ...\n}'}
+        className="h-[180px] w-full resize-none rounded-[5px] border border-border-default bg-bg-inset px-2.5 py-2 font-mono text-[11px] text-fg-0 outline-none focus:border-accent-line"
+      />
+
+      {error && (
+        <div className="mt-2.5 flex items-start gap-1.5 rounded-[4px] border border-[color-mix(in_oklab,var(--delete)_30%,var(--border-default))] bg-delete-bg px-3 py-2 text-[11px] text-delete">
+          <Icon.warn size={12} />
+          <span>{error}</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step 2 — review
+// ---------------------------------------------------------------------------
+
+function ReviewView({
+  plan,
+  setConnDecision,
+  setLayoutDecision,
+  bulkConn,
+  bulkLayout,
+  setSettingsApply,
+}: {
+  plan: ImportPlan;
+  setConnDecision: (idx: number, d: ConnDecision) => void;
+  setLayoutDecision: (idx: number, d: LayoutDecision) => void;
+  bulkConn: (fn: (c: ConnImportItem) => ConnDecision) => void;
+  bulkLayout: (fn: (l: LayoutImportItem) => LayoutDecision) => void;
+  setSettingsApply: (apply: boolean) => void;
+}) {
+  return (
+    <div className="flex-1 overflow-y-auto pb-4">
+      {plan.settings && (
+        <Section title="Appearance & settings">
+          <button
+            type="button"
+            onClick={() => setSettingsApply(!plan.settings!.apply)}
+            className={
+              "flex items-center gap-2.5 rounded-[5px] border px-3 py-2 text-left " +
+              (plan.settings.apply
+                ? "border-accent-line bg-accent-soft"
+                : "border-border-default bg-bg-2 hover:border-border-strong")
+            }
+          >
+            <span
+              className={
+                "inline-flex h-[15px] w-[15px] shrink-0 items-center justify-center rounded-[4px] border " +
+                (plan.settings.apply
+                  ? "border-accent bg-accent text-accent-fg"
+                  : "border-border-strong bg-bg-inset")
+              }
+            >
+              {plan.settings.apply && <Icon.check size={10} />}
+            </span>
+            <span className="min-w-0">
+              <span className="block text-[12px] font-medium text-fg-0">
+                Apply imported appearance & settings
+              </span>
+              <span className="flex items-center gap-1.5 text-[10.5px] text-fg-3">
+                <span
+                  className="inline-block h-2.5 w-2.5 rounded-full border border-white/15"
+                  style={{ background: plan.settings.settings.accent }}
+                />
+                {plan.settings.settings.theme} · {plan.settings.settings.density} ·{" "}
+                {plan.settings.settings.interfaceFont} /{" "}
+                {plan.settings.settings.monoFont}
+              </span>
+            </span>
+          </button>
+        </Section>
+      )}
+
+      {plan.connections.length > 0 && (
+        <Section
+          title={`Connections (${plan.connections.length})`}
+          sub="Duplicates (same engine, host, database and user) are skipped by default so nothing imports twice."
+        >
+          <BulkBar>
+            <BulkBtn onClick={() => bulkConn((c) => (c.duplicateOfId ? c.decision : "add"))}>
+              Add all new
+            </BulkBtn>
+            <BulkBtn
+              onClick={() => bulkConn((c) => (c.duplicateOfId ? "replace" : c.decision))}
+            >
+              Replace all duplicates
+            </BulkBtn>
+            <BulkBtn onClick={() => bulkConn(() => "skip")}>Skip all</BulkBtn>
+          </BulkBar>
+          <div className="flex flex-col gap-1">
+            {plan.connections.map((item, idx) => (
+              <ConnRow
+                key={`${item.identity}-${idx}`}
+                item={item}
+                onChange={(d) => setConnDecision(idx, d)}
+              />
+            ))}
+          </div>
+        </Section>
+      )}
+
+      {plan.layouts.length > 0 && (
+        <Section title={`Table grid layouts (${plan.layouts.length})`}>
+          <BulkBar>
+            <BulkBtn onClick={() => bulkLayout((l) => (l.exists ? l.decision : "add"))}>
+              Add all new
+            </BulkBtn>
+            <BulkBtn onClick={() => bulkLayout((l) => (l.exists ? "replace" : l.decision))}>
+              Replace all existing
+            </BulkBtn>
+            <BulkBtn onClick={() => bulkLayout(() => "skip")}>Skip all</BulkBtn>
+          </BulkBar>
+          <div className="flex flex-col gap-1">
+            {plan.layouts.map((item, idx) => (
+              <LayoutRow
+                key={`${item.key}-${idx}`}
+                item={item}
+                onChange={(d) => setLayoutDecision(idx, d)}
+              />
+            ))}
+          </div>
+        </Section>
+      )}
+    </div>
+  );
+}
+
+function ConnRow({
+  item,
+  onChange,
+}: {
+  item: ConnImportItem;
+  onChange: (d: ConnDecision) => void;
+}) {
+  const dup = Boolean(item.duplicateOfId);
+  const options: { value: ConnDecision; label: string }[] = dup
+    ? [
+        { value: "skip", label: "Skip" },
+        { value: "replace", label: "Replace" },
+        { value: "copy", label: "Add copy" },
+      ]
+    : [
+        { value: "add", label: "Add" },
+        { value: "skip", label: "Skip" },
+      ];
+  return (
+    <div className="flex items-center gap-2.5 rounded-[4px] border border-border-default bg-bg-2 px-2.5 py-1.5">
+      <span className="min-w-0 flex-1">
+        <span className="flex items-center gap-1.5">
+          <span className="truncate text-[11.5px] font-medium text-fg-0">
+            {item.incoming.name}
+          </span>
+          <StatusBadge
+            tone={dup ? "warn" : "ok"}
+            label={dup ? `dup of ${item.duplicateOfName}` : "new"}
+          />
+        </span>
+        <span className="block truncate font-mono text-[10px] text-fg-3">
+          {connHint(item.incoming)}
+        </span>
+      </span>
+      <MiniSegment value={item.decision} options={options} onChange={onChange} />
+    </div>
+  );
+}
+
+function LayoutRow({
+  item,
+  onChange,
+}: {
+  item: LayoutImportItem;
+  onChange: (d: LayoutDecision) => void;
+}) {
+  const options: { value: LayoutDecision; label: string }[] = item.exists
+    ? [
+        { value: "skip", label: "Skip" },
+        { value: "replace", label: "Replace" },
+      ]
+    : [
+        { value: "add", label: "Add" },
+        { value: "skip", label: "Skip" },
+      ];
+  return (
+    <div className="flex items-center gap-2.5 rounded-[4px] border border-border-default bg-bg-2 px-2.5 py-1.5">
+      <span className="min-w-0 flex-1">
+        <span className="flex items-center gap-1.5">
+          <span className="truncate font-mono text-[11px] text-fg-0">
+            {item.tablePath}
+          </span>
+          <StatusBadge
+            tone={item.exists ? "warn" : "ok"}
+            label={item.exists ? "exists" : "new"}
+          />
+        </span>
+        <span className="block truncate font-mono text-[10px] text-fg-3">
+          {item.connectionId || "—"} · {item.layout.order.length} cols
+        </span>
+      </span>
+      <MiniSegment value={item.decision} options={options} onChange={onChange} />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Result
+// ---------------------------------------------------------------------------
+
+function ResultView({ result }: { result: ImportResult }) {
+  const lines: string[] = [];
+  if (result.connectionsAdded) lines.push(`${result.connectionsAdded} connection(s) added`);
+  if (result.connectionsReplaced)
+    lines.push(`${result.connectionsReplaced} connection(s) replaced`);
+  if (result.connectionsSkipped)
+    lines.push(`${result.connectionsSkipped} connection(s) skipped`);
+  if (result.layoutsAdded) lines.push(`${result.layoutsAdded} layout(s) added`);
+  if (result.layoutsReplaced) lines.push(`${result.layoutsReplaced} layout(s) replaced`);
+  if (result.layoutsSkipped) lines.push(`${result.layoutsSkipped} layout(s) skipped`);
+  if (result.settingsApplied) lines.push("appearance & settings applied");
+  const importedConns = result.connectionsAdded + result.connectionsReplaced;
+
+  return (
+    <div className="flex-1 overflow-y-auto px-4 py-4">
+      <div className="mb-3 flex items-center gap-2">
+        <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-accent-soft text-accent">
+          <Icon.check size={13} />
+        </span>
+        <span className="text-[13px] font-semibold text-fg-0">Setup imported</span>
+      </div>
+      <ul className="m-0 flex list-none flex-col gap-1 p-0">
+        {lines.length ? (
+          lines.map((line) => (
+            <li key={line} className="flex items-center gap-1.5 text-[11.5px] text-fg-1">
+              <span className="h-1 w-1 rounded-full bg-fg-3" />
+              {line}
+            </li>
+          ))
+        ) : (
+          <li className="text-[11.5px] text-fg-2">Nothing was changed.</li>
+        )}
+      </ul>
+      {importedConns > 0 && (
+        <div className="mt-3 flex items-start gap-1.5 rounded-[4px] border border-dashed border-border-default bg-bg-inset px-3 py-2 text-[11px] text-fg-2">
+          <Icon.lock size={12} stroke="var(--fg-3)" />
+          <span>
+            Imported connections have no password yet — open each one and set its
+            credentials before connecting.
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Small shared bits
+// ---------------------------------------------------------------------------
+
+function StatusBadge({ tone, label }: { tone: "ok" | "warn"; label: string }) {
+  return (
+    <span
+      className={
+        "shrink-0 rounded-[3px] px-1.5 py-px font-mono text-[9px] uppercase tracking-[0.04em] " +
+        (tone === "warn"
+          ? "bg-warn-bg text-warn"
+          : "bg-insert-bg text-insert")
+      }
+    >
+      {label}
+    </span>
+  );
+}
+
+function MiniSegment<T extends string>({
+  value,
+  options,
+  onChange,
+}: {
+  value: T;
+  options: { value: T; label: string }[];
+  onChange: (v: T) => void;
+}) {
+  return (
+    <div className="inline-flex shrink-0 gap-px rounded-[4px] border border-border-default bg-bg-inset p-[2px]">
+      {options.map((o) => (
+        <button
+          key={o.value}
+          type="button"
+          onClick={() => onChange(o.value)}
+          aria-pressed={value === o.value}
+          className={
+            "h-5 rounded-[3px] px-2 text-[10.5px] " +
+            (value === o.value
+              ? "bg-bg-3 font-medium text-fg-0"
+              : "text-fg-2 hover:text-fg-0")
+          }
+        >
+          {o.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function BulkBar({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mb-1 flex items-center gap-1.5">
+      <span className="text-[10px] uppercase tracking-[0.06em] text-fg-3">Bulk</span>
+      {children}
+    </div>
+  );
+}
+
+function BulkBtn({
+  onClick,
+  children,
+}: {
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="rounded-[3px] border border-border-default bg-bg-2 px-2 py-0.5 text-[10.5px] text-fg-2 hover:border-border-strong hover:text-fg-0"
+    >
+      {children}
+    </button>
+  );
+}
+
+function connHint(c: ConnectionConfig): string {
+  return `${c.engine} · ${c.host}:${c.port}/${c.database} · ${c.user || "—"}`;
+}

--- a/apps/desktop/src/components/modals/Settings.tsx
+++ b/apps/desktop/src/components/modals/Settings.tsx
@@ -83,9 +83,13 @@ const SETTINGS_CATS: CatGroup[] = [
 export function SettingsModal({
   onClose,
   initialCat = "appearance",
+  onExportSetup,
+  onImportSetup,
 }: {
   onClose: () => void;
   initialCat?: SettingsCatId;
+  onExportSetup?: () => void;
+  onImportSetup?: () => void;
 }) {
   const [cat, setCat] = useState<SettingsCatId>(initialCat);
   const [q, setQ] = useState("");
@@ -164,7 +168,12 @@ export function SettingsModal({
               {cat === "keymap" && <SettingsKeymap />}
               {cat === "connections" && <SettingsConnections />}
               {cat === "history" && <SettingsHistory />}
-              {cat === "backups" && <SettingsBackups />}
+              {cat === "backups" && (
+                <SettingsBackups
+                  onExportSetup={onExportSetup}
+                  onImportSetup={onImportSetup}
+                />
+              )}
               {cat === "ai" && <SettingsAI />}
               {cat === "privacy" && <SettingsPrivacy />}
               {cat === "updates" && <SettingsUpdates />}

--- a/apps/desktop/src/components/modals/settingsDataPanels.tsx
+++ b/apps/desktop/src/components/modals/settingsDataPanels.tsx
@@ -1,6 +1,7 @@
 import { Icon } from "../icons";
 import {
   CD_INPUT,
+  ED_RUN_SUBTLE,
   Row,
   Section,
   StaticSegment,
@@ -94,9 +95,43 @@ export function SettingsHistory() {
   );
 }
 
-export function SettingsBackups() {
+export function SettingsBackups({
+  onExportSetup,
+  onImportSetup,
+}: {
+  onExportSetup?: () => void;
+  onImportSetup?: () => void;
+}) {
   return (
     <div className="flex-1 overflow-y-auto pb-6 pt-1">
+      <Section
+        title="Transfer setup"
+        sub="Export your connections, appearance, and grid layouts to a file you can share or restore on another machine. Passwords are never included."
+      >
+        <Row
+          label="Share or move your setup"
+          hint="Import lets you review each item and skip duplicates before applying."
+        >
+          <button
+            type="button"
+            className={ED_RUN_SUBTLE}
+            onClick={onExportSetup}
+            disabled={!onExportSetup}
+          >
+            <Icon.download size={11} />
+            <span>Export setup…</span>
+          </button>
+          <button
+            type="button"
+            className={ED_RUN_SUBTLE}
+            onClick={onImportSetup}
+            disabled={!onImportSetup}
+          >
+            <Icon.upload size={11} />
+            <span>Import setup…</span>
+          </button>
+        </Row>
+      </Section>
       <Section title="Backups">
         <Row
           label="Auto-snapshot before commits"

--- a/apps/desktop/src/components/modals/settingsPrimitives.tsx
+++ b/apps/desktop/src/components/modals/settingsPrimitives.tsx
@@ -2,10 +2,10 @@ import type { ReactNode } from "react";
 import { Icon } from "../icons";
 
 export const ED_RUN_BASE =
-  "inline-flex h-[26px] items-center gap-[5px] whitespace-nowrap rounded-[4px] border border-transparent px-2.5 text-[11.5px] font-medium text-fg-1 transition-[background,color,border-color,filter] duration-[120ms]";
+  "inline-flex h-[26px] items-center gap-[5px] whitespace-nowrap rounded-[4px] border border-transparent px-2.5 text-[11.5px] font-medium transition-[background,color,border-color,filter] duration-[120ms]";
 export const ED_RUN_SUBTLE =
   ED_RUN_BASE +
-  " bg-transparent border-border-default hover:bg-bg-3 hover:border-border-strong hover:text-fg-0";
+  " text-fg-1 bg-transparent border-border-default hover:bg-bg-3 hover:border-border-strong hover:text-fg-0";
 export const ED_RUN_PRIMARY =
   ED_RUN_BASE + " bg-accent text-accent-fg hover:brightness-[1.07]";
 export const ED_RUN_DANGER =

--- a/apps/desktop/src/lib/settings.tsx
+++ b/apps/desktop/src/lib/settings.tsx
@@ -37,7 +37,7 @@ export type Settings = {
   monoFont: string;
 };
 
-const DEFAULTS: Settings = {
+export const DEFAULTS: Settings = {
   theme: "dark",
   density: "compact",
   accent: "#a78bfa",
@@ -62,7 +62,7 @@ function load(): Settings {
   }
 }
 
-function sanitize(s: Settings): Settings {
+export function sanitize(s: Settings): Settings {
   return {
     ...s,
     fontSizePx: clamp(s.fontSizePx, FONT_SIZE_MIN, FONT_SIZE_MAX),
@@ -118,6 +118,8 @@ function hexToRgba(hex: string, alpha: number) {
 type Ctx = {
   settings: Settings;
   set: <K extends keyof Settings>(key: K, value: Settings[K]) => void;
+  /** Merge a partial settings object (e.g. an imported setup) over current. */
+  importSettings: (partial: Partial<Settings>) => void;
   reset: () => void;
 };
 
@@ -139,6 +141,15 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     });
   }, []);
 
+  const importSettings = useCallback((partial: Partial<Settings>) => {
+    setSettings((prev) => {
+      const next = sanitize({ ...prev, ...partial });
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+      applySideEffects(next);
+      return next;
+    });
+  }, []);
+
   const reset = useCallback(() => {
     localStorage.removeItem(STORAGE_KEY);
     applySideEffects(DEFAULTS);
@@ -153,7 +164,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     return () => mq.removeEventListener("change", onChange);
   }, [settings]);
 
-  const value = useMemo<Ctx>(() => ({ settings, set, reset }), [settings, set, reset]);
+  const value = useMemo<Ctx>(
+    () => ({ settings, set, importSettings, reset }),
+    [settings, set, importSettings, reset],
+  );
 
   return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>;
 }

--- a/apps/desktop/src/lib/setupTransfer.test.ts
+++ b/apps/desktop/src/lib/setupTransfer.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it } from "vitest";
+import type { ConnectionConfig } from "@cellar/ipc";
+
+import {
+  applyImportPlan,
+  buildBundle,
+  computeImportPlan,
+  connectionIdentity,
+  parseBundle,
+  serializeBundle,
+  uniqueConnectionId,
+  type SetupBundle,
+} from "./setupTransfer";
+
+function conn(overrides: Partial<ConnectionConfig> = {}): ConnectionConfig {
+  return {
+    id: "local-pg",
+    name: "Local Postgres",
+    engine: "postgres",
+    host: "localhost",
+    port: 5432,
+    database: "app",
+    user: "postgres",
+    ssl_mode: "prefer",
+    env_tag: "local",
+    application_name: "cellar",
+    color: "#4f8ff7",
+    ...overrides,
+  };
+}
+
+describe("connectionIdentity", () => {
+  it("matches on engine/host/port/db/user, ignoring id, name and case", () => {
+    const a = conn({ id: "a", name: "A", host: "LocalHost", user: "Postgres" });
+    const b = conn({ id: "b", name: "B different", host: "localhost", user: "postgres" });
+    expect(connectionIdentity(a)).toBe(connectionIdentity(b));
+  });
+
+  it("differs when the target server differs", () => {
+    expect(connectionIdentity(conn({ database: "app" }))).not.toBe(
+      connectionIdentity(conn({ database: "other" })),
+    );
+  });
+});
+
+describe("buildBundle", () => {
+  const sources = {
+    settings: {
+      theme: "dark" as const,
+      density: "compact" as const,
+      accent: "#a78bfa",
+      fontSizePx: 12.5,
+      interfaceFont: "Geist",
+      monoFont: "JetBrains Mono",
+    },
+    connections: [conn()],
+    tableLayouts: { "local-pg::app.public.orders": { order: ["id"], widths: { id: 80 } } },
+  };
+
+  it("only includes selected sections", () => {
+    const bundle = buildBundle(
+      { settings: true, connections: false, tableLayouts: false },
+      sources,
+      { app: "0.1.0", exportedAt: "2026-06-09T00:00:00Z" },
+    );
+    expect(bundle.sections.settings).toBeDefined();
+    expect(bundle.sections.connections).toBeUndefined();
+    expect(bundle.sections.tableLayouts).toBeUndefined();
+  });
+
+  it("never serializes a password, even if one was attached", () => {
+    const dirty = { ...conn(), password: "hunter2", secret: "x" } as ConnectionConfig;
+    const bundle = buildBundle(
+      { settings: false, connections: true, tableLayouts: false },
+      { ...sources, connections: [dirty] },
+      { app: "0.1.0", exportedAt: "2026-06-09T00:00:00Z" },
+    );
+    const json = serializeBundle(bundle);
+    expect(json).not.toContain("hunter2");
+    expect(json).not.toContain("password");
+    expect(json).not.toContain("secret");
+  });
+});
+
+describe("parseBundle", () => {
+  function validJson(): string {
+    return serializeBundle(
+      buildBundle(
+        { settings: false, connections: true, tableLayouts: false },
+        {
+          settings: {
+            theme: "dark",
+            density: "compact",
+            accent: "#a78bfa",
+            fontSizePx: 12.5,
+            interfaceFont: "Geist",
+            monoFont: "JetBrains Mono",
+          },
+          connections: [conn()],
+          tableLayouts: {},
+        },
+        { app: "0.1.0", exportedAt: "2026-06-09T00:00:00Z" },
+      ),
+    );
+  }
+
+  it("rejects non-JSON", () => {
+    const r = parseBundle("not json");
+    expect(r.ok).toBe(false);
+  });
+
+  it("rejects files without the cellar.setup marker", () => {
+    const r = parseBundle(JSON.stringify({ foo: "bar" }));
+    expect(r.ok).toBe(false);
+  });
+
+  it("rejects a newer bundle version", () => {
+    const r = parseBundle(
+      JSON.stringify({ format: "cellar.setup", version: 999, sections: { connections: [conn()] } }),
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it("accepts a valid bundle and strips unknown connection fields", () => {
+    const r = parseBundle(
+      JSON.stringify({
+        format: "cellar.setup",
+        version: 1,
+        sections: { connections: [{ ...conn(), password: "leak" }] },
+      }),
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      const c = r.bundle.sections.connections?.[0] as Record<string, unknown>;
+      expect(c.password).toBeUndefined();
+      expect(c.host).toBe("localhost");
+    }
+  });
+
+  it("round-trips a built bundle", () => {
+    const r = parseBundle(validJson());
+    expect(r.ok).toBe(true);
+  });
+
+  it("rejects a bundle with no importable sections", () => {
+    const r = parseBundle(JSON.stringify({ format: "cellar.setup", version: 1, sections: {} }));
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe("computeImportPlan", () => {
+  const bundle: SetupBundle = {
+    format: "cellar.setup",
+    version: 1,
+    exportedAt: "",
+    app: "",
+    sections: {
+      connections: [conn({ id: "incoming", name: "Imported PG" }), conn({ database: "fresh" })],
+      tableLayouts: {
+        "x::app.public.orders": { order: [], widths: {} },
+        "x::app.public.users": { order: [], widths: {} },
+      },
+      settings: {
+        theme: "light",
+        density: "comfortable",
+        accent: "#fff",
+        fontSizePx: 14,
+        interfaceFont: "Geist",
+        monoFont: "JetBrains Mono",
+      },
+    },
+  };
+
+  it("defaults duplicates to skip and new items to add", () => {
+    const plan = computeImportPlan(bundle, {
+      connections: [conn()], // same identity as first incoming
+      tableLayouts: { "x::app.public.orders": { order: [], widths: {} } },
+    });
+    const dup = plan.connections[0]!;
+    const fresh = plan.connections[1]!;
+    expect(dup.duplicateOfId).toBe("local-pg");
+    expect(dup.decision).toBe("skip");
+    expect(fresh.duplicateOfId).toBeNull();
+    expect(fresh.decision).toBe("add");
+
+    const existing = plan.layouts.find((l) => l.key === "x::app.public.orders");
+    const newLayout = plan.layouts.find((l) => l.key === "x::app.public.users");
+    expect(existing?.decision).toBe("skip");
+    expect(newLayout?.decision).toBe("add");
+    expect(plan.settings?.apply).toBe(true);
+  });
+});
+
+describe("uniqueConnectionId", () => {
+  it("appends a numeric suffix on collision", () => {
+    const taken = new Set(["local-pg", "local-pg-2"]);
+    expect(uniqueConnectionId("Local PG", taken)).toBe("local-pg-3");
+    expect(uniqueConnectionId("Brand New", new Set())).toBe("brand-new");
+  });
+});
+
+describe("applyImportPlan", () => {
+  it("adds, replaces, skips, and routes settings/layouts to deps", async () => {
+    const plan = computeImportPlan(
+      {
+        format: "cellar.setup",
+        version: 1,
+        exportedAt: "",
+        app: "",
+        sections: {
+          connections: [
+            conn({ id: "incoming", name: "Dup" }), // duplicate -> we'll replace
+            conn({ database: "fresh", id: "fresh" }), // new -> add
+            conn({ database: "skipme", id: "skipme" }), // new -> we'll skip
+          ],
+          tableLayouts: { "x::a.b.c": { order: ["id"], widths: {} } },
+          settings: {
+            theme: "light",
+            density: "comfortable",
+            accent: "#fff",
+            fontSizePx: 14,
+            interfaceFont: "Geist",
+            monoFont: "JetBrains Mono",
+          },
+        },
+      },
+      { connections: [conn({ id: "existing-1" })], tableLayouts: {} },
+    );
+
+    // duplicate -> replace; first new -> add; second new -> skip
+    plan.connections[0]!.decision = "replace";
+    plan.connections[1]!.decision = "add";
+    plan.connections[2]!.decision = "skip";
+
+    const saved: { id: string; password: string | null }[] = [];
+    let settingsApplied = false;
+    let layoutsApplied: Record<string, unknown> = {};
+
+    const result = await applyImportPlan(plan, {
+      existingConnectionIds: ["existing-1"],
+      saveConnection: async (config, password) => {
+        saved.push({ id: config.id, password });
+        return config;
+      },
+      importSettings: () => {
+        settingsApplied = true;
+      },
+      importTableLayouts: (entries) => {
+        layoutsApplied = entries;
+      },
+    });
+
+    expect(result.connectionsReplaced).toBe(1);
+    expect(result.connectionsAdded).toBe(1);
+    expect(result.connectionsSkipped).toBe(1);
+    expect(result.layoutsAdded).toBe(1);
+    expect(result.settingsApplied).toBe(true);
+    expect(settingsApplied).toBe(true);
+    expect(Object.keys(layoutsApplied)).toContain("x::a.b.c");
+
+    // Replace reuses the existing connection id; add never collides with it.
+    expect(saved.find((s) => s.id === "existing-1")).toBeDefined();
+    expect(saved.every((s) => s.password === null)).toBe(true);
+    expect(saved).toHaveLength(2); // skipped one never saved
+  });
+});

--- a/apps/desktop/src/lib/setupTransfer.ts
+++ b/apps/desktop/src/lib/setupTransfer.ts
@@ -1,0 +1,465 @@
+// Share-your-setup import/export. Builds a portable JSON "setup bundle" out of
+// the user's connections, appearance settings, and per-table grid layouts, and
+// merges a bundle back in with per-item review + duplicate detection.
+//
+// Security: passwords are never part of a bundle. Connection secrets live in
+// the OS keychain, not in `ConnectionConfig`, and `coerceConnection` rebuilds
+// each connection from a known field allowlist so a hand-edited bundle can't
+// smuggle a `password` field back into the app.
+
+import type { ConnectionConfig, Engine, EnvTag, SslMode } from "@cellar/ipc";
+import type { GridColumnLayout } from "@cellar/data-grid";
+import type { TableLayouts } from "../state/tabs";
+import { DEFAULTS as SETTINGS_DEFAULTS, sanitize as sanitizeSettings, type Settings } from "./settings";
+
+export const SETUP_FORMAT = "cellar.setup";
+export const SETUP_VERSION = 1;
+
+export type SetupSectionKey = "settings" | "connections" | "tableLayouts";
+
+export interface SetupBundle {
+  format: typeof SETUP_FORMAT;
+  version: number;
+  exportedAt: string;
+  app: string;
+  sections: {
+    settings?: Settings;
+    connections?: ConnectionConfig[];
+    tableLayouts?: TableLayouts;
+  };
+}
+
+export type SetupSelection = Record<SetupSectionKey, boolean>;
+
+export interface SetupSources {
+  settings: Settings;
+  connections: ConnectionConfig[];
+  tableLayouts: TableLayouts;
+}
+
+const ENGINES: Engine[] = [
+  "postgres",
+  "mysql",
+  "sqlite",
+  "mssql",
+  "azure",
+  "firestore",
+];
+const SSL_MODES: SslMode[] = [
+  "disable",
+  "prefer",
+  "require",
+  "verify-ca",
+  "verify-full",
+];
+const ENV_TAGS: EnvTag[] = ["local", "dev", "staging", "prod"];
+const THEMES: Settings["theme"][] = ["system", "dark", "light"];
+const DENSITIES: Settings["density"][] = ["compact", "comfortable"];
+
+// ---------------------------------------------------------------------------
+// Build (export)
+// ---------------------------------------------------------------------------
+
+export function buildBundle(
+  selection: SetupSelection,
+  sources: SetupSources,
+  meta: { app: string; exportedAt: string },
+): SetupBundle {
+  const sections: SetupBundle["sections"] = {};
+  if (selection.settings) {
+    sections.settings = sanitizeSettings({
+      ...SETTINGS_DEFAULTS,
+      ...sources.settings,
+    });
+  }
+  if (selection.connections) {
+    sections.connections = sources.connections
+      .map(coerceConnection)
+      .filter((c): c is ConnectionConfig => c !== null);
+  }
+  if (selection.tableLayouts) {
+    sections.tableLayouts = coerceTableLayouts(sources.tableLayouts);
+  }
+  return {
+    format: SETUP_FORMAT,
+    version: SETUP_VERSION,
+    exportedAt: meta.exportedAt,
+    app: meta.app,
+    sections,
+  };
+}
+
+export function serializeBundle(bundle: SetupBundle): string {
+  return JSON.stringify(bundle, null, 2);
+}
+
+/** Count of items per section, for UI summaries. */
+export function sectionCounts(sources: SetupSources): Record<SetupSectionKey, number> {
+  return {
+    settings: 1,
+    connections: sources.connections.length,
+    tableLayouts: Object.keys(sources.tableLayouts).length,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Parse (import)
+// ---------------------------------------------------------------------------
+
+export type ParseResult =
+  | { ok: true; bundle: SetupBundle }
+  | { ok: false; error: string };
+
+export function parseBundle(text: string): ParseResult {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch {
+    return { ok: false, error: "That doesn't look like valid JSON." };
+  }
+  if (!raw || typeof raw !== "object") {
+    return { ok: false, error: "The file is empty or not a setup bundle." };
+  }
+  const obj = raw as Record<string, unknown>;
+  if (obj.format !== SETUP_FORMAT) {
+    return {
+      ok: false,
+      error: "Not a Cellar setup file (missing the cellar.setup marker).",
+    };
+  }
+  const version = typeof obj.version === "number" ? obj.version : 0;
+  if (version > SETUP_VERSION) {
+    return {
+      ok: false,
+      error: `This file was exported by a newer Cellar (v${version}). Update Cellar to import it.`,
+    };
+  }
+
+  const sectionsRaw =
+    obj.sections && typeof obj.sections === "object"
+      ? (obj.sections as Record<string, unknown>)
+      : {};
+  const sections: SetupBundle["sections"] = {};
+
+  if (sectionsRaw.settings && typeof sectionsRaw.settings === "object") {
+    sections.settings = coerceSettings(
+      sectionsRaw.settings as Record<string, unknown>,
+    );
+  }
+  if (Array.isArray(sectionsRaw.connections)) {
+    sections.connections = sectionsRaw.connections
+      .map(coerceConnection)
+      .filter((c): c is ConnectionConfig => c !== null);
+  }
+  if (sectionsRaw.tableLayouts && typeof sectionsRaw.tableLayouts === "object") {
+    sections.tableLayouts = coerceTableLayouts(sectionsRaw.tableLayouts);
+  }
+
+  const hasSettings = Boolean(sections.settings);
+  const hasConnections = Boolean(sections.connections?.length);
+  const hasLayouts =
+    Boolean(sections.tableLayouts) &&
+    Object.keys(sections.tableLayouts ?? {}).length > 0;
+  if (!hasSettings && !hasConnections && !hasLayouts) {
+    return { ok: false, error: "This file has no importable sections." };
+  }
+
+  return {
+    ok: true,
+    bundle: {
+      format: SETUP_FORMAT,
+      version,
+      exportedAt: typeof obj.exportedAt === "string" ? obj.exportedAt : "",
+      app: typeof obj.app === "string" ? obj.app : "",
+      sections,
+    },
+  };
+}
+
+/**
+ * Rebuild a `ConnectionConfig` from a known field allowlist. Returns null if it
+ * lacks the minimum to be usable. This is the choke point that guarantees no
+ * secret/extra field survives a round-trip.
+ */
+function coerceConnection(raw: unknown): ConnectionConfig | null {
+  if (!raw || typeof raw !== "object") return null;
+  const c = raw as Record<string, unknown>;
+  const host = asString(c.host);
+  const name = asString(c.name);
+  const id = asString(c.id);
+  // Need at least something to identify and reach the server.
+  if (!host && !name && !id) return null;
+  return {
+    id,
+    name: name || host,
+    engine: ENGINES.includes(c.engine as Engine) ? (c.engine as Engine) : "postgres",
+    host,
+    port: Number.isFinite(Number(c.port)) ? Number(c.port) : 0,
+    database: asString(c.database),
+    user: asString(c.user),
+    ssl_mode: SSL_MODES.includes(c.ssl_mode as SslMode)
+      ? (c.ssl_mode as SslMode)
+      : "prefer",
+    env_tag: ENV_TAGS.includes(c.env_tag as EnvTag) ? (c.env_tag as EnvTag) : null,
+    application_name: c.application_name != null ? asString(c.application_name) : null,
+    color: c.color != null ? asString(c.color) : null,
+  };
+}
+
+function coerceSettings(raw: Record<string, unknown>): Settings {
+  const picked: Partial<Settings> = {};
+  if (THEMES.includes(raw.theme as Settings["theme"])) {
+    picked.theme = raw.theme as Settings["theme"];
+  }
+  if (DENSITIES.includes(raw.density as Settings["density"])) {
+    picked.density = raw.density as Settings["density"];
+  }
+  if (typeof raw.accent === "string") picked.accent = raw.accent;
+  if (typeof raw.fontSizePx === "number") picked.fontSizePx = raw.fontSizePx;
+  if (typeof raw.interfaceFont === "string") picked.interfaceFont = raw.interfaceFont;
+  if (typeof raw.monoFont === "string") picked.monoFont = raw.monoFont;
+  return sanitizeSettings({ ...SETTINGS_DEFAULTS, ...picked });
+}
+
+/** Mirror of `loadTableLayouts` coercion in state/tabs.ts. */
+function coerceTableLayouts(raw: unknown): TableLayouts {
+  const out: TableLayouts = {};
+  if (!raw || typeof raw !== "object") return out;
+  for (const [key, value] of Object.entries(raw)) {
+    if (!value || typeof value !== "object") continue;
+    const item = value as Partial<GridColumnLayout>;
+    out[key] = {
+      order: Array.isArray(item.order)
+        ? item.order.filter((k): k is string => typeof k === "string")
+        : [],
+      widths:
+        item.widths && typeof item.widths === "object"
+          ? Object.fromEntries(
+              Object.entries(item.widths).filter(
+                ([k, w]) => typeof k === "string" && typeof w === "number",
+              ),
+            )
+          : {},
+    };
+  }
+  return out;
+}
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value : value == null ? "" : String(value);
+}
+
+// ---------------------------------------------------------------------------
+// Import plan (per-item review)
+// ---------------------------------------------------------------------------
+
+export type ConnDecision = "skip" | "add" | "replace" | "copy";
+export type LayoutDecision = "skip" | "add" | "replace";
+
+export interface ConnImportItem {
+  incoming: ConnectionConfig;
+  identity: string;
+  /** Existing connection with the same identity, if any. */
+  duplicateOfId: string | null;
+  duplicateOfName: string | null;
+  decision: ConnDecision;
+}
+
+export interface LayoutImportItem {
+  key: string;
+  /** `database.schema.table` parsed from the storage key, for display. */
+  tablePath: string;
+  connectionId: string;
+  layout: GridColumnLayout;
+  exists: boolean;
+  decision: LayoutDecision;
+}
+
+export interface SettingsImportItem {
+  settings: Settings;
+  apply: boolean;
+}
+
+export interface ImportPlan {
+  connections: ConnImportItem[];
+  layouts: LayoutImportItem[];
+  settings: SettingsImportItem | null;
+}
+
+export function connectionIdentity(c: ConnectionConfig): string {
+  const norm = (s: string) => s.trim().toLowerCase();
+  return [c.engine, norm(c.host), c.port, norm(c.database), norm(c.user)].join("|");
+}
+
+export function tablePathFromKey(key: string): string {
+  const idx = key.indexOf("::");
+  return idx >= 0 ? key.slice(idx + 2) : key;
+}
+
+export function connectionIdFromKey(key: string): string {
+  const idx = key.indexOf("::");
+  return idx >= 0 ? key.slice(0, idx) : "";
+}
+
+export function computeImportPlan(
+  bundle: SetupBundle,
+  current: { connections: ConnectionConfig[]; tableLayouts: TableLayouts },
+): ImportPlan {
+  const byIdentity = new Map<string, ConnectionConfig>();
+  for (const c of current.connections) {
+    byIdentity.set(connectionIdentity(c), c);
+  }
+
+  const connections: ConnImportItem[] = (bundle.sections.connections ?? []).map(
+    (incoming) => {
+      const identity = connectionIdentity(incoming);
+      const dup = byIdentity.get(identity) ?? null;
+      return {
+        incoming,
+        identity,
+        duplicateOfId: dup?.id ?? null,
+        duplicateOfName: dup?.name ?? null,
+        // Don't import the same thing twice by default.
+        decision: dup ? "skip" : "add",
+      };
+    },
+  );
+
+  const layouts: LayoutImportItem[] = Object.entries(
+    bundle.sections.tableLayouts ?? {},
+  ).map(([key, layout]) => {
+    const exists = Object.prototype.hasOwnProperty.call(
+      current.tableLayouts,
+      key,
+    );
+    return {
+      key,
+      tablePath: tablePathFromKey(key),
+      connectionId: connectionIdFromKey(key),
+      layout,
+      exists,
+      decision: exists ? "skip" : "add",
+    };
+  });
+
+  const settings = bundle.sections.settings
+    ? { settings: bundle.sections.settings, apply: true }
+    : null;
+
+  return { connections, layouts, settings };
+}
+
+// ---------------------------------------------------------------------------
+// Id allocation
+// ---------------------------------------------------------------------------
+
+export function slugifyId(s: string): string {
+  return (
+    s
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 64) || "connection"
+  );
+}
+
+export function uniqueConnectionId(base: string, taken: Set<string>): string {
+  const slug = slugifyId(base);
+  if (!taken.has(slug)) return slug;
+  let n = 2;
+  while (taken.has(`${slug}-${n}`)) n += 1;
+  return `${slug}-${n}`;
+}
+
+// ---------------------------------------------------------------------------
+// Apply
+// ---------------------------------------------------------------------------
+
+export interface ImportDeps {
+  existingConnectionIds: string[];
+  saveConnection: (
+    config: ConnectionConfig,
+    password: string | null,
+  ) => Promise<unknown>;
+  importSettings: (settings: Partial<Settings>) => void;
+  importTableLayouts: (entries: TableLayouts) => void;
+}
+
+export interface ImportResult {
+  connectionsAdded: number;
+  connectionsReplaced: number;
+  connectionsSkipped: number;
+  layoutsAdded: number;
+  layoutsReplaced: number;
+  layoutsSkipped: number;
+  settingsApplied: boolean;
+}
+
+export async function applyImportPlan(
+  plan: ImportPlan,
+  deps: ImportDeps,
+): Promise<ImportResult> {
+  const result: ImportResult = {
+    connectionsAdded: 0,
+    connectionsReplaced: 0,
+    connectionsSkipped: 0,
+    layoutsAdded: 0,
+    layoutsReplaced: 0,
+    layoutsSkipped: 0,
+    settingsApplied: false,
+  };
+
+  const taken = new Set(deps.existingConnectionIds);
+
+  // Sequential so generated ids stay deterministic and collision-free.
+  for (const item of plan.connections) {
+    if (item.decision === "skip") {
+      result.connectionsSkipped += 1;
+      continue;
+    }
+    if (item.decision === "replace" && item.duplicateOfId) {
+      // Reuse the existing id so the keychain password (kept by passing null)
+      // and any open state stay attached to the same connection.
+      await deps.saveConnection(
+        { ...item.incoming, id: item.duplicateOfId },
+        null,
+      );
+      result.connectionsReplaced += 1;
+      continue;
+    }
+
+    const isCopy = item.decision === "copy";
+    const name = isCopy
+      ? `${item.incoming.name} (imported)`
+      : item.incoming.name || item.incoming.host;
+    const preferredId = isCopy ? "" : item.incoming.id;
+    const id =
+      preferredId && !taken.has(preferredId)
+        ? preferredId
+        : uniqueConnectionId(name || preferredId || "connection", taken);
+    taken.add(id);
+    await deps.saveConnection({ ...item.incoming, id, name }, null);
+    result.connectionsAdded += 1;
+  }
+
+  const layoutsToApply: TableLayouts = {};
+  for (const item of plan.layouts) {
+    if (item.decision === "skip") {
+      result.layoutsSkipped += 1;
+      continue;
+    }
+    layoutsToApply[item.key] = item.layout;
+    if (item.decision === "replace") result.layoutsReplaced += 1;
+    else result.layoutsAdded += 1;
+  }
+  if (Object.keys(layoutsToApply).length > 0) {
+    deps.importTableLayouts(layoutsToApply);
+  }
+
+  if (plan.settings?.apply) {
+    deps.importSettings(plan.settings.settings);
+    result.settingsApplied = true;
+  }
+
+  return result;
+}

--- a/apps/desktop/src/state/tabs.ts
+++ b/apps/desktop/src/state/tabs.ts
@@ -63,6 +63,8 @@ interface TabsStore {
   reorderTab: (sourceId: string, targetId: string) => void;
   setActive: (id: string) => void;
   setTableLayout: (id: string, layout: GridColumnLayout) => void;
+  /** Merge imported per-table layouts over the current ones and persist. */
+  importTableLayouts: (entries: TableLayouts) => void;
   setTableChanges: (id: string, changes: PendingChanges) => void;
   clearTableChanges: (id: string) => void;
   refreshTable: (id: string) => void;
@@ -372,6 +374,14 @@ export const useTabs = create<TabsStore>((set, get) => ({
   setTableLayout(id, layout) {
     set((s) => {
       const tableLayouts = { ...s.tableLayouts, [id]: layout };
+      saveTableLayouts(tableLayouts);
+      return { tableLayouts };
+    });
+  },
+
+  importTableLayouts(entries) {
+    set((s) => {
+      const tableLayouts = { ...s.tableLayouts, ...entries };
       saveTableLayouts(tableLayouts);
       return { tableLayouts };
     });


### PR DESCRIPTION
## Summary

Adds a **share-your-setup** import/export feature so users can export their Cellar configuration to a portable JSON file and import someone else's — connections, appearance settings, and per-table grid layouts. Entry points: Settings → *Backups & exports* → Transfer setup, and the ⌘K command palette ("Export setup…" / "Import setup…").

## What changed

- **Export** (`ExportSetupModal.tsx`): choose sections (Appearance & settings, Connections, Table grid layouts) → **Download .json** with a **Copy JSON** fallback. Empty sections are disabled; a notice states passwords are never exported.
- **Import** (`ImportSetupModal.tsx`): load a file or paste JSON → **per-item review**. Each connection is flagged `NEW` or `DUP OF …`, each layout `NEW`/`EXISTS`, with per-item Add/Skip/Replace/Add-copy decisions plus bulk actions, then a result summary.
- **Core logic** (`setupTransfer.ts`): bundle build/parse/validate, duplicate detection (engine/host/port/database/user), import-plan computation and apply. Fully unit-tested (`setupTransfer.test.ts`, 13 tests).
- **Reused IPC + state**: `saveConnection`/`listConnections`, new `importSettings` on the settings context, and `importTableLayouts` on the tabs store. No backend/Tauri changes, no new native permissions.
- **Button fix** (`settingsPrimitives.tsx`): the shared `ED_RUN_PRIMARY` accent button was rendering light text because `ED_RUN_BASE` baked in `text-fg-1`, which won over `text-accent-fg`. Moved the color onto each variant so accent (primary) buttons use the intended near-black `--accent-fg`.

## User impact

- Move your setup between machines or share it with teammates via a single JSON file.
- Imports are non-destructive and reviewable: duplicates are skipped by default so nothing imports twice.
- **No secrets leave the app** — passwords/API keys live in the OS keychain and are never written to the bundle; imported connections are password-less until you re-enter credentials. (Replacing an existing connection preserves its stored password.)

## Validation

- `pnpm --filter @cellar/desktop typecheck` — pass
- `pnpm --filter @cellar/desktop test` — 59 tests pass (13 new)
- `pnpm --filter @cellar/desktop build` — pass
- `pnpm lint` — pass
- Manually drove export + import end-to-end in the web preview, including live duplicate detection on a second import and the button-color fix (verified `color: rgb(10,11,14)` on the purple button).

## Known notes / follow-ups

- Table-layout keys embed the exporter's connection id, so a layout imported without its connection won't bind until a matching connection exists (the review list shows the raw table path, so it's visible). Remapping is out of scope for this slice.
- Pre-existing Vite warning: main JS chunk > 500 kB (not introduced by this change).