### PR TITLE
fix: make default editor/font size actually 13.5px

### DIFF
--- a/apps/desktop/src/components/modals/settingsWorkspacePanels.tsx
+++ b/apps/desktop/src/components/modals/settingsWorkspacePanels.tsx
@@ -86,7 +86,7 @@ export function SettingsAppearance() {
         </Row>
         <Row
           label="Font size"
-          hint="Scales the entire interface. Default is 12.5 px."
+          hint="Scales the entire interface. Default is 13.5 px."
         >
           <input
             className={CD_INPUT + " font-mono"}
@@ -109,7 +109,7 @@ export function SettingsAppearance() {
               {FONT_SIZE_MIN}
             </span>
             <span className="absolute top-0 left-1/2 -translate-x-1/2 whitespace-nowrap text-[9.5px] text-fg-3">
-              12.5
+              13.5
             </span>
             <span className="absolute top-0 right-0 translate-x-1/2 whitespace-nowrap text-[9.5px] text-fg-3">
               {FONT_SIZE_MAX}

--- a/apps/desktop/src/lib/settings.tsx
+++ b/apps/desktop/src/lib/settings.tsx
@@ -41,13 +41,13 @@ export const DEFAULTS: Settings = {
   theme: "dark",
   density: "compact",
   accent: "#a78bfa",
-  fontSizePx: 12.5,
+  fontSizePx: 13.5,
   interfaceFont: "Geist",
   monoFont: "JetBrains Mono",
 };
 
 const STORAGE_KEY = "cellar.settings.v1";
-const FONT_SIZE_BASELINE = 12.5;
+const FONT_SIZE_BASELINE = 13.5;
 export const FONT_SIZE_MIN = 10;
 export const FONT_SIZE_MAX = 22;
 


### PR DESCRIPTION
Fixes #51.

## Problem
The font-size setting defaulted to **12.5px** and used 12.5 as the scaling baseline (`FONT_SIZE_BASELINE`). But the editor's native CSS size is `--fs-md: 13.5px`. Because the UI scale is computed as `fontSizePx / baseline`, the default produced `12.5 / 12.5 = 1.0` — meaning the editor actually rendered at its native **13.5px** while the settings UI reported the size as **12.5px**. The displayed value never matched what the editor was really showing.

## Fix
- `apps/desktop/src/lib/settings.tsx`: default `fontSizePx` and `FONT_SIZE_BASELINE` changed `12.5 → 13.5`. Scale stays `1.0` at the default, so the editor still renders at its native `--fs-md` (13.5px) — but now the reported value is honest.
- `apps/desktop/src/components/modals/settingsWorkspacePanels.tsx`: updated the hint text ("Default is 13.5 px.") and the slider's default marker (`12.5 → 13.5`).

Test fixtures in `setupTransfer.test.ts` intentionally keep a non-default `12.5` value (they verify a value is transferred, not defaulted), so they're left unchanged.

## Verification
- `pnpm run typecheck` — passes
- `pnpm test` — 61/61 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)