### PR TITLE
feat: wire up Gemini AI assistant

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -14,6 +14,7 @@
     "tauri": "tauri"
   },
   "dependencies": {
+    "@cellar/ai": "workspace:*",
     "@cellar/data-grid": "workspace:*",
     "@cellar/ipc": "workspace:*",
     "@cellar/sql-editor": "workspace:*",

--- a/apps/desktop/src-tauri/src/commands/ai.rs
+++ b/apps/desktop/src-tauri/src/commands/ai.rs
@@ -1,0 +1,48 @@
+//! AI provider key storage (SPEC §6.7, §7).
+//!
+//! Cellar is bring-your-own-key: the provider API key is stored in the OS
+//! keychain via [`cellar_secrets`], never written to disk or config, and never
+//! logged. The actual provider HTTP call happens in the frontend (SPEC §3), so
+//! [`ai_load_key`] hands the key back to the renderer at request time only.
+//!
+//! Keys are namespaced `ai:<provider>` so they cannot collide with connection
+//! credentials, which key on the connection id.
+
+use cellar_core::error::CellarError;
+
+fn entry_name(provider: &str) -> String {
+    format!("ai:{provider}")
+}
+
+/// Persist the API key for `provider` in the OS keychain, overwriting any
+/// existing entry.
+#[tauri::command]
+#[specta::specta]
+pub async fn ai_store_key(provider: String, key: String) -> Result<(), CellarError> {
+    cellar_secrets::store(&entry_name(&provider), &key)?;
+    Ok(())
+}
+
+/// Load the stored API key for `provider`. Returns `None` when nothing is
+/// stored, which is distinct from a keychain failure.
+#[tauri::command]
+#[specta::specta]
+pub async fn ai_load_key(provider: String) -> Result<Option<String>, CellarError> {
+    Ok(cellar_secrets::load(&entry_name(&provider))?)
+}
+
+/// Remove the stored API key for `provider`. A no-op if none exists.
+#[tauri::command]
+#[specta::specta]
+pub async fn ai_delete_key(provider: String) -> Result<(), CellarError> {
+    cellar_secrets::delete(&entry_name(&provider))?;
+    Ok(())
+}
+
+/// Report whether a key is stored for `provider` without returning it — used by
+/// settings to show "configured" state.
+#[tauri::command]
+#[specta::specta]
+pub async fn ai_has_key(provider: String) -> Result<bool, CellarError> {
+    Ok(cellar_secrets::load(&entry_name(&provider))?.is_some())
+}

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -5,6 +5,7 @@
 //! 2. Add it to [`collect`] below so `tauri-specta` generates a typed wrapper
 //!    and the invoke handler picks it up.
 
+pub mod ai;
 pub mod connection;
 pub mod history;
 pub mod query;
@@ -33,6 +34,10 @@ pub fn builder() -> Builder<tauri::Wry> {
         transaction::preview_table_changes,
         transaction::commit_table_changes,
         history::list_query_history,
+        ai::ai_store_key,
+        ai::ai_load_key,
+        ai::ai_delete_key,
+        ai::ai_has_key,
     ])
 }
 

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -415,16 +415,34 @@ fn reconnectable_error(err: CellarError) -> CellarError {
 }
 
 fn find_table(dbs: &[Database], database: &str, schema: &str, table: &str) -> CellarResult<Table> {
-    dbs.iter()
+    let schema_meta = dbs
+        .iter()
         .find(|db| db.name == database)
-        .and_then(|db| db.schemas.iter().find(|s| s.name == schema))
-        .and_then(|s| s.tables.iter().find(|t| t.name == table))
-        .cloned()
-        .ok_or_else(|| {
-            CellarError::invalid_config(format!(
-                "table {database}.{schema}.{table} was not found in schema metadata"
-            ))
-        })
+        .and_then(|db| db.schemas.iter().find(|s| s.name == schema));
+
+    if let Some(s) = schema_meta {
+        if let Some(t) = s.tables.iter().find(|t| t.name == table) {
+            return Ok(t.clone());
+        }
+        // Views are browsable on the read path too. They carry no primary key,
+        // foreign keys, or indexes, so we present the view as a Table with just
+        // its columns; the browse query falls back to unordered SELECT *.
+        if let Some(v) = s.views.iter().find(|v| v.name == table) {
+            return Ok(Table {
+                name: v.name.clone(),
+                schema: v.schema.clone(),
+                row_count: None,
+                columns: v.columns.clone(),
+                primary_key: Vec::new(),
+                foreign_keys: Vec::new(),
+                indexes: Vec::new(),
+            });
+        }
+    }
+
+    Err(CellarError::invalid_config(format!(
+        "table {database}.{schema}.{table} was not found in schema metadata"
+    )))
 }
 
 fn driver_for(engine: Engine) -> CellarResult<Box<dyn Driver>> {
@@ -463,4 +481,70 @@ async fn persist(configs: &HashMap<String, ConnectionConfig>) -> CellarResult<()
     let json = serde_json::to_string_pretty(&list)?;
     fs::write(&path, json).await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::find_table;
+    use cellar_core::schema::{Column, Database, Schema, Table, View};
+
+    fn column(name: &str, data_type: &str) -> Column {
+        Column {
+            name: name.into(),
+            data_type: data_type.into(),
+            nullable: true,
+            default: None,
+            is_primary_key: false,
+            ordinal: 1,
+            comment: None,
+        }
+    }
+
+    fn dbs() -> Vec<Database> {
+        vec![Database {
+            name: "shop".into(),
+            is_default: true,
+            schemas: vec![Schema {
+                name: "public".into(),
+                tables: vec![Table {
+                    name: "orders".into(),
+                    schema: "public".into(),
+                    row_count: None,
+                    columns: vec![column("id", "int4"), column("status", "order_status")],
+                    primary_key: vec!["id".into()],
+                    foreign_keys: Vec::new(),
+                    indexes: Vec::new(),
+                }],
+                views: vec![View {
+                    name: "customer_order_summary".into(),
+                    schema: "public".into(),
+                    columns: vec![column("email", "text"), column("total_spent", "numeric")],
+                    definition: None,
+                }],
+            }],
+        }]
+    }
+
+    #[test]
+    fn resolves_a_table() {
+        let table = find_table(&dbs(), "shop", "public", "orders").expect("table");
+        assert_eq!(table.name, "orders");
+        assert_eq!(table.primary_key, vec!["id".to_string()]);
+    }
+
+    #[test]
+    fn resolves_a_view_as_a_pkless_table() {
+        // Regression: views were never searched, so browsing one failed with
+        // "not found in schema metadata".
+        let view = find_table(&dbs(), "shop", "public", "customer_order_summary")
+            .expect("view should be browsable");
+        assert_eq!(view.name, "customer_order_summary");
+        assert!(view.primary_key.is_empty());
+        assert_eq!(view.columns.len(), 2);
+    }
+
+    #[test]
+    fn errors_on_unknown_relation() {
+        assert!(find_table(&dbs(), "shop", "public", "nope").is_err());
+    }
 }

--- a/apps/desktop/src/components/AIMessage.test.ts
+++ b/apps/desktop/src/components/AIMessage.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { parseSegments } from "./AIMessage";
+
+describe("parseSegments", () => {
+  it("returns a single text segment for plain prose", () => {
+    expect(parseSegments("just words")).toEqual([
+      { kind: "text", text: "just words" },
+    ]);
+  });
+
+  it("extracts a fenced sql block with its language", () => {
+    const segs = parseSegments("Here you go:\n```sql\nSELECT 1;\n```\nDone.");
+    expect(segs).toEqual([
+      { kind: "text", text: "Here you go:" },
+      { kind: "code", lang: "sql", code: "SELECT 1;" },
+      { kind: "text", text: "Done." },
+    ]);
+  });
+
+  it("handles a block with no language tag", () => {
+    const segs = parseSegments("```\nplain\n```");
+    expect(segs).toEqual([{ kind: "code", lang: "", code: "plain" }]);
+  });
+
+  it("handles multiple code blocks", () => {
+    const segs = parseSegments("```sql\nA\n```\nmid\n```sql\nB\n```");
+    expect(segs.filter((s) => s.kind === "code")).toHaveLength(2);
+  });
+});

