### PR TITLE
feat: add Settings to macOS app menu and move gear to sidebar

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod commands;
 pub mod history;
+pub mod menu;
 pub mod state;
 
 use history::HistoryStore;
@@ -19,6 +20,7 @@ pub fn run() {
         .invoke_handler(invoke_handler)
         .setup(move |app| {
             builder.mount_events(app);
+            menu::setup(app.handle())?;
             Ok(())
         })
         .run(tauri::generate_context!())

--- a/apps/desktop/src-tauri/src/menu.rs
+++ b/apps/desktop/src-tauri/src/menu.rs
@@ -1,0 +1,52 @@
+//! Native application menu.
+//!
+//! macOS renders a system menu bar; everywhere else Cellar drives its chrome
+//! from the custom React title bar. So on macOS we take Tauri's default menu
+//! (which already wires up About, Services, Hide/Quit, Edit, View, and Window)
+//! and only add a "Settings…" item to the app menu. Selecting it emits
+//! [`SETTINGS_EVENT`] to the frontend, which opens the same settings modal as
+//! the in-app `⌘,` shortcut and the sidebar gear.
+
+/// Event emitted to the frontend when the app-menu "Settings…" item is chosen.
+/// The frontend listens for this and opens the settings modal.
+#[cfg(target_os = "macos")]
+pub const SETTINGS_EVENT: &str = "menu://settings";
+
+/// Install the native macOS menu with a "Settings…" item wired to
+/// [`SETTINGS_EVENT`]. No-op on other platforms.
+#[cfg(target_os = "macos")]
+pub fn setup(app: &tauri::AppHandle) -> tauri::Result<()> {
+    use tauri::menu::{Menu, MenuItemBuilder, PredefinedMenuItem};
+    use tauri::Emitter;
+
+    let menu = Menu::default(app)?;
+
+    let settings = MenuItemBuilder::new("Settings…")
+        .id("settings")
+        .accelerator("Cmd+,")
+        .build(app)?;
+
+    // The first submenu is the app ("Cellar") menu. Its default layout starts
+    // `About / ─── / Services / …`; slot `Settings… / ───` in after the first
+    // separator, the conventional macOS location for Settings.
+    let items = menu.items()?;
+    if let Some(app_menu) = items.first().and_then(|item| item.as_submenu()) {
+        app_menu.insert(&settings, 2)?;
+        app_menu.insert(&PredefinedMenuItem::separator(app)?, 3)?;
+    }
+
+    app.set_menu(menu)?;
+    app.on_menu_event(move |app, event| {
+        if event.id() == "settings" {
+            let _ = app.emit(SETTINGS_EVENT, ());
+        }
+    });
+
+    Ok(())
+}
+
+/// No native menu on non-macOS platforms; the React title bar owns the chrome.
+#[cfg(not(target_os = "macos"))]
+pub fn setup(_app: &tauri::AppHandle) -> tauri::Result<()> {
+    Ok(())
+}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
-import type { ConnectionConfig } from "@cellar/ipc";
+import { listen } from "@tauri-apps/api/event";
+import { isTauri, type ConnectionConfig } from "@cellar/ipc";
 import { TitleBar } from "./components/TitleBar";
 import { StatusBar } from "./components/StatusBar";
 import { Sidebar } from "./components/Sidebar";
@@ -157,6 +158,14 @@ export function App() {
     return () => window.removeEventListener("keydown", onKey);
   }, []);
 
