### PR TITLE
fix: close orphaned tabs when a connection is removed

### DIFF
--- a/apps/desktop/src/state/connections.ts
+++ b/apps/desktop/src/state/connections.ts
@@ -5,6 +5,7 @@ import type {
   DriverInfo,
 } from "@cellar/ipc";
 import { create } from "zustand";
+import { useTabs } from "./tabs";
 
 export type ConnStatus = "connected" | "connecting" | "disconnected" | "error";
 
@@ -94,6 +95,10 @@ export const useConnections = create<ConnectionsStore>((set, get) => ({
         byId: rest,
       };
     });
+    // Tear down any workspace tabs left pointing at the now-deleted
+    // connection — otherwise they linger in the tab bar and error the moment
+    // they are touched, making the connection look like it was never removed.
+    useTabs.getState().closeConnectionTabs(id);
   },
 
   async connect(id) {

--- a/apps/desktop/src/state/tabs.test.ts
+++ b/apps/desktop/src/state/tabs.test.ts
@@ -114,6 +114,41 @@ describe("tab workspace state", () => {
     expect(useTabResults.getState().byTabId[keepId]?.status).toBe("loading");
   });
 
+  it("closes every tab for a removed connection and keeps others intact", () => {
+    const store = useTabs.getState();
+    store.openTable("conn-1", "app", "public", "orders");
+    const goneQuery = useTabs.getState().newQueryTab("conn-1", "app");
+    const keepId = useTabs.getState().newQueryTab("conn-2", "analytics");
+
+    const goneTable = "conn-1::app.public.orders";
+    useTabs.getState().setTableChanges(goneTable, changes);
+    useTabs.getState().refreshTable(goneTable);
+    useTabResults.getState().setLoading(goneTable, source);
+
+    useTabs.getState().closeConnectionTabs("conn-1");
+
+    expect(useTabs.getState().tabs.map((t) => t.id)).toEqual([keepId]);
+    expect(useTabs.getState().activeId).toBe(keepId);
+    expect(
+      useTabs.getState().tabs.some((t) => t.id === goneQuery),
+    ).toBe(false);
+    expect(useTabs.getState().tableChanges[goneTable]).toBeUndefined();
+    expect(useTabs.getState().refreshKeys[goneTable]).toBeUndefined();
+    expect(useTabResults.getState().byTabId[goneTable]).toBeUndefined();
+  });
+
+  it("does not resurrect a removed connection's tab via reopen", () => {
+    const id = useTabs.getState().newQueryTab("conn-1", "app");
+    useTabs.getState().closeTab(id);
+    expect(useTabs.getState().closedTabs).toHaveLength(1);
+
+    useTabs.getState().closeConnectionTabs("conn-1");
+    expect(useTabs.getState().closedTabs).toHaveLength(0);
+
+    useTabs.getState().reopenClosedTab();
+    expect(useTabs.getState().tabs).toHaveLength(0);
+  });
+
   it("moves focus left when closing tabs to the right of a tab", () => {
     const store = useTabs.getState();
     store.openTable("conn-1", "app", "public", "orders");

--- a/apps/desktop/src/state/tabs.ts
+++ b/apps/desktop/src/state/tabs.ts
@@ -60,6 +60,7 @@ interface TabsStore {
   clearSplit: () => void;
   closeOtherTabs: (id: string) => void;
   closeTabsToRight: (id: string) => void;
+  closeConnectionTabs: (connectionId: string) => void;
   reorderTab: (sourceId: string, targetId: string) => void;
   setActive: (id: string) => void;
   setTableLayout: (id: string, layout: GridColumnLayout) => void;
@@ -296,6 +297,37 @@ export const useTabs = create<TabsStore>((set, get) => ({
       };
     });
     clearTabResults(closedIds);
+  },
+
+  closeConnectionTabs(connectionId) {
+    const removedIds = get()
+      .tabs.filter((t) => t.connectionId === connectionId)
+      .map((t) => t.id);
+    set((s) => {
+      const removed = new Set(removedIds);
+      const tabs = s.tabs.filter((t) => !removed.has(t.id));
+      const activeId = removed.has(s.activeId ?? "")
+        ? tabs[tabs.length - 1]?.id ?? null
+        : s.activeId;
+      const { tableChanges, refreshKeys } = dropTabScopedState(
+        removedIds,
+        s.tableChanges,
+        s.refreshKeys,
+      );
+      return {
+        tabs,
+        activeId,
+        // Drop the connection's tabs from the reopen stack too, so undo-close
+        // can't resurrect a tab that points at a connection that no longer exists.
+        closedTabs: s.closedTabs.filter(
+          (t) => t.connectionId !== connectionId,
+        ),
+        split: splitForTabs(tabs, s.split),
+        tableChanges,
+        refreshKeys,
+      };
+    });
+    if (removedIds.length > 0) clearTabResults(removedIds);
   },
 
   reorderTab(sourceId, targetId) {


### PR DESCRIPTION
## Summary

Fixes #44 — removing a connection didn't trigger the correct cleanup, so the database appeared to stick around.

The delete path itself was sound (sidebar → store → IPC → Rust registry drops the config, closes the pool, clears the schema cache, persists). The gap was in the frontend workspace: nothing closed the tabs belonging to the removed connection. Those tabs — with their cached results and pending edits — lingered in the tab bar and errored with "no open connection" the moment they were touched. From the user's view, the database was never really removed.

## What changed

- **`apps/desktop/src/state/tabs.ts`** — new `closeConnectionTabs(connectionId)` action: closes every tab for the connection, reassigns the active tab, clears scoped state (pending changes, refresh keys, cached results), fixes up any split, and prunes the tabs from the reopen stack so undo-close can't resurrect a tab pointing at a deleted connection.
- **`apps/desktop/src/state/connections.ts`** — `deleteConnection` now calls `closeConnectionTabs(id)` after the backend confirms the delete, keeping the cleanup centralized in the store (the single place removal happens).
- **`apps/desktop/src/state/tabs.test.ts`** — two new tests: closes all tabs for a removed connection while leaving other connections' tabs intact; does not resurrect a removed connection's tab via reopen.

## User impact

Removing a connection now also tears down its open tabs and their state, so the database fully disappears from the workspace instead of leaving behind dead, error-prone tabs.

## Validation

- `pnpm --filter @cellar/desktop test` → 48 passed (incl. 2 new)
- `pnpm --filter @cellar/desktop typecheck` → clean

## Known follow-ups

- The Sidebar's `void deleteConnection(...)` still swallows backend errors, so a genuine delete failure (e.g. disk write) would surface no feedback. Separate robustness gap, not part of this fix — can wire it into the notices system in a follow-up.