--- a/apps/desktop/src/components/AIMessage.tsx
+++ b/apps/desktop/src/components/AIMessage.tsx
@@ -1,0 +1,118 @@
+import { useState } from "react";
+import { TOPICS } from "@cellar/ai";
+import { Icon } from "./icons";
+import type { AiChatEntry } from "../state/ai";
+
+/** A run of message content: either prose or a fenced code block. */
+type Segment =
+  | { kind: "text"; text: string }
+  | { kind: "code"; lang: string; code: string };
+
+const FENCE = /```([\w-]*)\n?([\s\S]*?)```/g;
+
+/** Split markdown-ish content into prose and fenced code blocks. We only need
+ * enough fidelity to render SQL in a mono box with a copy button. */
+export function parseSegments(content: string): Segment[] {
+  const out: Segment[] = [];
+  let last = 0;
+  let m: RegExpExecArray | null;
+  FENCE.lastIndex = 0;
+  while ((m = FENCE.exec(content)) !== null) {
+    if (m.index > last) {
+      const text = content.slice(last, m.index).trim();
+      if (text) out.push({ kind: "text", text });
+    }
+    out.push({ kind: "code", lang: m[1] || "", code: (m[2] ?? "").trim() });
+    last = m.index + m[0].length;
+  }
+  if (last < content.length) {
+    const text = content.slice(last).trim();
+    if (text) out.push({ kind: "text", text });
+  }
+  if (out.length === 0) out.push({ kind: "text", text: content });
+  return out;
+}
+
+function CodeBlock({ lang, code }: { lang: string; code: string }) {
+  const [copied, setCopied] = useState(false);
+  const copy = () => {
+    void navigator.clipboard?.writeText(code).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1200);
+    });
+  };
+  return (
+    <div className="overflow-hidden rounded-[5px] border border-border-default bg-bg-inset">
+      <div className="flex items-center justify-between border-b border-border-divider px-2 py-1">
+        <span className="font-mono text-[9.5px] uppercase tracking-[0.05em] text-fg-3">
+          {lang || "code"}
+        </span>
+        <button
+          onClick={copy}
+          className="inline-flex items-center gap-1 rounded-[3px] px-1 text-[10px] text-fg-2 hover:bg-bg-3 hover:text-fg-0"
+          title="Copy"
+        >
+          <Icon.copy size={10} />
+          <span>{copied ? "copied" : "copy"}</span>
+        </button>
+      </div>
+      <pre className="overflow-x-auto px-2.5 py-2 font-mono text-[11.5px] leading-[1.5] text-fg-0">
+        <code>{code}</code>
+      </pre>
+    </div>
+  );
+}
+
+export function AIMessage({ entry }: { entry: AiChatEntry }) {
+  if (entry.role === "user") {
+    return (
+      <div className="flex flex-col items-end gap-1">
+        <div className="max-w-[88%] rounded-[7px] rounded-tr-[2px] border border-accent-line bg-accent-soft px-2.5 py-1.5">
+          {entry.topic && entry.topic !== "ask" && (
+            <span className="mb-0.5 block font-mono text-[9.5px] uppercase tracking-[0.05em] text-accent opacity-80">
+              {TOPICS[entry.topic].label}
+            </span>
+          )}
+          <div className="whitespace-pre-wrap text-[12px] leading-[1.5] text-fg-0">
+            {entry.content || <span className="text-fg-3 italic">(empty)</span>}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (entry.error) {
+    return (
+      <div className="flex items-start gap-2 rounded-[6px] border border-delete-line bg-delete-bg px-2.5 py-2 text-[11.5px] text-delete">
+        <span className="mt-px shrink-0">
+          <Icon.warn size={12} />
+        </span>
+        <div className="whitespace-pre-wrap leading-[1.5]">{entry.content}</div>
+      </div>
+    );
+  }
+
+  const segments = parseSegments(entry.content);
+  return (
+    <div className="flex flex-col gap-2">
+      {segments.map((seg, i) =>
+        seg.kind === "code" ? (
+          <CodeBlock key={i} lang={seg.lang} code={seg.code} />
+        ) : (
+          <div
+            key={i}
+            className="whitespace-pre-wrap text-[12px] leading-[1.55] text-fg-1"
+          >
+            {seg.text}
+          </div>
+        ),
+      )}
+      {entry.usage && (
+        <div className="text-[9.5px] text-fg-3">
+          {entry.usage.totalTokens} tokens · {entry.usage.promptTokens} in /{" "}
+          {entry.usage.completionTokens} out
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/AIPanel.tsx
+++ b/apps/desktop/src/components/AIPanel.tsx
@@ -1,27 +1,20 @@
-import { useState, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { ORDERED_TOPICS, TOPICS, type AiTopic } from "@cellar/ai";
 import { Icon } from "./icons";
+import { useAi } from "../state/ai";
+import { useTabs } from "../state/tabs";
+import { useConnections } from "../state/connections";
+import { buildActiveContext, type AiContextChip } from "../lib/aiContext";
+import { AIMessage } from "./AIMessage";
 
-type ChipKind =
-  | "schema"
-  | "table"
-  | "column"
-  | "query"
-  | "selection"
-  | "plan"
-  | "file";
-
-const chipMeta: Record<ChipKind, { icon: ReactNode; color: string }> = {
+const chipMeta: Record<AiContextChip["kind"], { icon: ReactNode; color: string }> = {
   schema: { icon: <Icon.schema size={9} />, color: "var(--fg-1)" },
   table: { icon: <Icon.table size={9} />, color: "var(--syn-tbl)" },
-  column: { icon: <Icon.fileText size={9} />, color: "var(--fg-1)" },
   query: { icon: <Icon.terminal size={9} />, color: "var(--syn-fn)" },
-  selection: { icon: <Icon.fileText size={9} />, color: "var(--accent)" },
-  plan: { icon: <Icon.tree size={9} />, color: "var(--fg-1)" },
-  file: { icon: <Icon.fileText size={9} />, color: "var(--fg-1)" },
 };
 
-function ContextChip({ kind, value }: { kind: ChipKind; value: string }) {
-  const m = chipMeta[kind];
+function ContextChip({ chip }: { chip: AiContextChip }) {
+  const m = chipMeta[chip.kind];
   return (
     <span className="inline-flex h-5 items-center gap-1 whitespace-nowrap rounded-[4px] border border-border-default bg-bg-1 px-1.5 pl-[5px] text-[10.5px] text-fg-1">
       <span
@@ -29,18 +22,18 @@ function ContextChip({ kind, value }: { kind: ChipKind; value: string }) {
         style={{ color: m.color }}
       >
         {m.icon}
-        <span>{kind}</span>
+        <span>{chip.kind}</span>
       </span>
       <span className="text-fg-3">:</span>
-      <span className="font-mono text-[10.5px] text-fg-0">{value}</span>
+      <span className="font-mono text-[10.5px] text-fg-0">{chip.value}</span>
     </span>
   );
 }
 
 const DISABLED_ICON =
   "icon-btn cursor-not-allowed opacity-45 hover:bg-transparent hover:text-fg-2";
-const DISABLED_PILL =
-  "inline-flex h-[22px] cursor-not-allowed items-center gap-1 rounded-[4px] px-2 text-[11px] text-fg-3 opacity-60";
+
+const TOPIC_BUTTONS: AiTopic[] = ORDERED_TOPICS.filter((t) => t !== "ask");
 
 export function AIPanel({
   onClose,
@@ -50,6 +43,52 @@ export function AIPanel({
   onOpenSettings?: () => void;
 }) {
   const [draft, setDraft] = useState("");
+  const [topic, setTopic] = useState<AiTopic>("ask");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const init = useAi((s) => s.init);
+  const modelId = useAi((s) => s.modelId);
+  const keyConfigured = useAi((s) => s.keyConfigured);
+  const messages = useAi((s) => s.messages);
+  const sending = useAi((s) => s.sending);
+  const send = useAi((s) => s.send);
+  const newThread = useAi((s) => s.newThread);
+
+  // Recompute context whenever the active tab or its schema changes.
+  const activeId = useTabs((s) => s.activeId);
+  const byId = useConnections((s) => s.byId);
+  const context = useMemo(
+    () => buildActiveContext(),
+    // byId carries introspected schema; activeId switches scope.
+    [activeId, byId],
+  );
+
+  useEffect(() => {
+    void init();
+  }, [init]);
+
+  const ready = keyConfigured && !!modelId;
+  const canSend = ready && draft.trim().length > 0 && !sending;
+
+  const submit = () => {
+    if (!canSend) return;
+    const text = draft;
+    setDraft("");
+    void send(topic, text, context.text);
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+      e.preventDefault();
+      submit();
+    }
+  };
+
+  const pickTopic = (t: AiTopic) => {
+    setTopic((cur) => (cur === t ? "ask" : t));
+    textareaRef.current?.focus();
+  };
+
   return (
     <div className="flex h-full flex-col bg-bg-1 text-[12.5px]">
       <div className="flex h-8 shrink-0 items-center justify-between border-b border-border-default pl-2.5 pr-2">
@@ -60,8 +99,8 @@ export function AIPanel({
           <span className="whitespace-nowrap font-semibold text-fg-0">
             AI Assistant
           </span>
-          <span className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-[11px] text-fg-2">
-            · new thread
+          <span className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap font-mono text-[10.5px] text-fg-2">
+            {modelId ? `· ${modelId}` : "· not configured"}
           </span>
         </div>
         <div className="flex gap-px">
@@ -73,9 +112,12 @@ export function AIPanel({
             <Icon.history size={12} />
           </button>
           <button
-            className={DISABLED_ICON}
-            disabled
-            title="AI threads are not wired yet"
+            className={
+              messages.length ? "icon-btn" : DISABLED_ICON
+            }
+            disabled={!messages.length}
+            onClick={newThread}
+            title="New thread"
           >
             <Icon.plus size={12} />
           </button>
@@ -98,78 +140,95 @@ export function AIPanel({
           <span>context</span>
         </div>
         <div className="flex flex-1 flex-wrap gap-1">
-          <ContextChip kind="schema" value="public" />
-          <ContextChip kind="table" value="orders" />
-          <button
-            className="inline-flex h-5 cursor-not-allowed items-center gap-[3px] rounded-[4px] border border-dashed border-border-default px-1.5 text-[10px] text-fg-3 opacity-60"
-            disabled
-            title="Context editing is not wired yet"
-          >
-            <Icon.plus size={9} />
-            <span>add</span>
-          </button>
+          {context.chips.length ? (
+            context.chips.map((chip, i) => (
+              <ContextChip key={`${chip.kind}-${i}`} chip={chip} />
+            ))
+          ) : (
+            <span className="inline-flex h-5 items-center text-[10.5px] text-fg-3">
+              no active connection
+            </span>
+          )}
         </div>
       </div>
 
-      <div className="flex flex-1 flex-col gap-[18px] overflow-y-auto px-2.5 pt-3 pb-4">
-        <div className="flex flex-1 flex-col items-center justify-center gap-1.5 p-6 text-center text-[11.5px] text-fg-3">
-          <span className="mb-1 text-accent">
-            <Icon.sparkles size={22} />
-          </span>
-          <div className="text-[12px] font-medium text-fg-1">
-            Ask Cellar AI
+      <div className="flex flex-1 flex-col gap-3 overflow-y-auto px-2.5 pt-3 pb-4">
+        {messages.length === 0 ? (
+          <div className="flex flex-1 flex-col items-center justify-center gap-1.5 p-6 text-center text-[11.5px] text-fg-3">
+            <span className="mb-1 text-accent">
+              <Icon.sparkles size={22} />
+            </span>
+            <div className="text-[12px] font-medium text-fg-1">Ask Cellar AI</div>
+            <div className="max-w-[280px] text-[10.5px] leading-[1.5] text-fg-3">
+              Generate SQL with full schema context, explain a result, or have it
+              review a slow query. Bring your own API key; Cellar never proxies.
+            </div>
+            {!ready && (
+              <button
+                onClick={onOpenSettings}
+                className="mt-2 inline-flex h-[24px] items-center gap-1.5 rounded-[5px] border border-accent-line bg-accent-soft px-2.5 text-[11px] font-medium text-accent hover:brightness-110"
+              >
+                <Icon.settings size={11} />
+                <span>
+                  {keyConfigured ? "Select a model" : "Configure a provider"}
+                </span>
+              </button>
+            )}
           </div>
-          <div className="max-w-[280px] text-[10.5px] leading-[1.5] text-fg-3">
-            Generate SQL with full schema context, explain a result, or have it
-            review a slow query. Bring your own API key; Cellar never proxies.
+        ) : (
+          messages.map((m) => <AIMessage key={m.id} entry={m} />)
+        )}
+        {sending && (
+          <div className="flex items-center gap-2 px-1 text-[11px] text-fg-3">
+            <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-accent" />
+            <span>thinking…</span>
           </div>
-        </div>
+        )}
       </div>
 
       <div className="shrink-0 border-t border-border-default bg-bg-1">
         <div className="flex items-center gap-0.5 border-b border-border-divider px-1.5 py-[5px]">
-          <button
-            className={DISABLED_PILL + " bg-accent-soft text-accent"}
-            disabled
-            title="AI generation is not wired yet"
-          >
-            <Icon.sparkles size={10} />
-            <span>generate</span>
-          </button>
-          <button
-            className={DISABLED_PILL}
-            disabled
-            title="AI explanation is not wired yet"
-          >
-            explain
-          </button>
-          <button
-            className={DISABLED_PILL}
-            disabled
-            title="AI optimization is not wired yet"
-          >
-            optimize
-          </button>
-          <button
-            className={DISABLED_PILL}
-            disabled
-            title="AI migrations are not wired yet"
-          >
-            migrate
-          </button>
+          {TOPIC_BUTTONS.map((t) => {
+            const active = topic === t;
+            return (
+              <button
+                key={t}
+                onClick={() => pickTopic(t)}
+                title={TOPICS[t].hint}
+                className={
+                  "inline-flex h-[22px] items-center gap-1 rounded-[4px] px-2 text-[11px] transition-colors " +
+                  (active
+                    ? "bg-accent-soft text-accent"
+                    : "text-fg-2 hover:bg-bg-2 hover:text-fg-1")
+                }
+              >
+                {t === "generate" && <Icon.sparkles size={10} />}
+                <span>{TOPICS[t].label}</span>
+              </button>
+            );
+          })}
           <div className="flex-1" />
           <span className="inline-flex h-[22px] items-center gap-1 rounded-[4px] px-2 text-[10.5px] text-fg-3">
-            <span style={{ color: "var(--fg-2)" }}>ask</span>
+            <span style={{ color: topic === "ask" ? "var(--accent)" : "var(--fg-2)" }}>
+              ask
+            </span>
             <span style={{ color: "var(--fg-3)" }}> · read-only</span>
           </span>
         </div>
         <div className="px-1.5 py-1.5">
           <textarea
-            placeholder="Ask, generate, or paste an error…  ⌘⏎ to send"
+            ref={textareaRef}
+            placeholder={
+              ready
+                ? "Ask, generate, or paste an error…  ⌘⏎ to send"
+                : "Configure a provider in AI settings to start…"
+            }
             value={draft}
             onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={onKeyDown}
             rows={2}
-            className="w-full resize-none rounded-[5px] border border-border-default bg-bg-inset px-2 py-[7px] text-[12px] leading-[1.45] text-fg-0 outline-none placeholder:text-fg-3 focus:border-accent-line font-sans min-h-[50px]"
+            disabled={!ready}
+            className="w-full resize-none rounded-[5px] border border-border-default bg-bg-inset px-2 py-[7px] text-[12px] leading-[1.45] text-fg-0 outline-none placeholder:text-fg-3 focus:border-accent-line font-sans min-h-[50px] disabled:opacity-60"
           />
           <div className="mt-1.5 flex items-center justify-between">
             <div className="flex items-center gap-1">
@@ -180,21 +239,24 @@ export function AIPanel({
               >
                 <Icon.paperclip size={11} />
               </button>
-              <button
-                className={DISABLED_ICON}
-                disabled
-                title="Table context attachments are not wired yet"
-              >
-                <Icon.table size={11} />
-              </button>
-              <span className="ml-1.5 inline-flex items-center gap-[3px] text-[10.5px]">
-                <span style={{ color: "var(--fg-3)" }}>
-                  provider not configured
-                </span>
+              <span className="ml-1 inline-flex items-center gap-[3px] text-[10.5px]">
+                {ready ? (
+                  <span style={{ color: "var(--fg-3)" }}>
+                    {topic === "ask" ? "ask" : TOPICS[topic].label} · {modelId}
+                  </span>
+                ) : (
+                  <button
+                    onClick={onOpenSettings}
+                    className="text-fg-3 underline decoration-dotted underline-offset-2 hover:text-fg-1"
+                  >
+                    provider not configured
+                  </button>
+                )}
               </span>
             </div>
             <button
-              disabled
+              onClick={submit}
+              disabled={!canSend}
               className="inline-flex h-[22px] items-center gap-1.5 rounded-[4px] bg-accent px-2 text-[11px] font-medium text-accent-fg hover:brightness-[1.07] disabled:opacity-40 disabled:hover:brightness-100"
             >
               <span>Send</span>

--- a/apps/desktop/src/components/modals/settingsAIPanel.tsx
+++ b/apps/desktop/src/components/modals/settingsAIPanel.tsx
@@ -1,94 +1,47 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { PROVIDERS, getProvider, type AiProviderId } from "@cellar/ai";
 import { Icon } from "../icons";
 import { CD_INPUT, ED_RUN_DANGER, Row, Section } from "./settingsPrimitives";
-
-type AiProviderId = "anthropic" | "openai" | "google" | "local" | "custom";
-type AiModelTag = "balanced" | "max" | "fast" | "local";
-
-type AiModel = {
-  id: string;
-  ctx: string;
-  tag: AiModelTag;
-  def?: boolean;
-};
-
-const PROVIDERS: Record<
-  AiProviderId,
-  {
-    label: string;
-    sub: string;
-    keyPrefix: string;
-    endpoint: string;
-    models: [AiModel, ...AiModel[]];
-  }
-> = {
-  anthropic: {
-    label: "Anthropic",
-    sub: "claude-* family",
-    keyPrefix: "sk-ant-",
-    endpoint: "https://api.anthropic.com/v1",
-    models: [
-      { id: "claude-sonnet-4.5", ctx: "200k", tag: "balanced", def: true },
-      { id: "claude-opus-4", ctx: "200k", tag: "max" },
-      { id: "claude-haiku-4.5", ctx: "200k", tag: "fast" },
-    ],
-  },
-  openai: {
-    label: "OpenAI",
-    sub: "gpt-* family",
-    keyPrefix: "sk-",
-    endpoint: "https://api.openai.com/v1",
-    models: [
-      { id: "gpt-5.1", ctx: "256k", tag: "balanced", def: true },
-      { id: "gpt-5.1-mini", ctx: "256k", tag: "fast" },
-    ],
-  },
-  google: {
-    label: "Google",
-    sub: "gemini-* family",
-    keyPrefix: "key",
-    endpoint: "https://generativelanguage.googleapis.com/v1beta",
-    models: [
-      { id: "gemini-2.5-pro", ctx: "1m", tag: "max", def: true },
-      { id: "gemini-2.5-flash", ctx: "1m", tag: "fast" },
-    ],
-  },
-  local: {
-    label: "Local",
-    sub: "Ollama, LM Studio",
-    keyPrefix: "none",
-    endpoint: "http://localhost:11434/v1",
-    models: [
-      { id: "local-default", ctx: "model", tag: "local", def: true },
-    ],
-  },
-  custom: {
-    label: "Custom",
-    sub: "OpenAI-compatible URL",
-    keyPrefix: "key",
-    endpoint: "https://example.invalid/v1",
-    models: [
-      { id: "custom-model", ctx: "provider", tag: "balanced", def: true },
-    ],
-  },
-};
-
-const TAG_CLASS: Record<AiModelTag, string> = {
-  balanced: "text-accent bg-accent-soft",
-  max: "text-update bg-update-bg",
-  fast: "text-insert bg-insert-bg",
-  local: "text-fg-1 bg-bg-3",
-};
+import { useAi } from "../../state/ai";
 
 export function SettingsAI() {
-  const [provider, setProvider] = useState<AiProviderId>("anthropic");
-  const [model, setModel] = useState(PROVIDERS.anthropic.models[0].id);
-  const [reveal, setReveal] = useState(false);
-  const current = PROVIDERS[provider];
+  const providerId = useAi((s) => s.providerId);
+  const modelId = useAi((s) => s.modelId);
+  const models = useAi((s) => s.models);
+  const modelsLoading = useAi((s) => s.modelsLoading);
+  const modelsError = useAi((s) => s.modelsError);
+  const keyConfigured = useAi((s) => s.keyConfigured);
+  const messages = useAi((s) => s.messages);
 
-  const selectProvider = (id: AiProviderId) => {
-    setProvider(id);
-    setModel(PROVIDERS[id].models[0].id);
+  const init = useAi((s) => s.init);
+  const setProvider = useAi((s) => s.setProvider);
+  const setModel = useAi((s) => s.setModel);
+  const saveKey = useAi((s) => s.saveKey);
+  const clearKey = useAi((s) => s.clearKey);
+  const refreshModels = useAi((s) => s.refreshModels);
+  const newThread = useAi((s) => s.newThread);
+
+  const [keyDraft, setKeyDraft] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [reveal, setReveal] = useState(false);
+
+  const current = getProvider(providerId);
+
+  useEffect(() => {
+    void init();
+  }, [init]);
+
+  const onSaveKey = async () => {
+    const key = keyDraft.trim();
+    if (!key || saving) return;
+    setSaving(true);
+    try {
+      await saveKey(key);
+      setKeyDraft("");
+      setReveal(false);
+    } finally {
+      setSaving(false);
+    }
   };
 
   return (
@@ -117,19 +70,23 @@ export function SettingsAI() {
       <Section title="Provider">
         <Row label="Provider">
           <div className="grid w-full grid-cols-5 gap-1.5">
-            {Object.entries(PROVIDERS).map(([id, p]) => {
-              const providerId = id as AiProviderId;
-              const active = provider === providerId;
+            {PROVIDERS.map((p) => {
+              const active = providerId === p.id;
+              const disabled = !p.enabled;
               return (
                 <button
                   type="button"
-                  key={id}
-                  onClick={() => selectProvider(providerId)}
+                  key={p.id}
+                  disabled={disabled}
+                  onClick={() => !disabled && setProvider(p.id as AiProviderId)}
+                  title={disabled ? "Coming soon" : p.label}
                   className={
                     "relative flex flex-col items-start gap-0.5 rounded-[5px] border px-[9px] py-2 text-left " +
-                    (active
-                      ? "border-accent bg-accent-soft shadow-[inset_0_0_0_1px_var(--accent)]"
-                      : "border-border-default bg-bg-2 hover:border-border-strong")
+                    (disabled
+                      ? "cursor-not-allowed border-border-default bg-bg-2 opacity-55"
+                      : active
+                        ? "border-accent bg-accent-soft shadow-[inset_0_0_0_1px_var(--accent)]"
+                        : "border-border-default bg-bg-2 hover:border-border-strong")
                   }
                 >
                   <span className="text-[11.5px] font-medium text-fg-0">
@@ -143,7 +100,12 @@ export function SettingsAI() {
                   >
                     {p.sub}
                   </span>
-                  {active && (
+                  {disabled && (
+                    <span className="absolute right-[5px] top-[5px] rounded-[3px] bg-bg-3 px-1 py-px text-[8.5px] uppercase tracking-[0.04em] text-fg-3">
+                      soon
+                    </span>
+                  )}
+                  {!disabled && active && (
                     <span className="absolute right-[5px] top-[5px] inline-flex h-3 w-3 items-center justify-center rounded-full bg-accent text-accent-fg">
                       <Icon.check size={9} />
                     </span>
@@ -154,97 +116,139 @@ export function SettingsAI() {
           </div>
         </Row>
 
-        <Row label="Model" hint="used for chat, generation, ghost text">
-          <div className="flex w-full flex-col gap-[3px]">
-            {current.models.map((m) => {
-              const active = model === m.id;
-              return (
-                <label
-                  key={m.id}
-                  className={
-                    "grid cursor-pointer grid-cols-[14px_1fr_auto_auto_auto] items-center gap-2.5 rounded-[4px] border px-2.5 py-1.5 " +
-                    (active
-                      ? "border-accent-line bg-accent-soft"
-                      : "border-border-default bg-bg-2 hover:border-border-strong")
-                  }
-                >
-                  <span
-                    className={
-                      "relative inline-block h-3 w-3 rounded-full border " +
-                      (active ? "border-accent" : "border-border-strong")
-                    }
-                  >
-                    {active && (
-                      <span
-                        className="absolute inset-[2px] rounded-full"
-                        style={{ background: "var(--accent)" }}
-                      />
-                    )}
-                  </span>
-                  <input
-                    type="radio"
-                    className="hidden"
-                    checked={active}
-                    onChange={() => setModel(m.id)}
-                  />
-                  <span className="font-mono text-[11.5px] text-fg-0">
-                    {m.id}
-                  </span>
-                  <span className="font-mono text-[10px] text-fg-3">
-                    {m.ctx} ctx
-                  </span>
-                  <span
-                    className={
-                      "rounded-[3px] px-1.5 py-px font-mono text-[9.5px] uppercase tracking-[0.04em] " +
-                      TAG_CLASS[m.tag]
-                    }
-                  >
-                    {m.tag}
-                  </span>
-                  {m.def && (
-                    <span className="text-[9.5px] italic text-fg-2">
-                      recommended
-                    </span>
-                  )}
-                </label>
-              );
-            })}
-          </div>
-        </Row>
-
         <Row label="API key" hint="stored in OS keychain, never written to disk">
-          <div className="inline-flex min-w-0 flex-1 items-center gap-1">
-            <span className="inline-flex h-[26px] items-center rounded-l-[4px] border border-r-0 border-border-default bg-bg-inset px-1.5 font-mono text-[11px] text-fg-2">
-              {current.keyPrefix}
-            </span>
-            <input
-              className="-ml-px h-[26px] min-w-0 flex-1 border border-border-default bg-bg-inset px-2 font-mono text-[11.5px] text-fg-0 outline-none focus:border-accent-line focus:bg-bg-2"
-              type={reveal ? "text" : "password"}
-              value=""
-              placeholder={reveal ? "No key configured" : "stored in keychain"}
-              readOnly
-              spellCheck={false}
-            />
-            <button
-              type="button"
-              onClick={() => setReveal(!reveal)}
-              className="inline-flex h-[26px] items-center gap-1 rounded-[4px] border border-border-default bg-bg-2 px-2 text-[10.5px] text-fg-1 hover:bg-bg-3"
-            >
-              {reveal ? "hide" : "reveal"}
-            </button>
-            <button
-              type="button"
-              disabled
-              title="Keychain editing is not wired yet"
-              className="inline-flex h-[26px] cursor-not-allowed items-center gap-1 rounded-[4px] border border-border-default bg-bg-2 px-2 text-[11px] text-fg-2 opacity-70"
-            >
-              <Icon.edit size={11} />
-              <span>change</span>
-            </button>
+          <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+            <div className="inline-flex min-w-0 items-center gap-1">
+              <span className="inline-flex h-[26px] items-center rounded-l-[4px] border border-r-0 border-border-default bg-bg-inset px-1.5 font-mono text-[11px] text-fg-2">
+                {current.keyPrefix}
+              </span>
+              <input
+                className="-ml-px h-[26px] min-w-0 flex-1 border border-border-default bg-bg-inset px-2 font-mono text-[11.5px] text-fg-0 outline-none focus:border-accent-line focus:bg-bg-2"
+                type={reveal ? "text" : "password"}
+                value={keyDraft}
+                onChange={(e) => setKeyDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") void onSaveKey();
+                }}
+                placeholder={
+                  keyConfigured ? "key stored — paste to replace" : "paste your API key"
+                }
+                spellCheck={false}
+                autoComplete="off"
+              />
+              <button
+                type="button"
+                onClick={() => setReveal((v) => !v)}
+                className="inline-flex h-[26px] items-center gap-1 rounded-[4px] border border-border-default bg-bg-2 px-2 text-[10.5px] text-fg-1 hover:bg-bg-3"
+              >
+                {reveal ? "hide" : "reveal"}
+              </button>
+              <button
+                type="button"
+                disabled={!keyDraft.trim() || saving}
+                onClick={() => void onSaveKey()}
+                className="inline-flex h-[26px] items-center gap-1 rounded-[4px] bg-accent px-2.5 text-[11px] font-medium text-accent-fg hover:brightness-[1.07] disabled:opacity-40"
+              >
+                {saving ? "saving…" : "save"}
+              </button>
+            </div>
+            <div className="flex items-center gap-1.5 text-[10.5px]">
+              {keyConfigured ? (
+                <span className="inline-flex items-center gap-1 text-insert">
+                  <Icon.check size={10} />
+                  <span>key configured</span>
+                </span>
+              ) : (
+                <span className="text-fg-3">no key configured</span>
+              )}
+            </div>
           </div>
         </Row>
 
-        <Row label="Endpoint" hint="override for proxies, custom routers">
+        <Row label="Model" hint="discovered from your API key">
+          <div className="flex w-full flex-col gap-[3px]">
+            <div className="mb-1 flex items-center justify-between">
+              <span className="text-[10.5px] text-fg-3">
+                {modelsLoading
+                  ? "loading models…"
+                  : modelsError
+                    ? ""
+                    : `${models.length} model${models.length === 1 ? "" : "s"} available`}
+              </span>
+              <button
+                type="button"
+                disabled={!keyConfigured || modelsLoading}
+                onClick={() => void refreshModels()}
+                className="inline-flex h-[22px] items-center gap-1 rounded-[4px] border border-border-default bg-bg-2 px-2 text-[10.5px] text-fg-1 hover:bg-bg-3 disabled:opacity-40"
+              >
+                <Icon.undo size={10} />
+                <span>refresh</span>
+              </button>
+            </div>
+
+            {modelsError && (
+              <div className="mb-1 flex items-start gap-1.5 rounded-[4px] border border-delete-line bg-delete-bg px-2 py-1.5 text-[10.5px] text-delete">
+                <Icon.warn size={11} />
+                <span>{modelsError}</span>
+              </div>
+            )}
+
+            {!keyConfigured ? (
+              <div className="rounded-[4px] border border-dashed border-border-default px-2.5 py-2 text-[10.5px] text-fg-3">
+                Add an API key above to discover available models.
+              </div>
+            ) : models.length === 0 && !modelsLoading && !modelsError ? (
+              <div className="rounded-[4px] border border-dashed border-border-default px-2.5 py-2 text-[10.5px] text-fg-3">
+                No chat-capable models found for this key.
+              </div>
+            ) : (
+              models.map((m) => {
+                const active = modelId === m.id;
+                return (
+                  <label
+                    key={m.id}
+                    className={
+                      "grid cursor-pointer grid-cols-[14px_1fr_auto] items-center gap-2.5 rounded-[4px] border px-2.5 py-1.5 " +
+                      (active
+                        ? "border-accent-line bg-accent-soft"
+                        : "border-border-default bg-bg-2 hover:border-border-strong")
+                    }
+                  >
+                    <span
+                      className={
+                        "relative inline-block h-3 w-3 rounded-full border " +
+                        (active ? "border-accent" : "border-border-strong")
+                      }
+                    >
+                      {active && (
+                        <span
+                          className="absolute inset-[2px] rounded-full"
+                          style={{ background: "var(--accent)" }}
+                        />
+                      )}
+                    </span>
+                    <input
+                      type="radio"
+                      className="hidden"
+                      checked={active}
+                      onChange={() => setModel(m.id)}
+                    />
+                    <span className="min-w-0 truncate font-mono text-[11.5px] text-fg-0">
+                      {m.id}
+                    </span>
+                    {m.ctx && (
+                      <span className="font-mono text-[10px] text-fg-3">
+                        {m.ctx} ctx
+                      </span>
+                    )}
+                  </label>
+                );
+              })
+            )}
+          </div>
+        </Row>
+
+        <Row label="Endpoint" hint="direct, not proxied through Cellar">
           <input
             className={CD_INPUT + " cursor-not-allowed font-mono opacity-80"}
             value={current.endpoint}
@@ -256,25 +260,32 @@ export function SettingsAI() {
 
       <Section title="Danger zone">
         <Row
-          label="Clear AI conversation history"
-          hint="20 conversations, 3.2 MB locally"
+          label="Clear AI conversation"
+          hint={
+            messages.length
+              ? `${messages.length} message${messages.length === 1 ? "" : "s"} in the current thread`
+              : "no active conversation"
+          }
         >
           <button
             type="button"
-            disabled
-            title="AI history deletion is not wired yet"
-            className={ED_RUN_DANGER + " cursor-not-allowed opacity-60"}
+            disabled={!messages.length}
+            onClick={newThread}
+            className={ED_RUN_DANGER + (messages.length ? "" : " cursor-not-allowed opacity-60")}
           >
             <Icon.trash size={11} />
-            <span>Clear all</span>
+            <span>Clear</span>
           </button>
         </Row>
-        <Row label="Revoke API key" hint="remove from keychain — does not affect provider">
+        <Row
+          label="Revoke API key"
+          hint="remove from keychain — does not affect provider"
+        >
           <button
             type="button"
-            disabled
-            title="Key revocation is not wired yet"
-            className={ED_RUN_DANGER + " cursor-not-allowed opacity-60"}
+            disabled={!keyConfigured}
+            onClick={() => void clearKey()}
+            className={ED_RUN_DANGER + (keyConfigured ? "" : " cursor-not-allowed opacity-60")}
           >
             <Icon.close size={11} />
             <span>Revoke</span>

--- a/apps/desktop/src/lib/aiContext.ts
+++ b/apps/desktop/src/lib/aiContext.ts
@@ -1,0 +1,93 @@
+// Derives the schema context sent to the AI from whatever the user is looking
+// at: the active tab's connection, database, schema, and tables. Returns both
+// the compact text block for the model and the chips shown in the panel header.
+
+import {
+  buildSchemaContext,
+  type ContextTable,
+  type SchemaContextInput,
+} from "@cellar/ai";
+import type { Table } from "@cellar/ipc";
+import { useConnections } from "../state/connections";
+import { useTabs } from "../state/tabs";
+
+/** Cap inlined tables for a query tab so the context stays small. */
+const MAX_TABLES = 12;
+
+export type AiContextChip = {
+  kind: "schema" | "table" | "query";
+  value: string;
+};
+
+export interface ActiveContext {
+  /** Compact schema block for the provider, or "" when nothing is in scope. */
+  text: string;
+  chips: AiContextChip[];
+}
+
+function toContextTable(t: Table): ContextTable {
+  return {
+    schema: t.schema,
+    name: t.name,
+    columns: t.columns.map((c) => ({
+      name: c.name,
+      data_type: c.data_type,
+      nullable: c.nullable,
+      is_primary_key: c.is_primary_key,
+    })),
+  };
+}
+
+export function buildActiveContext(): ActiveContext {
+  const tabs = useTabs.getState();
+  const active = tabs.tabs.find((t) => t.id === tabs.activeId) ?? null;
+  if (!active) return { text: "", chips: [] };
+
+  const conns = useConnections.getState();
+  const config = conns.connections.find((c) => c.id === active.connectionId);
+  const connState = conns.byId[active.connectionId];
+  const databases = connState?.databases ?? [];
+  const db =
+    databases.find((d) => d.name === active.database) ??
+    databases.find((d) => d.is_default) ??
+    databases[0];
+
+  const chips: AiContextChip[] = [];
+  let tables: ContextTable[] = [];
+  let schemaName: string | undefined;
+
+  if (active.kind === "table") {
+    schemaName = active.schema;
+    const schema = db?.schemas.find((s) => s.name === active.schema);
+    const table = schema?.tables.find((t) => t.name === active.table);
+    if (table) tables = [toContextTable(table)];
+    chips.push({ kind: "schema", value: active.schema });
+    chips.push({ kind: "table", value: active.table });
+  } else {
+    const schema =
+      db?.schemas.find((s) => s.name === "public") ?? db?.schemas[0];
+    if (schema) {
+      schemaName = schema.name;
+      tables = schema.tables.slice(0, MAX_TABLES).map(toContextTable);
+      chips.push({ kind: "schema", value: schema.name });
+      const shown = Math.min(schema.tables.length, MAX_TABLES);
+      if (shown > 0) {
+        chips.push({
+          kind: "table",
+          value: shown === 1 ? schema.tables[0]!.name : `${shown} tables`,
+        });
+      }
+    }
+    chips.push({ kind: "query", value: active.title });
+  }
+
+  const input: SchemaContextInput = {
+    connectionName: config?.name,
+    engine: config?.engine,
+    database: active.database,
+    schema: schemaName,
+    tables,
+  };
+
+  return { text: buildSchemaContext(input), chips };
+}

--- a/apps/desktop/src/state/ai.test.ts
+++ b/apps/desktop/src/state/ai.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock only the network functions of @cellar/ai; keep the real prompt/provider
+// helpers. The keychain commands run against the @cellar/ipc web-mode mock
+// (isTauri is false under vitest), which holds keys in memory.
+vi.mock("@cellar/ai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@cellar/ai")>();
+  return {
+    ...actual,
+    listGeminiModels: vi.fn(async () => [
+      { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro", ctx: "1m" },
+    ]),
+    generateContent: vi.fn(async () => ({
+      text: "```sql\nSELECT 1;\n```",
+      usage: { promptTokens: 1, completionTokens: 2, totalTokens: 3 },
+    })),
+  };
+});
+
+import { commands } from "@cellar/ipc";
+import * as ai from "@cellar/ai";
+import { useAi } from "./ai";
+
+function reset() {
+  useAi.setState({
+    providerId: "google",
+    modelId: null,
+    models: [],
+    modelsLoading: false,
+    modelsError: null,
+    keyConfigured: false,
+    messages: [],
+    sending: false,
+    initialized: false,
+  });
+}
+
+beforeEach(async () => {
+  await commands.aiDeleteKey("google");
+  reset();
+  vi.clearAllMocks();
+});
+
+describe("useAi store", () => {
+  it("saveKey stores the key and discovers models", async () => {
+    await useAi.getState().saveKey("AIzaTEST");
+    const s = useAi.getState();
+    expect(s.keyConfigured).toBe(true);
+    expect(s.models.map((m) => m.id)).toEqual(["gemini-2.5-pro"]);
+    expect(s.modelId).toBe("gemini-2.5-pro");
+    expect(ai.listGeminiModels).toHaveBeenCalledOnce();
+  });
+
+  it("send appends the user turn then the model reply", async () => {
+    await useAi.getState().saveKey("AIzaTEST");
+    await useAi.getState().send("generate", "top customers", "ctx");
+
+    const msgs = useAi.getState().messages;
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0]).toMatchObject({ role: "user", topic: "generate", content: "top customers" });
+    // the API turn wraps the preset instruction + context around the raw text
+    expect(msgs[0]!.apiContent).toContain("Schema context:\nctx");
+    expect(msgs[1]!.role).toBe("model");
+    expect(msgs[1]!.error).toBeFalsy();
+    expect(msgs[1]!.content).toContain("SELECT 1;");
+    expect(useAi.getState().sending).toBe(false);
+  });
+
+  it("send without a key records an error turn", async () => {
+    useAi.setState({ modelId: "gemini-2.5-pro" });
+    await useAi.getState().send("ask", "hello");
+    const msgs = useAi.getState().messages;
+    expect(msgs).toHaveLength(2);
+    expect(msgs[1]).toMatchObject({ role: "model", error: true });
+    expect(ai.generateContent).not.toHaveBeenCalled();
+  });
+
+  it("retrying after a failed turn sends clean alternating history", async () => {
+    // First turn fails (no key) -> error model entry recorded.
+    useAi.setState({ modelId: "gemini-2.5-pro" });
+    await useAi.getState().send("ask", "first try");
+    expect(useAi.getState().messages.at(-1)).toMatchObject({ error: true });
+
+    // Now configure a key and send again; history must not contain the
+    // orphaned user turn from the failed attempt.
+    await useAi.getState().saveKey("AIzaTEST");
+    await useAi.getState().send("ask", "second try");
+
+    const sent = vi.mocked(ai.generateContent).mock.calls.at(-1)![0];
+    const roles = sent.messages.map((m) => m.role);
+    // strictly alternating, ending on the new user turn
+    expect(roles).toEqual(["user"]);
+    expect(sent.messages[0]!.content).toContain("second try");
+  });
+
+  it("clearKey revokes the key and resets models", async () => {
+    await useAi.getState().saveKey("AIzaTEST");
+    await useAi.getState().clearKey();
+    const s = useAi.getState();
+    expect(s.keyConfigured).toBe(false);
+    expect(s.models).toEqual([]);
+    expect(await commands.aiHasKey("google")).toMatchObject({ data: false });
+  });
+
+  it("newThread clears the conversation", () => {
+    useAi.setState({ messages: [{ id: "x", role: "user", content: "hi" }] });
+    useAi.getState().newThread();
+    expect(useAi.getState().messages).toEqual([]);
+  });
+});

--- a/apps/desktop/src/state/ai.ts
+++ b/apps/desktop/src/state/ai.ts
@@ -1,0 +1,234 @@
+import { create } from "zustand";
+import {
+  buildUserPrompt,
+  DEFAULT_PROVIDER,
+  GeminiError,
+  generateContent,
+  listGeminiModels,
+  SYSTEM_PROMPT,
+  type AiModel,
+  type AiProviderId,
+  type AiTopic,
+  type ChatMessage,
+  type TokenUsage,
+} from "@cellar/ai";
+import { commands, unwrap } from "@cellar/ipc";
+
+/** One rendered row in the AI thread. `content` is what we show; `apiContent`
+ * (when set) is what was actually sent to the provider — the user sees their
+ * own text, the model sees the preset instruction + schema context wrapped in. */
+export interface AiChatEntry {
+  id: string;
+  role: "user" | "model";
+  topic?: AiTopic;
+  content: string;
+  apiContent?: string;
+  error?: boolean;
+  usage?: TokenUsage;
+}
+
+interface Persisted {
+  providerId: AiProviderId;
+  modelId: string | null;
+}
+
+const STORAGE_KEY = "cellar.ai.v1";
+
+function loadPersisted(): Persisted {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { providerId: DEFAULT_PROVIDER, modelId: null };
+    const parsed = JSON.parse(raw) as Partial<Persisted>;
+    return {
+      providerId: parsed.providerId ?? DEFAULT_PROVIDER,
+      modelId: parsed.modelId ?? null,
+    };
+  } catch {
+    return { providerId: DEFAULT_PROVIDER, modelId: null };
+  }
+}
+
+function persist(p: Persisted) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(p));
+  } catch {
+    // non-fatal: selection just won't survive a restart
+  }
+}
+
+let entrySeq = 0;
+function nextId(): string {
+  entrySeq += 1;
+  return `ai-${entrySeq}`;
+}
+
+function describeError(e: unknown): string {
+  if (e instanceof GeminiError) return e.message;
+  if (e instanceof Error) return e.message;
+  return "Unexpected error talking to the provider.";
+}
+
+interface AiStore {
+  providerId: AiProviderId;
+  modelId: string | null;
+  models: AiModel[];
+  modelsLoading: boolean;
+  modelsError: string | null;
+  keyConfigured: boolean;
+  messages: AiChatEntry[];
+  sending: boolean;
+  initialized: boolean;
+
+  /** Load persisted selection + key status; fetch models if a key exists. */
+  init: () => Promise<void>;
+  setProvider: (id: AiProviderId) => void;
+  setModel: (id: string) => void;
+  /** Persist a key to the keychain, then (re)discover models. */
+  saveKey: (key: string) => Promise<void>;
+  /** Remove the key from the keychain and reset discovered models. */
+  clearKey: () => Promise<void>;
+  refreshModels: () => Promise<void>;
+  send: (topic: AiTopic, text: string, context?: string) => Promise<void>;
+  newThread: () => void;
+}
+
+export const useAi = create<AiStore>((set, get) => ({
+  ...loadPersisted(),
+  models: [],
+  modelsLoading: false,
+  modelsError: null,
+  keyConfigured: false,
+  messages: [],
+  sending: false,
+  initialized: false,
+
+  async init() {
+    if (get().initialized) return;
+    set({ initialized: true });
+    try {
+      const has = await unwrap(commands.aiHasKey(get().providerId));
+      set({ keyConfigured: has });
+      if (has) await get().refreshModels();
+    } catch (e) {
+      set({ modelsError: describeError(e) });
+    }
+  },
+
+  setProvider(id) {
+    // Switching providers resets discovery state and re-evaluates the new
+    // provider's key/models from scratch.
+    set({
+      providerId: id,
+      initialized: false,
+      keyConfigured: false,
+      models: [],
+      modelsError: null,
+    });
+    persist({ providerId: id, modelId: get().modelId });
+    void get().init();
+  },
+
+  setModel(id) {
+    set({ modelId: id });
+    persist({ providerId: get().providerId, modelId: id });
+  },
+
+  async saveKey(key) {
+    const provider = get().providerId;
+    await unwrap(commands.aiStoreKey(provider, key));
+    set({ keyConfigured: true, modelsError: null });
+    await get().refreshModels();
+  },
+
+  async clearKey() {
+    const provider = get().providerId;
+    await unwrap(commands.aiDeleteKey(provider));
+    set({ keyConfigured: false, models: [], modelsError: null });
+  },
+
+  async refreshModels() {
+    const provider = get().providerId;
+    set({ modelsLoading: true, modelsError: null });
+    try {
+      const key = await unwrap(commands.aiLoadKey(provider));
+      if (!key) {
+        set({ modelsLoading: false, models: [], keyConfigured: false });
+        return;
+      }
+      const models = await listGeminiModels(key);
+      const current = get().modelId;
+      const stillValid = current && models.some((m) => m.id === current);
+      const modelId = stillValid ? current : (models[0]?.id ?? null);
+      set({ models, modelsLoading: false, keyConfigured: true, modelId });
+      persist({ providerId: provider, modelId });
+    } catch (e) {
+      set({ modelsLoading: false, modelsError: describeError(e) });
+    }
+  },
+
+  async send(topic, text, context) {
+    if (get().sending) return;
+    const provider = get().providerId;
+    const model = get().modelId;
+
+    const userEntry: AiChatEntry = {
+      id: nextId(),
+      role: "user",
+      topic,
+      content: text.trim(),
+      apiContent: buildUserPrompt(topic, text, context),
+    };
+    set((s) => ({ messages: [...s.messages, userEntry], sending: true }));
+
+    try {
+      const key = await unwrap(commands.aiLoadKey(provider));
+      if (!key) throw new GeminiError(401, "No API key configured. Add one in AI settings.");
+      if (!model) throw new GeminiError(400, "No model selected. Pick one in AI settings.");
+
+      // Gemini requires strictly alternating user/model turns. Drop failed
+      // model turns *and* the user turn that triggered them so we never send
+      // two consecutive user messages. The just-added user turn is last and
+      // has no response yet, so it ends the (clean) history correctly.
+      const history: ChatMessage[] = [];
+      for (const m of get().messages) {
+        if (m.role === "model" && m.error) {
+          if (history.length && history[history.length - 1]!.role === "user") {
+            history.pop();
+          }
+          continue;
+        }
+        history.push({
+          role: m.role,
+          content: m.role === "user" ? (m.apiContent ?? m.content) : m.content,
+        });
+      }
+
+      const result = await generateContent({
+        apiKey: key,
+        model,
+        systemInstruction: SYSTEM_PROMPT,
+        messages: history,
+      });
+
+      set((s) => ({
+        sending: false,
+        messages: [
+          ...s.messages,
+          { id: nextId(), role: "model", content: result.text, usage: result.usage },
+        ],
+      }));
+    } catch (e) {
+      set((s) => ({
+        sending: false,
+        messages: [
+          ...s.messages,
+          { id: nextId(), role: "model", content: describeError(e), error: true },
+        ],
+      }));
+    }
+  },
+
+  newThread() {
+    set({ messages: [] });
+  },
+}));

--- a/crates/cellar-drivers/postgres/src/decode.rs
+++ b/crates/cellar-drivers/postgres/src/decode.rs
@@ -98,11 +98,16 @@ pub fn decode_cell(row: &PgRow, ordinal: usize) -> CellarResult<CellValue> {
 
         // Fall back to text. `try_get::<String>` works for many implicit
         // string casts (e.g. inet, cidr, mac, money) when sqlx supports the
-        // decode; otherwise we surface the type name so the user can file a
-        // sharper bug.
+        // decode. User-defined enums are the common case here: sqlx rejects the
+        // custom type OID in `try_get`, but Postgres transmits an enum's *label*
+        // as the value bytes in both wire formats, so a raw UTF-8 read recovers
+        // it. Only if that also fails do we surface the type name.
         other => match row.try_get::<String, _>(ordinal) {
             Ok(s) => Ok(CellValue::Text(s)),
-            Err(_) => Err(CellarError::UnsupportedType(other.to_string())),
+            Err(_) => match raw.as_str() {
+                Ok(s) => Ok(CellValue::Text(s.to_string())),
+                Err(_) => Err(CellarError::UnsupportedType(other.to_string())),
+            },
         },
     }
 }

--- a/crates/cellar-drivers/postgres/tests/integration.rs
+++ b/crates/cellar-drivers/postgres/tests/integration.rs
@@ -225,6 +225,44 @@ async fn execute_query_decodes_common_types() {
 }
 
 #[tokio::test]
+async fn execute_query_decodes_user_defined_enums() {
+    // Regression: enum columns hit the decode fallback. sqlx's String decode
+    // rejects the custom type OID, so the driver now reads the raw value bytes
+    // (which carry the enum label) as UTF-8. Before the fix this surfaced as
+    // `UnsupportedType` and failed the whole table/view load.
+    let live = boot().await;
+    let driver = PostgresDriver::new();
+    let conn = driver
+        .connect(&live.config, Some(&live.password))
+        .await
+        .expect("connect");
+
+    driver
+        .execute_query(
+            conn.as_ref(),
+            &Query::new("CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy')"),
+        )
+        .await
+        .expect("create enum type");
+
+    let result = driver
+        .execute_query(
+            conn.as_ref(),
+            &Query::new("SELECT 'happy'::mood AS m, NULL::mood AS n"),
+        )
+        .await
+        .expect("query enum");
+
+    assert_eq!(result.rows.len(), 1);
+    if let CellValue::Text(m) = &result.rows[0][0] {
+        assert_eq!(m, "happy");
+    } else {
+        panic!("expected enum decoded as text, got {:?}", result.rows[0][0]);
+    }
+    assert!(matches!(result.rows[0][1], CellValue::Null));
+}
+
+#[tokio::test]
 async fn execute_query_caps_to_default_limit() {
     let live = boot().await;
     let driver = PostgresDriver::new();

--- a/docker/demo-postgres/README.md
+++ b/docker/demo-postgres/README.md
@@ -1,0 +1,68 @@
+# Demo Postgres
+
+A throwaway Postgres instance with a small, realistic **e-commerce** dataset for
+taking Cellar screenshots. All data is procedurally generated — no real PII.
+
+## Start
+
+```bash
+cd docker/demo-postgres
+docker compose up -d
+```
+
+First boot runs `initdb/01-schema.sql` then `initdb/02-seed.sql` automatically.
+
+## Connect
+
+Add a connection in Cellar (or use `psql`) with:
+
+| field    | value         |
+| -------- | ------------- |
+| Host     | `localhost`   |
+| Port     | `5432`        |
+| Database | `cellar_demo` |
+| User     | `cellar`      |
+| Password | `cellar`      |
+| SSL mode | `disable`     |
+
+```bash
+psql "postgresql://cellar:cellar@localhost:5432/cellar_demo"
+```
+
+## What's inside
+
+Schema `public`:
+
+| object                  | kind  | rows  | notes                                   |
+| ----------------------- | ----- | ----- | --------------------------------------- |
+| `categories`            | table | 8     |                                         |
+| `products`              | table | 120   | `numeric` price, `jsonb` attributes     |
+| `customers`             | table | 200   | `jsonb` metadata, `is_vip` flag         |
+| `orders`                | table | 600   | `order_status` enum, FK → customers     |
+| `order_items`           | table | ~1450 | 1–4 line items per order                |
+| `payments`              | table | ~520  | `payment_method` / `payment_status` enums |
+| `customer_order_summary`| view  | —     | per-customer order count + spend        |
+| `product_sales`         | view  | —     | per-product units sold + revenue        |
+
+Enum types: `order_status`, `payment_method`, `payment_status`. Foreign keys,
+indexes, and column comments are all set so the schema browser has plenty to show.
+
+## Re-seed (fresh random data)
+
+The init scripts only run when the data volume is empty, so wiping the volume
+gives a fresh dataset:
+
+```bash
+docker compose down -v && docker compose up -d
+```
+
+The seed uses a fixed `setseed(0.42)`, so a re-seed reproduces the same data.
+Change that value in `initdb/02-seed.sql` for a different (still deterministic) set.
+
+## Stop / remove
+
+```bash
+docker compose stop        # pause, keep data
+docker compose down        # remove container, keep data volume
+docker compose down -v     # remove container AND data
+```

--- a/docker/demo-postgres/docker-compose.yml
+++ b/docker/demo-postgres/docker-compose.yml
@@ -1,0 +1,35 @@
+# Local demo Postgres for Cellar screenshots.
+#
+#   cd docker/demo-postgres
+#   docker compose up -d
+#
+# Connect from Cellar (or psql) with:
+#   host=localhost  port=5432  database=cellar_demo  user=cellar  password=cellar
+#
+# The init scripts in ./initdb run once, when the data volume is first created.
+# To wipe and re-seed (fresh random data):  docker compose down -v && docker compose up -d
+services:
+  demo-postgres:
+    image: postgres:16
+    container_name: cellar-demo-postgres
+    environment:
+      POSTGRES_USER: cellar
+      POSTGRES_PASSWORD: cellar
+      POSTGRES_DB: cellar_demo
+      # Make the seed deterministic-ish and timestamps readable in screenshots.
+      TZ: UTC
+      PGTZ: UTC
+    ports:
+      - "5432:5432"
+    volumes:
+      - cellar-demo-data:/var/lib/postgresql/data
+      - ./initdb:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U cellar -d cellar_demo"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+
+volumes:
+  cellar-demo-data:

--- a/docker/demo-postgres/initdb/01-schema.sql
+++ b/docker/demo-postgres/initdb/01-schema.sql
@@ -1,0 +1,132 @@
+-- Cellar demo schema: a small, recognizable e-commerce model.
+-- Rich on purpose — enums, jsonb, numeric, timestamps, FKs, indexes, comments,
+-- and views — so the schema browser and grid have interesting things to show.
+
+SET client_min_messages = warning;
+
+-- ---------------------------------------------------------------------------
+-- Enumerated types (render as type badges in the grid)
+-- ---------------------------------------------------------------------------
+CREATE TYPE order_status AS ENUM (
+  'pending', 'paid', 'shipped', 'delivered', 'cancelled', 'refunded'
+);
+
+CREATE TYPE payment_method AS ENUM (
+  'card', 'paypal', 'bank_transfer', 'apple_pay', 'google_pay'
+);
+
+CREATE TYPE payment_status AS ENUM (
+  'pending', 'completed', 'failed', 'refunded'
+);
+
+-- ---------------------------------------------------------------------------
+-- Tables
+-- ---------------------------------------------------------------------------
+CREATE TABLE categories (
+  id          serial PRIMARY KEY,
+  name        text        NOT NULL,
+  slug        text        NOT NULL UNIQUE,
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+COMMENT ON TABLE  categories      IS 'Product categories shown in the storefront nav.';
+COMMENT ON COLUMN categories.slug IS 'URL-safe identifier, unique per category.';
+
+CREATE TABLE products (
+  id           serial PRIMARY KEY,
+  category_id  integer     NOT NULL REFERENCES categories(id),
+  sku          text        NOT NULL UNIQUE,
+  name         text        NOT NULL,
+  description  text,
+  price        numeric(10,2) NOT NULL CHECK (price >= 0),
+  in_stock     integer     NOT NULL DEFAULT 0,
+  is_active    boolean     NOT NULL DEFAULT true,
+  attributes   jsonb       NOT NULL DEFAULT '{}'::jsonb,
+  created_at   timestamptz NOT NULL DEFAULT now()
+);
+COMMENT ON TABLE  products            IS 'Sellable catalog items.';
+COMMENT ON COLUMN products.attributes IS 'Free-form product spec (color, size, weight, ...).';
+
+CREATE TABLE customers (
+  id              serial PRIMARY KEY,
+  first_name      text        NOT NULL,
+  last_name       text        NOT NULL,
+  email           text        NOT NULL UNIQUE,
+  country         text        NOT NULL,
+  city            text        NOT NULL,
+  signup_date     date        NOT NULL,
+  lifetime_value  numeric(12,2) NOT NULL DEFAULT 0,
+  is_vip          boolean     NOT NULL DEFAULT false,
+  metadata        jsonb       NOT NULL DEFAULT '{}'::jsonb
+);
+COMMENT ON TABLE customers IS 'People who have signed up — all data here is synthetic.';
+
+CREATE TABLE orders (
+  id           serial PRIMARY KEY,
+  customer_id  integer       NOT NULL REFERENCES customers(id),
+  status       order_status  NOT NULL DEFAULT 'pending',
+  currency     char(3)       NOT NULL DEFAULT 'USD',
+  total        numeric(12,2) NOT NULL DEFAULT 0,
+  placed_at    timestamptz   NOT NULL DEFAULT now(),
+  shipped_at   timestamptz
+);
+COMMENT ON TABLE orders IS 'Customer orders; total is rolled up from order_items.';
+
+CREATE TABLE order_items (
+  id          serial PRIMARY KEY,
+  order_id    integer       NOT NULL REFERENCES orders(id) ON DELETE CASCADE,
+  product_id  integer       NOT NULL REFERENCES products(id),
+  quantity    integer       NOT NULL CHECK (quantity > 0),
+  unit_price  numeric(10,2) NOT NULL
+);
+COMMENT ON TABLE order_items IS 'Line items belonging to an order.';
+
+CREATE TABLE payments (
+  id        serial PRIMARY KEY,
+  order_id  integer        NOT NULL REFERENCES orders(id) ON DELETE CASCADE,
+  method    payment_method NOT NULL,
+  amount    numeric(12,2)  NOT NULL,
+  status    payment_status NOT NULL DEFAULT 'pending',
+  paid_at   timestamptz
+);
+COMMENT ON TABLE payments IS 'Payment attempts against an order.';
+
+-- ---------------------------------------------------------------------------
+-- Indexes
+-- ---------------------------------------------------------------------------
+CREATE INDEX idx_products_category   ON products(category_id);
+CREATE INDEX idx_customers_country   ON customers(country);
+CREATE INDEX idx_orders_customer     ON orders(customer_id);
+CREATE INDEX idx_orders_status       ON orders(status);
+CREATE INDEX idx_orders_placed_at    ON orders(placed_at);
+CREATE INDEX idx_order_items_order   ON order_items(order_id);
+CREATE INDEX idx_order_items_product ON order_items(product_id);
+CREATE INDEX idx_payments_order      ON payments(order_id);
+
+-- ---------------------------------------------------------------------------
+-- Views
+-- ---------------------------------------------------------------------------
+CREATE VIEW customer_order_summary AS
+SELECT c.id,
+       c.first_name,
+       c.last_name,
+       c.email,
+       c.country,
+       count(o.id)                  AS order_count,
+       coalesce(sum(o.total), 0)    AS total_spent,
+       max(o.placed_at)             AS last_order_at
+FROM customers c
+LEFT JOIN orders o ON o.customer_id = c.id
+GROUP BY c.id;
+
+CREATE VIEW product_sales AS
+SELECT p.id,
+       p.sku,
+       p.name,
+       cat.name                                AS category,
+       count(oi.id)                            AS times_ordered,
+       coalesce(sum(oi.quantity), 0)           AS units_sold,
+       coalesce(sum(oi.quantity * oi.unit_price), 0) AS revenue
+FROM products p
+JOIN categories cat ON cat.id = p.category_id
+LEFT JOIN order_items oi ON oi.product_id = p.id
+GROUP BY p.id, cat.name;

--- a/docker/demo-postgres/initdb/02-seed.sql
+++ b/docker/demo-postgres/initdb/02-seed.sql
@@ -1,0 +1,175 @@
+-- Synthetic seed data. Everything below is procedurally generated with random()
+-- so there is zero real-world PII. Volumes are tuned to look real but load fast.
+--
+-- NOTE: random() picks are computed in a subquery SELECT list *over*
+-- generate_series (so they evaluate once per row), and the per-order line-item
+-- pick uses a correlated LATERAL (references o.id). An *uncorrelated* LATERAL
+-- would have its random() folded to a single value and every row would match.
+
+SET client_min_messages = warning;
+
+-- Fixed seed -> the same demo data every time you re-seed (down -v && up -d).
+SELECT setseed(0.42);
+
+-- ---------------------------------------------------------------------------
+-- Categories (fixed set -> ids 1..8)
+-- ---------------------------------------------------------------------------
+INSERT INTO categories (name, slug) VALUES
+  ('Audio',       'audio'),
+  ('Wearables',   'wearables'),
+  ('Home Office', 'home-office'),
+  ('Cameras',     'cameras'),
+  ('Gaming',      'gaming'),
+  ('Accessories', 'accessories'),
+  ('Networking',  'networking'),
+  ('Storage',     'storage');
+
+-- ---------------------------------------------------------------------------
+-- Products (~120)
+-- ---------------------------------------------------------------------------
+INSERT INTO products (category_id, sku, name, description, price, in_stock, is_active, attributes, created_at)
+SELECT
+  category_id,
+  'SKU-' || lpad(g::text, 5, '0'),
+  adj || ' ' || noun,
+  'A ' || lower(adj) || ' ' || lower(noun) || ' for everyday use.',
+  price,
+  in_stock,
+  is_active,
+  jsonb_build_object('color', color, 'weight_g', weight_g, 'warranty_months', warranty),
+  created_at
+FROM (
+  SELECT
+    g,
+    1 + floor(random() * 8)::int AS category_id,
+    (ARRAY['Aurora','Nimbus','Vertex','Quartz','Pulse','Atlas','Lumen','Echo',
+           'Pixel','Nova','Forge','Drift','Orbit','Halo','Cobalt','Zenith'])[1 + floor(random() * 16)::int] AS adj,
+    (ARRAY['Headphones','Watch','Desk Lamp','Camera','Controller','Keyboard',
+           'Mouse','Router','SSD','Earbuds','Monitor','Webcam','Speaker','Hub',
+           'Microphone','Tripod'])[1 + floor(random() * 16)::int] AS noun,
+    round((5 + random() * 995)::numeric, 2) AS price,
+    floor(random() * 500)::int AS in_stock,
+    random() < 0.92 AS is_active,
+    (ARRAY['black','white','silver','blue','red','graphite'])[1 + floor(random() * 6)::int] AS color,
+    floor(50 + random() * 1950)::int AS weight_g,
+    (ARRAY[12, 24, 36])[1 + floor(random() * 3)::int] AS warranty,
+    now() - (random() * 720 || ' days')::interval AS created_at
+  FROM generate_series(1, 120) g
+) r;
+
+-- ---------------------------------------------------------------------------
+-- Customers (~200 -> ids 1..200)
+-- ---------------------------------------------------------------------------
+INSERT INTO customers (first_name, last_name, email, country, city, signup_date, lifetime_value, is_vip, metadata)
+SELECT
+  fn,
+  ln,
+  lower(fn || '.' || ln || g || '@example.com'),
+  (ARRAY['United States','United Kingdom','Germany','France','Australia',
+         'Canada','Japan','Netherlands','Spain','Sweden'])[loc],
+  (ARRAY['New York','London','Berlin','Paris','Sydney',
+         'Toronto','Tokyo','Amsterdam','Madrid','Stockholm'])[loc],
+  signup_date,
+  lifetime_value,
+  is_vip,
+  jsonb_build_object('segment', segment, 'newsletter', newsletter, 'referral', referral)
+FROM (
+  SELECT
+    g,
+    (ARRAY['Ava','Liam','Mia','Noah','Emma','Ethan','Olivia','Lucas','Sofia',
+           'Mason','Isla','Leo','Aria','Finn','Maya','Hugo','Nora','Felix',
+           'Ruby','Theo'])[1 + floor(random() * 20)::int] AS fn,
+    (ARRAY['Smith','Johnson','Williams','Brown','Jones','Garcia','Miller',
+           'Davis','Rodriguez','Martinez','Hernandez','Lopez','Wilson','Anderson',
+           'Thomas','Taylor','Moore','Jackson','Martin','Lee'])[1 + floor(random() * 20)::int] AS ln,
+    1 + floor(random() * 10)::int AS loc,
+    (DATE '2022-01-01' + (random() * 1250)::int) AS signup_date,
+    round((random() * 8000)::numeric, 2) AS lifetime_value,
+    random() < 0.15 AS is_vip,
+    (ARRAY['consumer','smb','enterprise'])[1 + floor(random() * 3)::int] AS segment,
+    random() < 0.6 AS newsletter,
+    (ARRAY['organic','ads','partner','referral'])[1 + floor(random() * 4)::int] AS referral
+  FROM generate_series(1, 200) g
+) r;
+
+-- ---------------------------------------------------------------------------
+-- Orders (~600 -> ids 1..600). total filled in after line items exist.
+-- ---------------------------------------------------------------------------
+INSERT INTO orders (customer_id, status, currency, total, placed_at, shipped_at)
+SELECT
+  customer_id,
+  status,
+  currency,
+  0,
+  placed_at,
+  CASE WHEN status IN ('shipped','delivered')
+       THEN placed_at + (random() * 9 || ' days')::interval
+       ELSE NULL END
+FROM (
+  SELECT
+    g,
+    1 + floor(random() * 200)::int AS customer_id,
+    -- weighted toward delivered/paid so the shop looks healthy
+    (ARRAY['pending','paid','paid','shipped','delivered','delivered','delivered',
+           'cancelled','refunded'])[1 + floor(random() * 9)::int]::order_status AS status,
+    (ARRAY['USD','EUR','GBP','AUD'])[1 + floor(random() * 4)::int]::char(3) AS currency,
+    now() - (random() * 600 || ' days')::interval AS placed_at
+  FROM generate_series(1, 600) g
+) r;
+
+-- ---------------------------------------------------------------------------
+-- Order items (1..4 distinct products per order; correlated LATERAL)
+-- ---------------------------------------------------------------------------
+INSERT INTO order_items (order_id, product_id, quantity, unit_price)
+SELECT o.id, p.id, 1 + floor(random() * 4)::int, p.price
+FROM orders o
+CROSS JOIN LATERAL (
+  SELECT id, price
+  FROM products
+  WHERE o.id IS NOT NULL          -- correlation hook: forces per-order evaluation
+  ORDER BY random()
+  LIMIT 1 + floor(random() * 4)::int
+) p;
+
+-- Roll the line-item totals back up onto the order.
+UPDATE orders o
+SET total = s.total
+FROM (
+  SELECT order_id, round(sum(quantity * unit_price), 2) AS total
+  FROM order_items
+  GROUP BY order_id
+) s
+WHERE o.id = s.order_id;
+
+-- ---------------------------------------------------------------------------
+-- Payments (one per non-pending order; status tracks the order)
+-- ---------------------------------------------------------------------------
+INSERT INTO payments (order_id, method, amount, status, paid_at)
+SELECT
+  o.id,
+  method,
+  o.total,
+  CASE
+    WHEN o.status = 'refunded'  THEN 'refunded'
+    WHEN o.status = 'cancelled' THEN 'failed'
+    ELSE 'completed'
+  END::payment_status,
+  CASE WHEN o.status = 'cancelled' THEN NULL
+       ELSE o.placed_at + (random() * 2 || ' days')::interval END
+FROM orders o
+CROSS JOIN LATERAL (
+  SELECT (ARRAY['card','card','paypal','bank_transfer','apple_pay','google_pay'])[1 + floor(random() * 6)::int]::payment_method AS method
+  WHERE o.id IS NOT NULL
+) m
+WHERE o.status <> 'pending';
+
+-- Refresh lifetime_value from real order history for a believable column.
+UPDATE customers c
+SET lifetime_value = s.spent
+FROM (
+  SELECT customer_id, round(sum(total), 2) AS spent
+  FROM orders
+  WHERE status IN ('paid','shipped','delivered')
+  GROUP BY customer_id
+) s
+WHERE c.id = s.customer_id;

--- a/packages/ai/src/context.ts
+++ b/packages/ai/src/context.ts
@@ -1,0 +1,57 @@
+// Builds the compact schema context string sent to the model. Kept structurally
+// typed (not tied to @cellar/ipc) so the package stays standalone and testable;
+// the desktop app maps its introspected `Database[]` onto these shapes.
+
+export interface ContextColumn {
+  name: string;
+  data_type: string;
+  nullable: boolean;
+  is_primary_key: boolean;
+}
+
+export interface ContextTable {
+  schema: string;
+  name: string;
+  columns: ContextColumn[];
+}
+
+export interface SchemaContextInput {
+  connectionName?: string;
+  engine?: string;
+  database?: string;
+  schema?: string;
+  /** Tables to inline as lightweight DDL. Cap upstream — this renders all. */
+  tables?: ContextTable[];
+}
+
+function renderColumn(c: ContextColumn): string {
+  const flags: string[] = [];
+  if (c.is_primary_key) flags.push("pk");
+  if (!c.nullable) flags.push("not null");
+  const suffix = flags.length ? ` [${flags.join(", ")}]` : "";
+  return `  ${c.name} ${c.data_type}${suffix}`;
+}
+
+function renderTable(t: ContextTable): string {
+  const head = `${t.schema}.${t.name} (`;
+  const cols = t.columns.map(renderColumn).join(",\n");
+  return `${head}\n${cols}\n)`;
+}
+
+/** Produce a terse, deterministic context block. Returns an empty string when
+ * there is nothing useful to send, so callers can omit the section entirely. */
+export function buildSchemaContext(input: SchemaContextInput): string {
+  const header: string[] = [];
+  if (input.engine) header.push(`Engine: ${input.engine}`);
+  if (input.connectionName) header.push(`Connection: ${input.connectionName}`);
+  if (input.database) header.push(`Database: ${input.database}`);
+  if (input.schema) header.push(`Schema: ${input.schema}`);
+
+  const tables = (input.tables ?? []).filter((t) => t.columns.length > 0);
+  const body = tables.map(renderTable).join("\n\n");
+
+  if (!header.length && !body) return "";
+  if (!body) return header.join("\n");
+  if (!header.length) return body;
+  return `${header.join("\n")}\n\n${body}`;
+}

--- a/packages/ai/src/gemini.test.ts
+++ b/packages/ai/src/gemini.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  GeminiError,
+  generateContent,
+  humanizeTokenLimit,
+  listGeminiModels,
+  modelVersion,
+} from "./gemini";
+import type { FetchLike } from "./types";
+
+function jsonResponse(status: number, body: unknown): Awaited<ReturnType<FetchLike>> {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+describe("humanizeTokenLimit", () => {
+  it("formats millions and thousands", () => {
+    expect(humanizeTokenLimit(1_048_576)).toBe("1m");
+    expect(humanizeTokenLimit(2_000_000)).toBe("2m");
+    expect(humanizeTokenLimit(200_000)).toBe("200k");
+    expect(humanizeTokenLimit(900)).toBe("900");
+  });
+  it("returns undefined for missing/zero", () => {
+    expect(humanizeTokenLimit(0)).toBeUndefined();
+    expect(humanizeTokenLimit(undefined)).toBeUndefined();
+  });
+});
+
+describe("modelVersion", () => {
+  it("extracts major.minor", () => {
+    expect(modelVersion("gemini-2.5-pro")).toBeCloseTo(2.05);
+    expect(modelVersion("gemini-1.5-flash")).toBeCloseTo(1.05);
+    expect(modelVersion("gemini-pro")).toBe(-1);
+  });
+});
+
+describe("listGeminiModels", () => {
+  it("filters to chat-capable gemini models and sorts newest first", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse(200, {
+        models: [
+          {
+            name: "models/gemini-1.5-flash",
+            displayName: "Gemini 1.5 Flash",
+            inputTokenLimit: 1_000_000,
+            supportedGenerationMethods: ["generateContent"],
+          },
+          {
+            name: "models/gemini-2.5-pro",
+            displayName: "Gemini 2.5 Pro",
+            inputTokenLimit: 2_000_000,
+            supportedGenerationMethods: ["generateContent", "countTokens"],
+          },
+          {
+            name: "models/embedding-001",
+            displayName: "Embedding",
+            supportedGenerationMethods: ["embedContent"],
+          },
+          {
+            name: "models/gemini-1.0-pro-vision",
+            displayName: "Vision",
+            // no generateContent -> filtered out
+            supportedGenerationMethods: ["countTokens"],
+          },
+        ],
+      }),
+    );
+
+    const models = await listGeminiModels("AIzaTEST", { fetchImpl });
+    expect(models.map((m) => m.id)).toEqual([
+      "gemini-2.5-pro",
+      "gemini-1.5-flash",
+    ]);
+    expect(models[0]).toMatchObject({ label: "Gemini 2.5 Pro", ctx: "2m" });
+    // key must be passed in the query string, never a header/body
+    const url = fetchImpl.mock.calls[0]![0] as string;
+    expect(url).toContain("key=AIzaTEST");
+  });
+
+  it("falls back to id when displayName is missing", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse(200, {
+        models: [
+          {
+            name: "models/gemini-2.0-flash",
+            supportedGenerationMethods: ["generateContent"],
+          },
+        ],
+      }),
+    );
+    const models = await listGeminiModels("k", { fetchImpl });
+    expect(models[0]).toMatchObject({ id: "gemini-2.0-flash", label: "gemini-2.0-flash" });
+  });
+
+  it("throws a GeminiError with the provider message on failure", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse(400, { error: { message: "API key not valid" } }),
+    );
+    await expect(listGeminiModels("bad", { fetchImpl })).rejects.toMatchObject({
+      name: "GeminiError",
+      status: 400,
+      message: "API key not valid",
+    });
+  });
+
+  it("rejects an empty key without calling fetch", async () => {
+    const fetchImpl = vi.fn();
+    await expect(listGeminiModels("", { fetchImpl })).rejects.toBeInstanceOf(
+      GeminiError,
+    );
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe("generateContent", () => {
+  it("posts contents and system instruction, returns joined text + usage", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse(200, {
+        candidates: [{ content: { parts: [{ text: "SELECT " }, { text: "1;" }] } }],
+        usageMetadata: {
+          promptTokenCount: 10,
+          candidatesTokenCount: 5,
+          totalTokenCount: 15,
+        },
+      }),
+    );
+
+    const result = await generateContent(
+      {
+        apiKey: "k",
+        model: "gemini-2.5-pro",
+        systemInstruction: "be terse",
+        messages: [{ role: "user", content: "give me one" }],
+      },
+      { fetchImpl },
+    );
+
+    expect(result.text).toBe("SELECT 1;");
+    expect(result.usage).toEqual({
+      promptTokens: 10,
+      completionTokens: 5,
+      totalTokens: 15,
+    });
+
+    const [url, init] = fetchImpl.mock.calls[0]!;
+    expect(url).toContain("gemini-2.5-pro:generateContent");
+    const body = JSON.parse((init as { body: string }).body);
+    expect(body.systemInstruction.parts[0].text).toBe("be terse");
+    expect(body.contents[0]).toEqual({
+      role: "user",
+      parts: [{ text: "give me one" }],
+    });
+  });
+
+  it("throws when the prompt is blocked", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse(200, { promptFeedback: { blockReason: "SAFETY" } }),
+    );
+    await expect(
+      generateContent(
+        { apiKey: "k", model: "m", messages: [{ role: "user", content: "x" }] },
+        { fetchImpl },
+      ),
+    ).rejects.toThrow(/blocked/i);
+  });
+
+  it("throws on an empty candidate", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse(200, { candidates: [{ finishReason: "MAX_TOKENS", content: { parts: [] } }] }),
+    );
+    await expect(
+      generateContent(
+        { apiKey: "k", model: "m", messages: [{ role: "user", content: "x" }] },
+        { fetchImpl },
+      ),
+    ).rejects.toThrow(/MAX_TOKENS/);
+  });
+
+  it("surfaces HTTP errors", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse(429, { error: { message: "Quota exceeded" } }),
+    );
+    await expect(
+      generateContent(
+        { apiKey: "k", model: "m", messages: [{ role: "user", content: "x" }] },
+        { fetchImpl },
+      ),
+    ).rejects.toMatchObject({ status: 429, message: "Quota exceeded" });
+  });
+});

--- a/packages/ai/src/gemini.ts
+++ b/packages/ai/src/gemini.ts
@@ -1,0 +1,190 @@
+// Gemini (Google Generative Language API) client.
+//
+// Per SPEC §3 and §6.7 the request goes directly from the user's machine to the
+// provider with their own key — Cellar never proxies. This module is pure data
+// plumbing: it takes an API key + payload and talks HTTP. The key is supplied by
+// the caller (loaded from the OS keychain) and is never persisted here.
+
+import type {
+  AiModel,
+  FetchLike,
+  GenerateRequest,
+  GenerateResult,
+} from "./types";
+
+const BASE = "https://generativelanguage.googleapis.com/v1beta";
+
+/** Error carrying the provider's HTTP status and message so the UI can show a
+ * useful reason (bad key, quota, model not found) instead of a generic failure. */
+export class GeminiError extends Error {
+  override readonly name = "GeminiError";
+  constructor(
+    readonly status: number,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+interface ListModelsResponse {
+  models?: Array<{
+    name?: string;
+    displayName?: string;
+    description?: string;
+    inputTokenLimit?: number;
+    supportedGenerationMethods?: string[];
+  }>;
+}
+
+interface GenerateContentResponse {
+  candidates?: Array<{
+    content?: { parts?: Array<{ text?: string }> };
+    finishReason?: string;
+  }>;
+  promptFeedback?: { blockReason?: string };
+  usageMetadata?: {
+    promptTokenCount?: number;
+    candidatesTokenCount?: number;
+    totalTokenCount?: number;
+  };
+  error?: { message?: string };
+}
+
+/** Collapse a raw token limit into a compact display string (`1m`, `200k`). */
+export function humanizeTokenLimit(n: number | undefined): string | undefined {
+  if (!n || n <= 0) return undefined;
+  if (n >= 1_000_000) return `${Math.round(n / 1_000_000)}m`;
+  if (n >= 1_000) return `${Math.round(n / 1_000)}k`;
+  return String(n);
+}
+
+/** Pull a comparable version number out of a model id (`gemini-2.5-pro` -> 2.5).
+ * Used only to surface newer models first; unknown shapes sort last. */
+export function modelVersion(id: string): number {
+  const m = /(\d+)(?:\.(\d+))?/.exec(id);
+  if (!m) return -1;
+  const major = Number(m[1]);
+  const minor = m[2] ? Number(m[2]) : 0;
+  return major + minor / 100;
+}
+
+function sortModels(models: AiModel[]): AiModel[] {
+  return [...models].sort((a, b) => {
+    const dv = modelVersion(b.id) - modelVersion(a.id);
+    if (dv !== 0) return dv;
+    return a.id.localeCompare(b.id);
+  });
+}
+
+async function errorFrom(
+  res: { status: number; json: () => Promise<unknown>; text: () => Promise<string> },
+  fallback: string,
+): Promise<GeminiError> {
+  try {
+    const body = (await res.json()) as { error?: { message?: string } };
+    const msg = body?.error?.message;
+    if (msg) return new GeminiError(res.status, msg);
+  } catch {
+    // fall through to status-only message
+  }
+  return new GeminiError(res.status, `${fallback} (HTTP ${res.status})`);
+}
+
+function resolveFetch(custom?: FetchLike): FetchLike {
+  if (custom) return custom;
+  if (typeof fetch === "function") return fetch as unknown as FetchLike;
+  throw new Error("no fetch implementation available");
+}
+
+/** Discover the models this API key can call. Filters to chat-capable Gemini
+ * models (those exposing `generateContent`) and surfaces newest first. */
+export async function listGeminiModels(
+  apiKey: string,
+  opts: { fetchImpl?: FetchLike; signal?: AbortSignal } = {},
+): Promise<AiModel[]> {
+  if (!apiKey) throw new GeminiError(401, "An API key is required to list models.");
+  const f = resolveFetch(opts.fetchImpl);
+  const res = await f(
+    `${BASE}/models?pageSize=1000&key=${encodeURIComponent(apiKey)}`,
+    { method: "GET", signal: opts.signal },
+  );
+  if (!res.ok) throw await errorFrom(res, "Failed to list models");
+
+  const body = (await res.json()) as ListModelsResponse;
+  const models: AiModel[] = [];
+  for (const m of body.models ?? []) {
+    const name = m.name ?? "";
+    const id = name.startsWith("models/") ? name.slice("models/".length) : name;
+    if (!id) continue;
+    const methods = m.supportedGenerationMethods ?? [];
+    if (!methods.includes("generateContent")) continue;
+    if (!id.startsWith("gemini")) continue;
+    models.push({
+      id,
+      label: m.displayName?.trim() || id,
+      ctx: humanizeTokenLimit(m.inputTokenLimit),
+    });
+  }
+  return sortModels(models);
+}
+
+/** Run one non-streaming generation. Returns the joined candidate text plus
+ * token usage. Throws {@link GeminiError} on HTTP failure or a blocked prompt. */
+export async function generateContent(
+  req: GenerateRequest,
+  opts: { fetchImpl?: FetchLike } = {},
+): Promise<GenerateResult> {
+  if (!req.apiKey) throw new GeminiError(401, "An API key is required.");
+  if (!req.model) throw new GeminiError(400, "No model selected.");
+  const f = resolveFetch(opts.fetchImpl);
+
+  const body: Record<string, unknown> = {
+    contents: req.messages.map((m) => ({
+      role: m.role,
+      parts: [{ text: m.content }],
+    })),
+  };
+  if (req.systemInstruction) {
+    body.systemInstruction = { parts: [{ text: req.systemInstruction }] };
+  }
+
+  const res = await f(
+    `${BASE}/models/${encodeURIComponent(req.model)}:generateContent?key=${encodeURIComponent(req.apiKey)}`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+      signal: req.signal,
+    },
+  );
+  if (!res.ok) throw await errorFrom(res, "Generation failed");
+
+  const data = (await res.json()) as GenerateContentResponse;
+  if (data.promptFeedback?.blockReason) {
+    throw new GeminiError(
+      400,
+      `Request blocked by the provider (${data.promptFeedback.blockReason}).`,
+    );
+  }
+  const parts = data.candidates?.[0]?.content?.parts ?? [];
+  const text = parts.map((p) => p.text ?? "").join("");
+  if (!text) {
+    const reason = data.candidates?.[0]?.finishReason;
+    throw new GeminiError(
+      502,
+      reason
+        ? `The model returned no text (finish reason: ${reason}).`
+        : "The model returned an empty response.",
+    );
+  }
+
+  const usage = data.usageMetadata
+    ? {
+        promptTokens: data.usageMetadata.promptTokenCount ?? 0,
+        completionTokens: data.usageMetadata.candidatesTokenCount ?? 0,
+        totalTokens: data.usageMetadata.totalTokenCount ?? 0,
+      }
+    : undefined;
+
+  return { text, usage };
+}

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -1,2 +1,45 @@
-// AI providers, prompts, and context building land here.
-export {};
+// AI providers, prompts, and context building.
+//
+// Today this wires Gemini (Google Generative Language API) end-to-end; other
+// providers are declared in `providers.ts` but disabled until implemented.
+
+export type {
+  AiProviderId,
+  AiTopic,
+  AiModel,
+  ChatMessage,
+  TokenUsage,
+  GenerateRequest,
+  GenerateResult,
+  FetchLike,
+} from "./types";
+
+export {
+  PROVIDERS,
+  DEFAULT_PROVIDER,
+  getProvider,
+  type ProviderMeta,
+} from "./providers";
+
+export {
+  GeminiError,
+  listGeminiModels,
+  generateContent,
+  humanizeTokenLimit,
+  modelVersion,
+} from "./gemini";
+
+export {
+  SYSTEM_PROMPT,
+  TOPICS,
+  ORDERED_TOPICS,
+  buildUserPrompt,
+  type TopicMeta,
+} from "./prompts";
+
+export {
+  buildSchemaContext,
+  type SchemaContextInput,
+  type ContextTable,
+  type ContextColumn,
+} from "./context";

--- a/packages/ai/src/prompts.test.ts
+++ b/packages/ai/src/prompts.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { buildUserPrompt, ORDERED_TOPICS, TOPICS } from "./prompts";
+import { buildSchemaContext } from "./context";
+import { PROVIDERS, getProvider } from "./providers";
+
+describe("topics", () => {
+  it("exposes the four presets plus ask in order", () => {
+    expect(ORDERED_TOPICS).toEqual([
+      "generate",
+      "explain",
+      "optimize",
+      "migrate",
+      "ask",
+    ]);
+  });
+
+  it("every topic has a label and hint", () => {
+    for (const t of ORDERED_TOPICS) {
+      expect(TOPICS[t].label.length).toBeGreaterThan(0);
+      expect(TOPICS[t].hint.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("buildUserPrompt", () => {
+  it("prepends the preset instruction and includes context + request", () => {
+    const out = buildUserPrompt("generate", "top 10 customers by spend", "ctx here");
+    expect(out).toContain(TOPICS.generate.instruction);
+    expect(out).toContain("Schema context:\nctx here");
+    expect(out).toContain("Request:\ntop 10 customers by spend");
+  });
+
+  it("ask has no instruction prefix", () => {
+    const out = buildUserPrompt("ask", "what is a CTE?");
+    expect(out).toBe("Request:\nwhat is a CTE?");
+  });
+
+  it("omits empty sections", () => {
+    const out = buildUserPrompt("explain", "");
+    expect(out).toBe(TOPICS.explain.instruction);
+  });
+});
+
+describe("buildSchemaContext", () => {
+  it("renders header and table DDL", () => {
+    const ctx = buildSchemaContext({
+      engine: "postgres",
+      database: "shop",
+      schema: "public",
+      tables: [
+        {
+          schema: "public",
+          name: "orders",
+          columns: [
+            { name: "id", data_type: "int4", nullable: false, is_primary_key: true },
+            { name: "total", data_type: "numeric", nullable: true, is_primary_key: false },
+          ],
+        },
+      ],
+    });
+    expect(ctx).toContain("Engine: postgres");
+    expect(ctx).toContain("public.orders (");
+    expect(ctx).toContain("id int4 [pk, not null]");
+    expect(ctx).toContain("total numeric");
+  });
+
+  it("returns empty string when there is nothing to send", () => {
+    expect(buildSchemaContext({})).toBe("");
+  });
+
+  it("skips tables with no columns", () => {
+    const ctx = buildSchemaContext({
+      tables: [{ schema: "public", name: "empty", columns: [] }],
+    });
+    expect(ctx).toBe("");
+  });
+});
+
+describe("providers", () => {
+  it("enables only google", () => {
+    const enabled = PROVIDERS.filter((p) => p.enabled).map((p) => p.id);
+    expect(enabled).toEqual(["google"]);
+  });
+  it("getProvider throws on unknown", () => {
+    // @ts-expect-error testing the runtime guard
+    expect(() => getProvider("nope")).toThrow();
+  });
+});

--- a/packages/ai/src/prompts.ts
+++ b/packages/ai/src/prompts.ts
@@ -1,0 +1,79 @@
+import type { AiTopic } from "./types";
+
+/** System instruction sent out-of-band on every turn. Keeps the model anchored
+ * on Cellar's product stance: inspectable, dialect-correct SQL, read-only by
+ * default, destructive statements clearly flagged (SPEC §6.7). */
+export const SYSTEM_PROMPT = `You are Cellar's built-in SQL assistant, embedded in a desktop database client.
+
+Rules:
+- The user works against a real database. Prefer correct, dialect-appropriate SQL over generic advice.
+- When you return SQL, put it in a single fenced \`\`\`sql code block so the app can render and gate it.
+- Use the schema context provided. Never invent table or column names; if something is missing, say so.
+- Cellar runs queries read-only by default. Destructive statements (DROP, TRUNCATE, DELETE/UPDATE without WHERE) must be called out explicitly with a one-line warning.
+- Be concise and technical. The user understands SQL.`;
+
+export interface TopicMeta {
+  /** Bottom-bar label. */
+  label: string;
+  /** Hover hint / one-liner. */
+  hint: string;
+  /** Instruction prepended to the user's text for this preset. */
+  instruction: string;
+}
+
+export const TOPICS: Record<AiTopic, TopicMeta> = {
+  generate: {
+    label: "generate",
+    hint: "Write SQL from a description",
+    instruction:
+      "Generate a SQL query for the request below. Return the query in a single ```sql block, then a one-sentence explanation of what it does.",
+  },
+  explain: {
+    label: "explain",
+    hint: "Explain SQL, a table, or a result",
+    instruction:
+      "Explain the following clearly and concisely. If it is SQL, describe what it returns and any performance characteristics worth noting.",
+  },
+  optimize: {
+    label: "optimize",
+    hint: "Suggest a faster equivalent query",
+    instruction:
+      "Optimize the SQL below. Return an improved query in a ```sql block, then a short bulleted list of the changes and why they help. Preserve the original result set.",
+  },
+  migrate: {
+    label: "migrate",
+    hint: "Draft a schema migration",
+    instruction:
+      "Draft the SQL migration described below. Return forward DDL in a ```sql block. Flag any destructive or irreversible step explicitly, and note whether it can run inside a transaction.",
+  },
+  ask: {
+    label: "ask",
+    hint: "Free-form question",
+    instruction: "",
+  },
+};
+
+export const ORDERED_TOPICS: AiTopic[] = [
+  "generate",
+  "explain",
+  "optimize",
+  "migrate",
+  "ask",
+];
+
+/** Assemble the user-role turn for a topic: preset instruction, then schema
+ * context, then the user's own text. Any part may be empty. */
+export function buildUserPrompt(
+  topic: AiTopic,
+  userText: string,
+  context?: string,
+): string {
+  const sections: string[] = [];
+  const instruction = TOPICS[topic].instruction.trim();
+  if (instruction) sections.push(instruction);
+  const ctx = context?.trim();
+  if (ctx) sections.push(`Schema context:\n${ctx}`);
+  const text = userText.trim();
+  if (text) sections.push(`Request:\n${text}`);
+  return sections.join("\n\n");
+}

--- a/packages/ai/src/providers.ts
+++ b/packages/ai/src/providers.ts
@@ -1,0 +1,68 @@
+import type { AiProviderId } from "./types";
+
+/** Static metadata for the provider picker. `enabled` gates whether a provider
+ * can be selected — only Google/Gemini is wired today; everything else renders
+ * with a "coming soon" tag and is non-interactive. */
+export interface ProviderMeta {
+  id: AiProviderId;
+  label: string;
+  /** Short mono subtitle, e.g. `gemini-* family`. */
+  sub: string;
+  enabled: boolean;
+  /** Leading hint shown next to the API-key input. */
+  keyPrefix: string;
+  /** Base endpoint, shown read-only in settings. */
+  endpoint: string;
+}
+
+export const PROVIDERS: ProviderMeta[] = [
+  {
+    id: "google",
+    label: "Google",
+    sub: "gemini-* family",
+    enabled: true,
+    keyPrefix: "AIza",
+    endpoint: "https://generativelanguage.googleapis.com/v1beta",
+  },
+  {
+    id: "anthropic",
+    label: "Anthropic",
+    sub: "claude-* family",
+    enabled: false,
+    keyPrefix: "sk-ant-",
+    endpoint: "https://api.anthropic.com/v1",
+  },
+  {
+    id: "openai",
+    label: "OpenAI",
+    sub: "gpt-* family",
+    enabled: false,
+    keyPrefix: "sk-",
+    endpoint: "https://api.openai.com/v1",
+  },
+  {
+    id: "local",
+    label: "Local",
+    sub: "Ollama, LM Studio",
+    enabled: false,
+    keyPrefix: "none",
+    endpoint: "http://localhost:11434/v1",
+  },
+  {
+    id: "custom",
+    label: "Custom",
+    sub: "OpenAI-compatible URL",
+    enabled: false,
+    keyPrefix: "key",
+    endpoint: "https://example.invalid/v1",
+  },
+];
+
+export function getProvider(id: AiProviderId): ProviderMeta {
+  const p = PROVIDERS.find((x) => x.id === id);
+  if (!p) throw new Error(`unknown AI provider: ${id}`);
+  return p;
+}
+
+/** The provider Cellar defaults to and the only one wired end-to-end. */
+export const DEFAULT_PROVIDER: AiProviderId = "google";

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -1,0 +1,66 @@
+// Shared AI types. This package is provider-agnostic at the type level: the
+// concrete provider client (currently Gemini) lives alongside in its own file.
+
+/** Providers Cellar knows about. Only `google` is wired today; the rest are
+ * surfaced in the UI as "coming soon" and are not selectable. */
+export type AiProviderId = "google" | "anthropic" | "openai" | "local" | "custom";
+
+/** The four task presets the AI panel exposes, plus the free-form `ask`. These
+ * map 1:1 to the bottom-bar buttons in the right-hand AI panel. */
+export type AiTopic = "generate" | "explain" | "optimize" | "migrate" | "ask";
+
+/** A model offered by a provider. For Gemini these are discovered live from the
+ * API key rather than hardcoded. */
+export interface AiModel {
+  /** API id used in request paths, e.g. `gemini-2.5-pro` (no `models/` prefix). */
+  id: string;
+  /** Human label, e.g. `Gemini 2.5 Pro`. Falls back to `id` when absent. */
+  label: string;
+  /** Context-window descriptor for display, e.g. `1m`, `200k`. */
+  ctx?: string;
+}
+
+/** One turn in a conversation. Gemini uses `model` (not `assistant`) for the
+ * provider's role; we keep that vocabulary end-to-end to avoid translation. */
+export interface ChatMessage {
+  role: "user" | "model";
+  content: string;
+}
+
+/** Token accounting returned by the provider, when available. */
+export interface TokenUsage {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+}
+
+export interface GenerateRequest {
+  apiKey: string;
+  model: string;
+  messages: ChatMessage[];
+  /** Optional system instruction prepended out-of-band from the turn history. */
+  systemInstruction?: string;
+  signal?: AbortSignal;
+}
+
+export interface GenerateResult {
+  text: string;
+  usage?: TokenUsage;
+}
+
+/** The subset of `fetch` this package relies on. Injectable so tests can run
+ * without a real network and callers can swap in a Tauri http client later. */
+export type FetchLike = (
+  input: string,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+    signal?: AbortSignal;
+  },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+  text: () => Promise<string>;
+}>;

--- a/packages/ipc/src/generated.ts
+++ b/packages/ipc/src/generated.ts
@@ -116,6 +116,53 @@ async listQueryHistory(connectionId: string | null, database: string | null, tab
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
+},
+/**
+ * Persist the API key for `provider` in the OS keychain, overwriting any
+ * existing entry.
+ */
+async aiStoreKey(provider: string, key: string) : Promise<Result<null, CellarError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("ai_store_key", { provider, key }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Load the stored API key for `provider`. Returns `None` when nothing is
+ * stored, which is distinct from a keychain failure.
+ */
+async aiLoadKey(provider: string) : Promise<Result<string | null, CellarError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("ai_load_key", { provider }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Remove the stored API key for `provider`. A no-op if none exists.
+ */
+async aiDeleteKey(provider: string) : Promise<Result<null, CellarError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("ai_delete_key", { provider }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Report whether a key is stored for `provider` without returning it — used by
+ * settings to show "configured" state.
+ */
+async aiHasKey(provider: string) : Promise<Result<boolean, CellarError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("ai_has_key", { provider }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
 }
 }
 

--- a/packages/ipc/src/index.test.ts
+++ b/packages/ipc/src/index.test.ts
@@ -15,6 +15,10 @@ describe("@cellar/ipc", () => {
     // If a command name changes, this test should fail so the UI gets a heads-up.
     expect(Object.keys(commands).sort()).toEqual(
       [
+        "aiDeleteKey",
+        "aiHasKey",
+        "aiLoadKey",
+        "aiStoreKey",
         "browseTable",
         "commitTableChanges",
         "connect",

--- a/packages/ipc/src/mock.ts
+++ b/packages/ipc/src/mock.ts
@@ -152,4 +152,24 @@ export const mockCommands = {
     _search: string | null,
     _limit: number | null,
   ): Promise<Result<QueryHistoryRecord[], CellarError>> => ok([]),
+
+  // AI keys: in web mode there is no keychain, so hold them in memory for the
+  // session. Enough to drive the settings/panel flow without persistence.
+  aiStoreKey: async (provider: string, key: string): Promise<Result<null, CellarError>> => {
+    mockAiKeys.set(provider, key);
+    return ok(null);
+  },
+
+  aiLoadKey: async (provider: string): Promise<Result<string | null, CellarError>> =>
+    ok(mockAiKeys.get(provider) ?? null),
+
+  aiDeleteKey: async (provider: string): Promise<Result<null, CellarError>> => {
+    mockAiKeys.delete(provider);
+    return ok(null);
+  },
+
+  aiHasKey: async (provider: string): Promise<Result<boolean, CellarError>> =>
+    ok(mockAiKeys.has(provider)),
 };
+
+const mockAiKeys = new Map<string, string>();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
 
   apps/desktop:
     dependencies:
+      '@cellar/ai':
+        specifier: workspace:*
+        version: link:../../packages/ai
       '@cellar/data-grid':
         specifier: workspace:*
         version: link:../../packages/data-grid


### PR DESCRIPTION
## Summary
Wires Cellar's right-hand AI panel and AI settings to **Google Gemini** end-to-end — the first fully supported provider. Other providers (Anthropic, OpenAI, Local, Custom) appear with a "coming soon" tag and are disabled. Also adds a local demo Postgres for screenshots, and fixes two Postgres driver bugs that demo data surfaced.

## What changed
**Gemini AI (`packages/ai`, desktop)**
- `packages/ai`: Gemini client with **live model discovery** (`listGeminiModels`) and `generateContent`, a provider registry (only Google enabled), the four topic presets — **generate / explain / optimize / migrate** — plus free-form `ask`, and a schema-context builder. Fully unit tested.
- Keychain-backed key storage: new `ai_store_key` / `ai_load_key` / `ai_delete_key` / `ai_has_key` commands via `cellar-secrets` (namespaced `ai:<provider>`, never written to disk). IPC bindings regenerated; web mock updated.
- Frontend AI store (`state/ai.ts`): provider/model selection (persisted), model fetch on key save, chat send with clean alternating history on retries.
- `AIPanel` / `AIMessage`: the four topic buttons, context chips from the active tab, and replies rendered with copyable SQL code blocks. `settingsAIPanel` wires provider/key/model config.

**Demo database (`docker/demo-postgres`)**
- `docker compose up -d` stands up Postgres 16 with a seeded e-commerce schema (enums, jsonb, FKs, indexes, comments, views) — all synthetic data, tuned to look real but load fast.

**Postgres driver fixes**
- `decode.rs`: decode user-defined **enums** via their label bytes instead of failing with `UnsupportedType`.
- `state.rs` `find_table`: resolve **views** as primary-key-less tables so they're browsable, instead of "not found in schema metadata".

## User impact
- Configure a Gemini key in AI settings, pick a discovered model, and use the AI panel against real schema context.
- `orders`, `payments`, and database views now load in the grid (previously failed).
- A one-command local database for taking clean screenshots.

## Validation
- `pnpm test` (cargo workspace + 4 JS packages + typecheck): green
- `pnpm lint` + `cargo fmt --all --check`: green
- `cargo test -p cellar-driver-postgres --features integration-tests` (real Postgres via testcontainers): green, incl. new `execute_query_decodes_user_defined_enums`
- New unit tests: AI store/gemini/prompts/parser, `find_table` view resolution
- Verified the app's browse queries against the live demo DB for orders/payments/both views

## Known follow-ups
- A single undecodable cell still fails the whole grid; rendering just that cell as an error would be more resilient (separate change).
- AI history persistence, inline editor completion, and the remaining providers are still stubs.