+  // The native macOS app menu's "Settings…" item (see src-tauri/src/menu.rs)
+  // emits this event; open the same modal as the in-app ⌘, shortcut.
+  useEffect(() => {
+    if (!isTauri) return;
+    const unlisten = listen("menu://settings", () => openSettings());
+    return () => void unlisten.then((off) => off());
+  }, [openSettings]);
+
   return (
     <div className="flex h-full w-full flex-col bg-bg-0">
       <TitleBar
@@ -165,7 +174,6 @@ export function App() {
         empty={empty}
         onToggleEmpty={() => setEmpty((v) => !v)}
         onOpenPalette={() => openModal("palette")}
-        onOpenSettings={() => openSettings()}
       />
 
       <div className="flex flex-1 min-h-0">
@@ -179,6 +187,7 @@ export function App() {
                 onNewConnection={openNewConnection}
                 onEditConnection={editConnection}
                 onDuplicateConnection={duplicateConnection}
+                onOpenSettings={() => openSettings()}
               />
             </div>
             <ResizeHandle

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -32,12 +32,14 @@ export interface SidebarProps {
   onNewConnection?: () => void;
   onEditConnection?: (config: ConnectionConfig) => void;
   onDuplicateConnection?: (config: ConnectionConfig) => void;
+  onOpenSettings?: () => void;
 }
 
 export function Sidebar({
   onNewConnection,
   onEditConnection,
   onDuplicateConnection,
+  onOpenSettings,
 }: SidebarProps = {}) {
   const [filter, setFilter] = useState("");
   const [menu, setMenu] = useState<ContextMenuState | null>(null);
@@ -475,6 +477,18 @@ export function Sidebar({
           );
         })}
 
+      </div>
+
+      <div className="flex shrink-0 items-center border-t border-border-default px-2 py-1.5">
+        <button
+          type="button"
+          onClick={onOpenSettings}
+          title="Settings (⌘,)"
+          className="flex items-center gap-1.5 rounded-[4px] px-1.5 py-1 text-[11.5px] text-fg-2 transition-colors duration-150 hover:bg-bg-2 hover:text-fg-0"
+        >
+          <Icon.settings size={13} />
+          <span>Settings</span>
+        </button>
       </div>
 
       <ContextMenu state={menu} onClose={() => setMenu(null)} />

--- a/apps/desktop/src/components/TitleBar.tsx
+++ b/apps/desktop/src/components/TitleBar.tsx
@@ -32,14 +32,12 @@ export function TitleBar({
   empty,
   onToggleEmpty,
   onOpenPalette,
-  onOpenSettings,
 }: {
   panels: Panels;
   onTogglePanel: (k: PanelId) => void;
   empty?: boolean;
   onToggleEmpty?: () => void;
   onOpenPalette?: () => void;
-  onOpenSettings?: () => void;
 }) {
   const activeId = useTabs((s) => s.activeId);
   const tabs = useTabs((s) => s.tabs);
@@ -169,14 +167,6 @@ export function TitleBar({
             <Icon.layout size={13} />
           </button>
         )}
-        <button
-          type="button"
-          className="icon-btn"
-          onClick={onOpenSettings}
-          title="Settings (⌘,)"
-        >
-          <Icon.settings size={13} />
-        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Implements #50. Settings is now reachable from the native macOS **Cellar** app menu, and the settings gear has moved from the top-right title bar to the bottom of the left sidebar.

## What changed

- **`apps/desktop/src-tauri/src/menu.rs`** (new): On macOS, takes Tauri's default menu and inserts a `Settings…` item (⌘,) into the app menu in its conventional spot — `About / ─── / Settings… / ─── / Services / …`. Selecting it emits a `menu://settings` event. Gated to macOS (`#[cfg(target_os = "macos")]`); no-op elsewhere, where the React title bar owns the chrome.
- **`lib.rs`**: Calls `menu::setup` during Tauri setup.
- **`App.tsx`**: Listens for `menu://settings` (guarded by `isTauri`, listener cleaned up on unmount) and opens the same modal as the in-app ⌘, shortcut.
- **`TitleBar.tsx`**: Removed the settings gear and its `onOpenSettings` prop.
- **`Sidebar.tsx`**: Added a labeled **Settings** button pinned to the bottom of the sidebar, separated by a top border.

## User impact

Settings is now reachable four ways on macOS: the Cellar menu, ⌘,, the command palette, and the sidebar footer. When the left panel is collapsed the sidebar button is hidden, but the menu, ⌘,, and command palette still reach it — so it's never stranded.

## Validation

- `cargo check -p cellar-desktop` ✓
- `cargo fmt --all --check` ✓
- `cargo clippy -p cellar-desktop` — no new warnings (one pre-existing warning in `query.rs`, unrelated)
- `pnpm typecheck` ✓ (desktop + site)
- Desktop vitest: 61 tests passing ✓

## Follow-ups

- Recommend a quick `pnpm tauri dev` on a Mac to eyeball the menu placement, since the GUI couldn't be launched in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)