### PR TITLE
docs: improvement plan, bug audit, and execution backlog

### DIFF
--- a/docs/improvement-plan-INDEX.md
+++ b/docs/improvement-plan-INDEX.md
@@ -1,0 +1,60 @@
+# Cellar Improvement Plan — Index & Execution Backlog
+
+A single entry point to the planning docs produced during the planning loop, plus one merged, execution-ordered backlog combining bug fixes and features.
+
+> **Status update (2026-06-10): Phase 1 is complete and merged.**
+> - Grid cell-editor fixes (B1/B2/B13): [#58](https://github.com/MRL-00/cellar/pull/58)
+> - Registry persist-before-mutate (B4): [#57](https://github.com/MRL-00/cellar/pull/57)
+> - Result paging past the 500-row cap + B9: [#60](https://github.com/MRL-00/cellar/pull/60)
+> - Settings persistence (Editor/Grid): [#59](https://github.com/MRL-00/cellar/pull/59)
+>
+> Next up: **Phase 2** (export, query cancellation, store/effect cleanup B6/B7/B8, rows_affected surfacing).
+
+## The docs
+
+| Doc | What's in it |
+|---|---|
+| [improvement-plan.md](improvement-plan.md) | The tiered roadmap (Tier 0 landmines → Tier 4 differentiators) + the user wishlist section. Start here for the "why/what". |
+| [improvement-plan-top5.md](improvement-plan-top5.md) | Implementation-ready specs for the 5 highest-impact features (files, contract changes, acceptance criteria). |
+| [improvement-plan-wishlist.md](improvement-plan-wishlist.md) | Implementation specs for the 3 user-requested wishlist items (CSV upsert import, dumps/restores, quick+advanced filter). |
+| [improvement-plan-bugs.md](improvement-plan-bugs.md) | 13 correctness bugs (8 verified ✅, 5 suspected 🟡) with file:line, repro scenario, and fix. |
+
+## The single most important finding
+
+**The UI is far ahead of the backend.** Much of Cellar looks finished but is static stubs, and two classes of issue make it unsafe/unusable on real data today: (1) a hard 500-row cap on every query and table browse, and (2) correctness bugs in the editable grid (Escape commits instead of cancelling; NULL cells record phantom edits). Fixing those two classes is what turns Cellar from "impressive demo" into "usable daily on Postgres."
+
+## Merged execution backlog (recommended order)
+
+Each item links to its full spec. Bugs (B#) are in the bugs doc; features (#/W#/Tier) in the roadmap/spec docs.
+
+### Phase 1 — Trust & safety (the grid must not lie or lose data)
+1. **B1 + B2 + B13** — data-grid cell-editor fixes (Escape-commits, NULL phantom edit, double-commit). _Already flagged as a background task._ ✅ verified, contained, same file.
+2. **B4** — persist-before-mutate in `ConnectionRegistry.save`/`delete` (state/disk divergence on I/O error). ✅
+3. **Top 5 #1** — kill the 500-row cap → pagination + grid virtualization. Pulls in **B9** (SQL Server `continue`→`break`).
+4. **Top 5 #3** — persist settings + make them take effect (frontend-only; unblocks the page-size knob for #1).
+
+### Phase 2 — Feels finished
+5. **Top 5 #4** — result export (CSV/JSON/SQL) + grid copy-as. Shares "fetch all rows" plumbing with #1.
+6. **Top 5 #2** — query cancellation (`Driver::cancel_query` + `pg_cancel_backend`).
+7. **B6 + B7 + B8** — frontend store/effect cleanup: clear messages/notices on tab close, fix sticky dirty flag, stale-guard the EXPLAIN/table-load async results.
+8. **rows_affected** surfacing (Tier 0 #3) — the field already exists on `QueryResult`, just always `None`.
+
+### Phase 3 — Competitive parity
+9. **Top 5 #5** — schema-aware autocomplete (the #1 felt gap vs DataGrip).
+10. **W3** — quick + advanced filter coexistence (mostly grid state; rides with #1).
+11. **B3** — SQL Server `Contains` LIKE-metacharacter escaping (silent wrong results). ✅
+12. **Tier 2** — FK navigation in grid · generate SELECT/INSERT/UPDATE/DELETE · type-aware cell editors.
+
+### Phase 4 — Breadth & wishlist
+13. **W1** — CSV upsert/update import (reuses `cellar-diff`; the one backend add is an `ON CONFLICT` variant).
+14. **Tier 3** — SQLite driver (low-effort, high-delight) · SQL Server EXPLAIN + commit-edits · SSH tunneling.
+15. **B5** — confirm + fix Postgres OID/TIMETZ decode (needs a live catalog-query repro first). 🟡
+16. **W2** — dumps/restores ("Data movement" workstream).
+
+### Phase 5 — Differentiators
+17. ER diagram view · read-only/prod guardrails · crash recovery/session restore · plugin runtime + exporters · DataGrip/DBeaver import · demo database.
+
+## Open decisions for the maintainer
+- **Build vs issues:** these can be cut straight into GitHub issues (one per B#/#/W#) or picked up directly for implementation.
+- **B5/B8/B10/B13 repros:** require running the app against a live Postgres/SQL Server to demonstrate; worth a containerized test harness.
+- **Driver priority:** SQLite (easy, broad appeal) vs finishing SQL Server (commit-edits + EXPLAIN) — depends on target users.

--- a/docs/improvement-plan-bugs.md
+++ b/docs/improvement-plan-bugs.md
@@ -1,0 +1,89 @@
+# Cellar — Confirmed & Suspected Bugs
+
+> **Status update (2026-06-10):** B1, B2, B13 fixed in [#58](https://github.com/MRL-00/cellar/pull/58); B4 fixed in [#57](https://github.com/MRL-00/cellar/pull/57); B9 fixed in [#60](https://github.com/MRL-00/cellar/pull/60) — all merged. Still open: B3, B5, B6, B7, B8, B10, B11, B12.
+
+Companion to [improvement-plan.md](improvement-plan.md). The roadmap docs cover missing features; this is a **correctness bug hunt** (the user's original ask included "bugs that need to be fixed"). Found via code review of the Rust drivers, shared state, the diff engine, the data grid, and the frontend stores.
+
+**Confidence levels:** ✅ _Verified_ = I read the exact code and the bug is unambiguous. 🟡 _Likely_ = pointed at real code with a plausible failure path, but depends on library behavior or a path I didn't execute — confirm with a test before fixing.
+
+---
+
+## High severity
+
+### ✅ B1 — Pressing **Escape** in a cell editor commits the edit instead of cancelling
+`packages/data-grid/src/Cell.tsx:85-89`
+```ts
+onKeyDown={(e) => {
+  if (e.key === "Enter") onCommit(v);
+  if (e.key === "Escape") onCancel();   // cancels…
+}}
+onBlur={() => onCommit(v)}              // …then blur immediately commits
+```
+Pressing Escape calls `onCancel()`, which unmounts the input → the input blurs → `onBlur` fires `onCommit(v)`. **The cancellation is overridden and the edit is written.** A user who opens a cell, types a wrong value, and hits Escape to back out has just committed the wrong value to pending changes.
+**Fix:** guard blur with a ref set on cancel/commit (e.g. `committedRef`), or use `onKeyDown` `preventDefault` + a "settled" flag so blur is a no-op after Enter/Escape.
+
+### ✅ B2 — Opening a NULL cell and closing it records a spurious `NULL → ''` edit
+`packages/data-grid/src/Cell.tsx:49`
+```ts
+const [v, setV] = useState<string>(value == null ? "" : String(value));
+```
+A database NULL initializes the editor to `""`. Double-click a NULL cell, change nothing, press Enter (or blur) → `onCommit("")`. Since `null !== ""`, the grid records `{from: null, to: ""}` — a phantom change marking an untouched NULL cell as edited. The pending bar shows "1 update" and the commit modal emits `SET col = ''` on a row the user never meant to touch.
+**Fix:** track whether the value actually changed; treat an unedited editor as a no-op; distinguish "" (intentional empty) from NULL (untouched) — likely needs an explicit "set to NULL" affordance rather than overloading empty string.
+
+### ✅ B3 — SQL Server `Contains` filter doesn't escape LIKE metacharacters → wrong rows
+`crates/cellar-drivers/sqlserver/src/table_browse.rs:185-193`
+```rust
+Ok(format!("{ident} LIKE {}", quote_literal(&format!("%{value}%"))))
+```
+`quote_literal` escapes single quotes but **not** `%`, `_`, or `[`. A `Contains` filter for `50%` becomes `LIKE N'%50%%'` (matches far more than intended); `[abc]` becomes a T-SQL character class. Not SQL injection (the value is still quoted), but **silently returns the wrong result set**. The Postgres path is safe — it uses `push_bind` (parameterized). Fix: escape `%`/`_`/`[` and add `ESCAPE '\'`.
+
+### ✅ B4 — `ConnectionRegistry.save`/`delete` mutate in-memory state *before* persisting → divergence on I/O failure
+`apps/desktop/src-tauri/src/state.rs:89-93` (save) and `:97-106` (delete)
+```rust
+inner.configs.insert(config.id.clone(), config.clone());
+persist(&inner.configs).await?;   // if this Errs, memory already changed
+```
+If `persist` fails (disk full, perms, missing home dir), the function returns `Err` but memory is already mutated. For `delete`, the connection is also already closed and removed — the UI reports failure, yet the connection is gone until restart, and reappears from disk after restart. **Fix:** persist to a temp file and rename first, then mutate memory only on success (persist-then-commit ordering).
+
+### 🟡 B5 — Postgres `OID` columns decoded as `i64` → likely decode error on every catalog query
+`crates/cellar-drivers/postgres/src/decode.rs:42-45`
+```rust
+"OID" => row.try_get::<i64, _>(ordinal)...
+```
+Postgres `oid` is a 4-byte unsigned type (wire OID 26), distinct from `int8`. sqlx 0.8's `i64` decoder type-checks against `INT8`, so `try_get::<i64>` on a real `oid` column should return a decode error, failing the whole row. Triggered by e.g. `SELECT oid, relname FROM pg_class`. **Verify with a quick test against a catalog query; fix is `try_get::<u32, _>`.** (Same file: 🟡 `TIMETZ` decoded as `NaiveTime` at `:84-87` — `timetz` is wire OID 1266 and carries an offset `NaiveTime` can't accept; likely decode error + drops the zone.)
+
+### ✅ B6 — `queryMessages` and `notices` are never cleared when a tab closes → leak + message eviction
+`apps/desktop/src/state/tabs.ts` (closeTab `:229`, closeOtherTabs `:252`, closeTabsToRight `:277`, closeConnectionTabs `:304`)
+**Verified by grep:** `clearForTab` is defined at `state/queryMessages.ts:12,44` and is **never called anywhere** in `apps/desktop/src`. All four close paths call `clearTabResults` and `dropTabScopedState` (which clean `tableChanges`/`refreshKeys`/results) but none call `clearForTab` or clear `useNotices.byScope`. Orphaned messages from closed tabs accumulate; with the global `MAX_MESSAGES=300` cap, messages from *still-open* tabs get evicted by ghosts from dead ones. **Fix:** call `clearForTab` / notice-scope cleanup in every close path.
+
+## Medium severity
+
+### ✅ B7 — Sticky `dirty` flag: a fully-reverted query tab stays marked unsaved
+`apps/desktop/src/state/tabs.ts:215` — `dirty: sql !== t.sql ? true : t.dirty`. **Verified:** `dirty` only clears in `markQueryRun:221`. It compares against the *previous* value each keystroke, never a saved baseline, so once set it never returns to `false` without a run. Type a char then delete it and the tab keeps its unsaved-dot until you run a query. Fix: compare against a stored baseline/last-run SQL.
+
+### 🟡 B8 — EXPLAIN plan result has no stale-guard → lands on the wrong tab
+`apps/desktop/src/components/BottomPlanPanel.tsx:57-78` — `loadPlan` awaits `commands.explainQuery(...)` then `setPlan(next)` with no mounted/generation check. Click Explain on a slow query, switch tabs → the resolved plan overwrites the new tab's panel. Fix: generation counter or `cancelled` ref (same pattern needed in the table-load and query paths).
+
+### ✅ B9 — SQL Server `execute_query` drains the full result after the cap (`continue` vs `break`)
+`crates/cellar-drivers/sqlserver/src/query.rs:62-66` — **Verified:** once `rows.len() >= max_rows` it sets `truncated` and `continue`s. The `continue` sits *before* `rows.push`, so it correctly skips *decoding* the extra rows — but it still iterates the stream to completion, so **every remaining row is transferred over the network**. A 1M-row query with cap 500 still pulls 1M rows over the wire (just doesn't decode 999,500 of them). Fix: `break`. (Ties into the Tier-0 pagination work.)
+
+### 🟡 B10 — No-PK tables key pending edits by row position → wrong row on concurrent change
+`apps/desktop/src/hooks/useTableData.ts:299` — `rowIdFor` returns `row:${index}` when there's no primary key. Pending edits survive sort/filter within a page (row objects keep their id), but across a page reload, position `5` may be a *different* row if another session modified the table; the commit modal applies the change without re-verifying by PK. Affects views/log/temp tables. Fix: hash the full row contents as the identity for no-PK tables, or block editing without a PK and say so.
+
+## Low severity / polish
+
+- 🟡 **B11 — Postgres connection URL not percent-encoded.** `connect.rs:121-128` builds `postgres://{user}@{host}:{port}/{db}` by string interpolation; a `user` containing `@` or a `database` with `/` misroutes or fails with a confusing parse error. Fix: use `PgConnectOptions::new()` builder (`.username()/.host()/.database()`) instead of a URL.
+- ✅ **B12 — Closing the active tab jumps to the *last* tab, not the adjacent one.** `tabs.ts:234` picks `tabs[tabs.length-1]`. Close tab 3 of 10 → you land on tab 10. Fix: select the neighbor (left, or right if leftmost).
+- 🟡 **B13 — `CellEditor` double-commits on Enter.** Enter fires `onCommit` then blur fires it again — idempotent but an extra Zustand write + grid re-render per confirm (visible flicker on large grids). Same blur-after-unmount mechanism as B1.
+
+---
+
+## Suggested triage order
+1. **B1 + B2** (data-grid edit correctness — Escape commits, NULL phantom edits). Same file, same blur mechanism; fix together. Highest user-trust impact.
+2. **B3** (SQL Server filter correctness) and **B4** (state divergence on save/delete) — both silent-wrong-result/corruption class.
+3. **B5/B9** fold into the driver work; **B6/B7/B8** into the frontend store/effect cleanup pass.
+4. **B10** gate or fix before promoting no-PK table editing.
+
+_Verified (✅): B1, B2, B3, B4, B6, B7, B9, B12. Likely / verify-with-test (🟡): B5, B8, B10, B11, B13._
+
+_B5 (Postgres OID/TIMETZ decode) needs a live Postgres catalog query to confirm — couldn't runtime-verify statically. B8/B10/B13 are race/edge-condition bugs whose code paths are confirmed present but need a runtime repro to demonstrate the failure._

--- a/docs/improvement-plan-top5.md
+++ b/docs/improvement-plan-top5.md
@@ -1,0 +1,117 @@
+# Top 5 — Implementation-Ready Breakdowns
+
+Companion to [improvement-plan.md](improvement-plan.md). Each item lists the files to touch, the contract changes, the work, and acceptance criteria. Grounded in the actual code as of 2026-06-09.
+
+Key architectural facts discovered:
+- Driver contract: `Driver` trait in `crates/cellar-core/src/driver.rs:109` (`connect`/`introspect`/`execute_query`/`explain_query`). `browse_table` + `commit_table_changes` are driver free-functions, **not** trait methods.
+- Query shape: `Query { sql, max_rows: Option<u32>, database }` (`crates/cellar-core/src/query.rs:9`). `QueryResult` already has `rows_affected: Option<u64>` and `truncated: bool` fields — partially plumbed.
+- IPC commands registered via `collect_commands!` in `apps/desktop/src-tauri/src/commands/mod.rs:21`; generated TS lands in `packages/ipc/src/generated.ts`.
+- `run_query` command (`commands/query.rs:12`) already accepts `max_rows: Option<u32>`; registry dispatch in `state.rs:210`.
+- Settings are **frontend-only**: `localStorage` key `cellar.settings.v1`, type has just 6 fields (`theme/density/accent/fontSizePx/interfaceFont/monoFont`) in `apps/desktop/src/lib/settings.tsx:31`. No Rust/IPC involved.
+
+---
+
+## 1. Kill the 500-row cap → real pagination + virtualization
+
+**Problem:** `DEFAULT_MAX_ROWS = 500` (`postgres/src/query.rs:16`) and `MAX_TABLE_BROWSE_ROWS = 500` (table_browse) silently truncate. `truncated` is plumbed to `QueryResult` but there's no way to fetch page 2.
+
+**Contract changes (`crates/cellar-core/src/query.rs`):**
+- Add `offset: Option<u32>` to `Query` (table browse already has `offset`).
+- Add `total_rows: Option<u64>` to `QueryResult` for "showing N of M" (best-effort; `None` when unknown).
+
+**Backend work:**
+- `postgres/src/query.rs:execute_query` — honor `query.offset`; raise default page size to a setting-driven value (e.g. 1000) and support explicit "fetch next page". Keep the stream-and-cap approach (already good — it doesn't materialize the whole server result).
+- `postgres/src/table_browse.rs` — already does `LIMIT $1 OFFSET $2`; raise the hard `MAX_TABLE_BROWSE_ROWS` cap to a page-size + allow paging via `offset`. Add an optional `SELECT count(*)` for `total_rows` (gated behind a setting — expensive on big tables).
+- Mirror in `sqlserver/src/table_browse.rs` (already uses `OFFSET n ROWS FETCH NEXT m`).
+
+**Frontend work:**
+- `apps/desktop/src/components/BottomPanel.tsx` — footer "showing N of M · [Load more] [Fetch all]"; wire infinite-scroll page fetches into the grid.
+- `@cellar/data-grid` — confirm it's virtualized for the larger row counts (windowed rendering). If TanStack Virtual isn't wired, add it.
+- `commands/query.rs` — pass `offset` through; add a `fetch_query_page` command or reuse `run_query` with offset.
+
+**Acceptance:** Browse a 1M-row table, scroll smoothly, footer shows true total, "load more" pages without re-running from row 0. No silent 500 truncation; truncation only when the user-set cap is hit, and it's clearly labeled.
+
+---
+
+## 2. Query cancellation
+
+**Problem:** No cancel anywhere. A runaway query blocks the connection's pool slot with no escape.
+
+**Contract changes:**
+- Add `query_id: Option<String>` to `Query` (host-generated UUID per execution).
+- Add trait method to `Driver` (`driver.rs:109`): `async fn cancel_query(&self, conn: &dyn Connection, query_id: &str) -> CellarResult<()>;` with a default impl returning `CellarError::unsupported` so non-Postgres drivers compile.
+
+**Backend work (Postgres):**
+- On `execute_query`, capture the backend PID via `pg_backend_pid()` on the acquired connection (or use a dedicated connection so the PID is knowable), store `query_id → (pid, database)` in a registry on `PgConnection`.
+- `cancel_query` opens a **second** pool connection and runs `SELECT pg_cancel_backend($1)`.
+- Clean up the registry entry on completion.
+- Registry/state: `apps/desktop/src-tauri/src/state.rs` holds `ConnectionRegistry`; add an in-flight-query map keyed by `query_id`.
+
+**IPC + frontend:**
+- New command `cancel_query(connection_id, query_id)` in `commands/query.rs`, registered in `commands/mod.rs`.
+- `run_query` returns/echoes the `query_id`; UI shows a "Cancel" button in the editor toolbar / bottom panel while a query is running; `⌘.` shortcut.
+
+**Acceptance:** Run `SELECT pg_sleep(60)`, hit Cancel, query aborts within ~1s with a clean "cancelled" message, pool slot freed, connection still usable.
+
+---
+
+## 3. Persist settings + make them take effect
+
+**Problem:** Almost the entire Settings modal is `StaticSegment`/`readOnly` with no `onChange`. The real settings store (`settings.tsx`) only models 6 appearance fields. Editor/Grid/General/History/Keymap panels save nothing and affect nothing.
+
+**Work (frontend-only — no Rust needed):**
+- Expand `Settings` type in `apps/desktop/src/lib/settings.tsx:31` with the panels' real fields:
+  - Editor: `tabSize`, `softWrap`, `lineNumbers`, `bracketMatching`, `keywordCase`, `formatOnSave`, `statementRunMode`, `selectStarLimit`.
+  - Grid: `rowHeight`, `nullDisplay`, `numberAlign`, `stripeRows`, `stickyPrimaryKey`, `truncateCells`, `defaultPageSize`.
+  - General: `startupMode`, `confirmBeforeQuit`, `defaultSchemaSearchPath`.
+- Extend `DEFAULTS`, `sanitize`, and `load`/persist (already merges `{...DEFAULTS, ...parsed}` so it's forward-compatible).
+- Replace `StaticSegment`/`readOnly` controls in `settingsWorkspacePanels.tsx` (lines ~147–262), `settingsDataPanels.tsx`, with live `useSettings().set(...)` bindings.
+- Make settings **take effect**: pass editor settings into `@cellar/sql-editor` (tab size, wrap, line numbers, bracket matching, run mode), grid settings into `@cellar/data-grid` (row height, NULL display, alignment, stripes, page size — ties into #1), and the `selectStarLimit`/page-size into the browse/query path.
+- Fix the lying placeholders: replace hardcoded stats ("23,418 queries · 14.2 MB") in `settingsDataPanels.tsx:93` / `settingsSystemPanels.tsx` with real counts from the history store, or hide the banners until wired.
+- Window toggles (`settingsWorkspacePanels.tsx:132`) — wire to Tauri window APIs or remove.
+
+**Acceptance:** Change tab size / NULL display / page size; editor and grid reflect it immediately and after restart. No `readOnly` control in the modal that pretends to be editable. No fabricated stats.
+
+---
+
+## 4. Result export (CSV / TSV / JSON / SQL INSERT)
+
+**Problem:** "Export not implemented yet" button (`BottomPanel.tsx:148`); no grid copy-as either. SPEC §9.1 promises CSV/TSV/JSON/SQL first-party exporters.
+
+**Work (frontend-first; the data is already in the grid):**
+- New module `apps/desktop/src/lib/export.ts` — pure functions `toCsv/toTsv/toJson/toSqlInserts(columns, rows, opts)`. Reuse `ColumnMeta` typing; respect NULL handling and quoting (CSV RFC 4180; SQL identifier/value escaping mirroring `cellar-diff`'s literal escaping).
+- Wire the `BottomPanel.tsx:148` Export button → format menu → Tauri `save` dialog (`tauri-plugin-dialog`) + `fs` write. Add `tauri-plugin-dialog`/`fs` to `tauri.conf.json` capabilities if absent.
+- Grid context menu (`@cellar/data-grid`): "Copy as TSV/CSV", "Copy row(s) as INSERT" → clipboard. Multi-row selection copy.
+- Honor the active filters/sort and the **full** result, not just the visible page (depends on #1's fetch-all).
+
+**Acceptance:** Run a query, Export → CSV/JSON/SQL writes a correct file; right-click rows → copy as INSERT yields runnable SQL; large exports stream rather than freeze the UI.
+
+---
+
+## 5. Schema-aware autocomplete in the SQL editor
+
+**Problem:** The CodeMirror editor exists but has no completion from live schema. This is the #1 felt gap vs DataGrip. Introspection data (databases→schemas→tables→columns, with FKs) is already available in the Zustand connection store.
+
+**Work (frontend, in `@cellar/sql-editor` + desktop wiring):**
+- Add a CodeMirror `autocompletion` source fed by the current tab's connection schema (from the connections store, already populated by `introspect`).
+- Context-awareness (start simple, iterate):
+  - After `FROM`/`JOIN`/`UPDATE`/`INTO` → suggest `schema.table` (and bare table for the search-path schema).
+  - After `SELECT`/`WHERE`/`ON`/`,` → suggest columns, preferring tables referenced earlier in the statement (parse the `FROM`/`JOIN` clause for table aliases).
+  - Keywords + functions as a lower-priority tier.
+- Use the tab's `connection_id`/`database` to scope suggestions to the right schema set.
+- Snippet completions (`sel`, `ins`, `upd`, `del`, `jln`) per SPEC §6.4 as a quick add-on.
+- Reuse FK metadata for future "join suggestion" but not required for v1.
+
+**Acceptance:** Type `SELECT * FROM ` and get table suggestions from the connected DB; type `SELECT ` after a FROM and get that table's columns; suggestions update when the schema is refreshed; no suggestions leak across connections.
+
+---
+
+## Recommended build order for the loop
+
+1. **#3 settings** (frontend-only, unblocks page-size for #1, immediate "feels finished" win).
+2. **#1 pagination** (core; depends on grid virtualization + page-size setting).
+3. **#4 export** (depends on #1's fetch-all for full-result export; otherwise independent).
+4. **#2 cancellation** (backend trait change; isolated).
+5. **#5 autocomplete** (frontend; independent; high perceived value).
+
+Each is independently shippable. #1 and #4 share the "fetch all rows" plumbing, so sequence them together.

--- a/docs/improvement-plan-wishlist.md
+++ b/docs/improvement-plan-wishlist.md
@@ -1,0 +1,86 @@
+# Wishlist Items — Implementation-Ready Breakdowns
+
+Companion to [improvement-plan.md](improvement-plan.md) (Wishlist section) and [improvement-plan-top5.md](improvement-plan-top5.md). User-requested features, grounded in the actual code as of 2026-06-09.
+
+Key fact that shapes all three: **the transactional commit engine already exists.** `cellar-diff` (`crates/cellar-diff/src/lib.rs`) models:
+```
+TableChangeRequest { schema, table, primary_key: Vec<String>, changes: Vec<RowChange> }
+RowChange::Update { row_id, keys, assignments }  // match on keys, set assignments
+RowChange::Insert { row_id, values }
+RowChange::Delete { row_id, keys }
+build_postgres_plan(req) -> CommitPlan { statements, preview { sql, expected_rows } }
+```
+and `commit_table_changes` (`postgres/src/query.rs:86`) runs the plan in a single `BEGIN`/`COMMIT` with affected-row validation and rollback-on-mismatch. The grid edit path already uses it. **The wishlist items below mostly feed new front-ends into this same engine** rather than building new backends.
+
+---
+
+## W1. CSV upsert / update import — _"the Sequel Pro import"_ (Tier 2, high priority)
+
+**Goal:** Pick a CSV → map columns → choose a match key (PK or unique column set) → update matched rows' selected fields with CSV values, optionally insert unmatched rows. Dry-run preview, single transactional commit.
+
+**Why it's mostly frontend:** A CSV upsert is exactly a `TableChangeRequest`:
+- `primary_key` = the user-chosen **match key** columns.
+- For each CSV row that matches an existing row → `RowChange::Update { keys: <match cols>, assignments: <selected fields> }`.
+- For each unmatched CSV row (insert mode) → `RowChange::Insert { values }`.
+The existing `build_postgres_plan` + `commit_table_changes` then handle SQL generation, transaction, and validation.
+
+**Frontend work (new import wizard modal, `apps/desktop/src/components/modals/ImportDataModal.tsx`):**
+1. File picker (`tauri-plugin-dialog`) + CSV parse (header detection, delimiter sniff, quote handling). Stream/iterate for large files.
+2. **Column mapping** UI: CSV column → table column, with type hints from introspected `ColumnMeta`. Auto-map by name.
+3. **Match-key selector**: choose one or more columns to match on; default to the table PK (already in schema metadata). Validate the key columns are present in the CSV mapping.
+4. **Mode toggle**: Update-only · Insert-only · Upsert (update matched + insert unmatched). Update-only with no match = skip; show counts.
+5. **Field selection**: which mapped columns to actually write on update (Sequel Pro's "update all selected fields"). Match-key columns excluded from the SET list.
+6. **Dry-run preview**: show "N rows match → update · M rows new → insert · K unmatched → skipped", reusing `preview_table_changes` IPC (already exists per the generated command list) to render the generated SQL before commit.
+7. Commit via the existing `commit_table_changes` path.
+
+**Backend work (small):**
+- To detect which CSV rows match existing rows, either (a) let the DB decide via `INSERT ... ON CONFLICT (match_key) DO UPDATE` for the upsert case (Postgres-native, fastest, atomic), or (b) pre-query existing keys. Recommend adding an **`RowChange::Upsert`** variant (or an `on_conflict` flag on the plan) to `cellar-diff` so upsert compiles to `INSERT ... ON CONFLICT DO UPDATE SET ...` in one statement per row/batch. This keeps it transactional and avoids a read-then-write race.
+- Batch inserts (multi-row `VALUES`) for throughput on large CSVs rather than one statement per row.
+
+**Acceptance:** Import a 10k-row CSV, match on `id`, update `name`+`status` only, insert new ids; preview shows accurate match/insert/skip counts; commit is one transaction; re-running is idempotent; match-key columns are never overwritten.
+
+**Stretch:** remember mappings per table; support TSV/Excel paste into the same wizard (folds in Tier 2 #4).
+
+---
+
+## W2. Faster dumps & restores (Tier 3 / new "Data movement" area, medium)
+
+**Scope guard:** SPEC §2 lists "backup orchestration" as a non-goal. Frame this as **developer-convenience dump/restore**, not cluster/backup management: export a table / schema / database to a `.sql` or archive, and restore from one. Keep it desktop-first and local.
+
+**Backend work:**
+- New driver capability (free functions like `browse_table`, or a small trait extension): `dump(conn, scope, options) -> stream` and `restore(conn, source) -> progress`.
+  - **Postgres:** two paths — (a) shell out to `pg_dump`/`pg_restore` when present on PATH (fastest, most faithful, supports custom/directory formats), surfacing version-mismatch errors clearly; (b) a native fallback using `COPY ... TO STDOUT` / `COPY ... FROM STDIN` for data-only export when the binaries aren't available. Schema-only dumps can reuse introspection + a DDL generator.
+  - Scope selector: whole DB · selected schemas · selected tables · data-only / schema-only / both.
+- **Streaming**: pipe `pg_dump` stdout (or COPY stream) straight to the target file — never materialize the whole dump in memory. Emit progress events over IPC (bytes written / rows copied).
+- Restore: stream the file into `psql`/`pg_restore` or `COPY FROM`, with progress + a clear error surface on failure.
+
+**Frontend work:**
+- Entry points in the connection / database / table context menus ("Dump…", "Restore…").
+- A dump/restore modal: scope, format, options, destination path; live progress bar fed by IPC events; cancel button (ties into the cancellation work from Top 5 #2).
+
+**Acceptance:** Dump a mult-GB table to a file with a live progress bar and flat memory usage; restore it into another connection; cancel mid-dump cleanly; clear error if `pg_dump` is missing or version-mismatched, with the native COPY fallback offered for data-only.
+
+---
+
+## W3. Quick filter + advanced filter coexistence (Tier 2, medium)
+
+**Goal:** A fast quick-filter (type an ID / free text) that lives **alongside** structured advanced filters without either clobbering the other — both visible, independently clearable, with a clear active-state indicator.
+
+**Why it's mostly UI/state:** `TableBrowseRequest.filters: Vec<TableFilterClause>` (`crates/cellar-core/src/query.rs:200`) already supports multiple clauses combined server-side, and the Postgres/SQL Server `table_browse` paths already AND them together. So the backend can already express "quick + advanced" — this is a front-end composition problem.
+
+**Frontend work (`@cellar/data-grid` filter bar + `BottomPanel.tsx` / table tab state):**
+1. Model two distinct filter layers in tab state: `quickFilter` (string) and `advancedFilters` (`TableFilterClause[]`). Keep them separate so clearing one doesn't touch the other.
+2. **Compile quick filter → clause(s)**: by default, a free-text quick filter becomes an OR across text-ish columns (`ILIKE`/Contains); if it's numeric and the table has an obvious id/PK, offer "match id = N". Send the union as additional `TableFilterClause`s appended to the advanced ones in the `TableBrowseRequest`.
+   - Note: `TableFilterClause`s are currently AND-combined in the drivers. To support an OR'd quick filter across columns, either add a lightweight `group`/`logic` notion to the filter model, or (simpler v1) scope the quick filter to a single user-chosen column so it's one clause. Pick the simpler v1, leave OR-across-columns as a follow-up.
+3. **Both visible**: quick-filter input pinned in the toolbar; advanced filter chips below. Each shows its own clear (×). A combined "N filters active" indicator.
+4. Debounce quick-filter input; re-issue `browse_table` with the merged filter set; preserve sort + pagination (ties into Top 5 #1).
+
+**Acceptance:** Set an advanced filter (`status = 'active'`), then type an id in quick-filter; both apply together; clearing the quick filter leaves the advanced filter intact and vice-versa; the active-filter indicator reflects both; results page/sort correctly with both applied.
+
+---
+
+## Where these slot in the build order
+
+- **W3** is the cheapest (mostly grid state) and pairs well with the **Top 5 #1 pagination** work since both touch the browse path and grid — do them together.
+- **W1 (CSV upsert)** is high user-value and reuses `cellar-diff`; schedule it right after the grid/commit groundwork is solid. The one backend addition is an `Upsert`/`ON CONFLICT` variant in `cellar-diff`.
+- **W2 (dumps/restores)** is the largest and most independent; treat it as its own "Data movement" workstream, sequenced after the core grid/query work lands.

--- a/docs/improvement-plan.md
+++ b/docs/improvement-plan.md
@@ -1,0 +1,96 @@
+# Cellar — Next Steps to Become the Best Database Client
+
+_Audit date: 2026-06-09. Based on a full sweep of the desktop app, Rust drivers, and SPEC.md._
+
+The AI workflow is being built out in a separate loop. This plan covers **everything else**: broken/stubbed menu items, correctness bugs, production gaps, and the table-stakes features that DataGrip/TablePlus/DBeaver have and Cellar doesn't yet.
+
+The audit found a recurring theme: **the UI is far ahead of the backend.** Many surfaces _look_ finished but are static stubs (`title="… not wired yet"`). The biggest credibility wins are turning that existing chrome into real functionality, plus fixing two correctness landmines that make Cellar unsafe on real databases.
+
+---
+
+## Tier 0 — Correctness landmines (do first; these make Cellar unsafe/unusable on real data)
+
+1. **The 500-row hard cap on everything.** `DEFAULT_MAX_ROWS = 500` in the Postgres query path and `MAX_TABLE_BROWSE_ROWS = 500` for browsing. No serious client can ship with this. Needs real keyset/offset pagination + grid virtualization wired end-to-end, with a footer showing "showing N of M" and a "load more / fetch all" control.
+   - Files: `crates/cellar-drivers/postgres/src/query.rs:55`, `table_browse.rs`, `apps/desktop/src/components/BottomPanel.tsx`.
+2. **No query cancellation.** A runaway query locks the session with no escape. Add `cancel_query` to the `Driver` trait; Postgres via `pg_cancel_backend` on a second connection. This is table-stakes.
+   - Files: `crates/cellar-core/src/driver.rs:109`.
+3. **`rows_affected` is always `None`.** Run an `UPDATE`/`DELETE`/`INSERT` in the editor and Cellar can't tell you how many rows changed. Surface it in the Messages tab.
+   - Files: all drivers' `query.rs`; `BottomPanel.tsx:313` ("rows-affected not surfaced yet").
+4. **SQL Server cross-database `USE [db];` is stateful and unsafe** — concurrent queries on the single Mutex-guarded client see the wrong database. Adopt the Postgres sibling-pool-per-database approach.
+   - Files: `crates/cellar-drivers/sqlserver/src/query.rs:21`, `connect.rs:17`.
+5. **SQL Server SSL `Prefer`/`Require` silently trust any cert** (`trust_cert()`), so "Require" gives no real verification. Fix the mapping so only `Disable`/`Prefer` skip validation.
+   - Files: `crates/cellar-drivers/sqlserver/src/connect.rs:126`.
+
+## Tier 1 — Wire the stubs that already have UI (high ROI, low risk)
+
+These are buttons/panels that already exist and just need a backend. Fastest path to "feels finished."
+
+1. **Persist settings.** Almost the entire Settings modal is `StaticSegment`/`readOnly` with no `onChange` — Editor, Grid, General, History, Keymap, Connections panels don't save anything. Wire them to `~/.cellar/settings.json` and make them actually affect the editor/grid.
+   - Files: `settingsWorkspacePanels.tsx`, `settingsDataPanels.tsx`, `settingsSystemPanels.tsx`.
+2. **Result/grid export.** "Export not implemented yet" button in the bottom panel; no CSV/JSON/TSV/SQL export anywhere. Ship the first-party exporters the SPEC already promises (CSV, TSV, JSON, SQL INSERTs) + "copy as INSERT" and "copy as TSV/CSV" in the grid.
+   - Files: `BottomPanel.tsx:148`, grid copy handlers.
+3. **SQL formatting.** Format button is disabled pending `cellar-sql`, which is an empty placeholder crate. Build (or vendor) a Postgres-dialect formatter and wire format-on-demand + format-on-save.
+   - Files: `SqlEditor.tsx:152`, `crates/cellar-sql`.
+4. **Query bookmarks / saved queries.** Bookmark button disabled. Saved/named queries is one of the most-requested features missing here.
+   - Files: `SqlEditor.tsx:184`.
+5. **Keymap rebinding.** Preset selector is static; rebind buttons disabled. Wire to a real keymap store with VS Code / DataGrip / Vim presets (SPEC §6.8).
+6. **Migration export from the commit modal.** "Migration export is not wired yet" — generate a `.sql` migration file from pending grid changes.
+   - Files: `CommitModal.tsx:258`.
+7. **Live external links + updater.** Docs/GitHub/Changelog/About links are all disabled no-ops across EmptyState and Settings; "Check for updates" is dead. Wire `tauri-plugin-shell` opener + the Tauri updater (also needs `tauri.conf.json` CSP, currently `null`).
+8. **Replace hardcoded placeholder stats** in Privacy/History settings (e.g. "23,418 queries · 14.2 MB") with real counts — currently lies to the user.
+
+## Tier 2 — Core editor/grid features that competitors have and we don't
+
+1. **Schema-aware autocomplete** in the SQL editor (tables post-FROM, columns post-WHERE, functions). The editor exists; completion from live introspection does not. This is the #1 thing people feel missing vs DataGrip.
+2. **Foreign-key navigation in the grid** — click an FK cell to open the referenced row in a new tab. SPEC §6.5; FK metadata is already introspected.
+3. **Generate SQL from schema tree** — right-click table → generate SELECT/INSERT/UPDATE/DELETE (only "SELECT *" exists today).
+4. **Type-aware cell editors + Excel paste** — date pickers, enum dropdowns, NULL toggle, paste a block from Excel/CSV into the grid.
+5. **Tab split views** — SPEC promises drag-to-split (two queries / query+table side by side); only single tabs exist.
+6. **Multi-statement execution with correlated result tabs** — run a file, get one result set per statement.
+7. **Open structure / DDL view** for a table (columns, indexes, constraints, "Copy CREATE TABLE").
+
+## Tier 3 — Broaden the engine matrix (Cellar is really a Postgres client today)
+
+1. **MySQL + SQLite drivers** — declared in the `Engine` enum but no crate exists; `cellar-drivers/src/lib.rs` is a one-line placeholder. SQLite especially is low-effort, high-delight (local files, demo DB).
+2. **SQL Server: add EXPLAIN + commit-edits path.** EXPLAIN returns "not available yet"; there's no `commit_table_changes` for SQL Server, so grid editing is Postgres-only. `cellar-diff` only emits Postgres dialect.
+3. **Firestore: at least basic query execution** (currently every query/EXPLAIN/sort/filter returns "not supported yet"; it's browse-only).
+4. **SSH tunneling + mTLS/custom CA** — `ConnectionConfig` has no SSH fields at all; the SSH tab in the dialog is UI-only. This is a hard requirement for most companies' prod databases.
+
+## Tier 4 — Differentiators that push toward "best in class"
+
+1. **ER diagram view** (SPEC post-1.0) — schema visualization is a marquee DataGrip/DBeaver feature.
+2. **Connection-wide read-only mode + prod guardrails** — SPEC §6.1 promises a read-only toggle and confirmation before unguarded `DELETE`/`UPDATE`/DDL on `prod`-tagged connections. The prod badge exists; the safety behavior doesn't.
+3. **Crash recovery / session restore** — restore open tabs, unsaved queries, and pending edits across restarts (SPEC §7); persist pending edits to local SQLite.
+4. **Plugin runtime** — `cellar-plugin-host` is an empty placeholder; the whole extensibility principle is unrealized. Exporters are the easiest first plugin type.
+5. **DataGrip/DBeaver/TablePlus import** — "Import from DataGrip/DBeaver" button is disabled; importing existing connections is a huge adoption lever.
+6. **Demo database** — disabled "Connect to demo database" button; a one-click sample DB makes first-run delightful.
+
+---
+
+## Suggested sequencing
+
+- **Sprint A (safety + polish):** Tier 0 #1–3 (pagination, cancellation, rows-affected) + Tier 1 #1–2 (settings persistence, export). This alone moves Cellar from "demo" to "usable daily on Postgres."
+- **Sprint B (feel finished):** remaining Tier 1 (formatting, bookmarks, keymap, links/updater) + Tier 2 #1–3 (autocomplete, FK nav, generate SQL).
+- **Sprint C (breadth):** SQLite driver, SQL Server EXPLAIN/commit, SSH tunneling.
+- **Sprint D (differentiate):** ER diagram, read-only/prod guardrails, plugin runtime + exporters.
+
+## Wishlist (user-requested; not yet slotted into a tier)
+
+These come from real day-to-day pain with Sequel Pro / TablePlus and are strong differentiators. None are covered by the tiers above — slot them in as noted.
+
+1. **Stable, elegant CSV upsert/update import — _"the Sequel Pro import"_.** Pick a CSV, map its columns to table columns, **choose a primary key (or unique column set) to match on**, then update all selected fields with the CSV values for matched rows (and optionally insert unmatched rows). Sequel Pro did this far better than TablePlus. This is more than the "Excel paste into grid" idea in Tier 2 #4 — it's a dedicated import wizard with column mapping, match-key selection, update-vs-insert-vs-upsert mode, a dry-run preview of affected rows, and a single transactional commit. Builds naturally on the existing `cellar-diff` pending-changes → transactional-SQL engine. **Suggested home: Tier 2 (core grid/data feature), high priority.**
+   - Touches: new import wizard modal; `cellar-diff` (reuse plan builder for UPDATE/INSERT by match key); commit path in `postgres/src/query.rs:commit_table_changes`.
+
+2. **Better / faster dumps and restores.** First-class schema + data dump (whole DB, selected schemas, or selected tables) and restore, with a progress UI and sensible defaults — faster and less fiddly than shelling out to `pg_dump` by hand. Note: SPEC §2 lists "backup orchestration" as a non-goal, so scope this as **developer-convenience dump/restore** (export a table or DB to a `.sql`/archive, restore from one), not cluster/backup management. Streaming so big dumps don't materialize in memory. **Suggested home: Tier 3 (engine-level capability) or a new "Data movement" area, medium priority.**
+   - Touches: new driver capability (wrap `pg_dump`/`pg_restore` where present, or native COPY-based export); progress events over IPC; UI in connection/table context menus.
+
+3. **Better coexistence of quick filter + advanced filtering.** Let a fast quick-filter (e.g. type an ID / free-text) live alongside structured advanced filters (the type-aware `=`/`LIKE`/`IS NULL` clauses already in `TableFilterClause`) without one clobbering the other. TablePlus does this passably but it "could do with love" — make the quick filter an additive layer over advanced filters, both visible, independently clearable, with a clear indicator of what's active. **Suggested home: Tier 2 (grid UX), medium priority.**
+   - Touches: `@cellar/data-grid` filter bar; `BottomPanel.tsx`; the `TableBrowseRequest.filters` plumbing (`crates/cellar-core/src/query.rs:200`) already supports multiple clauses, so this is largely a UI/state-composition problem.
+
+## Top 5 if you only do five things
+
+1. Kill the 500-row cap (pagination + virtualization).
+2. Query cancellation.
+3. Persist settings + make them take effect.
+4. Result export (CSV/JSON/SQL).
+5. Schema-aware autocomplete.


### PR DESCRIPTION
Adds the five planning documents produced by the Cellar improvement-planning loop, giving the repo a durable record of the audit and the forward backlog.

## What's included

| Doc | Content |
|---|---|
| `docs/improvement-plan-INDEX.md` | Entry point + execution-ordered backlog (5 phases, bugs and features merged) |
| `docs/improvement-plan.md` | Tiered roadmap: Tier 0 correctness landmines → Tier 4 differentiators, plus the wishlist (CSV upsert import, dumps/restores, filter coexistence) |
| `docs/improvement-plan-top5.md` | Implementation-ready specs for the 5 highest-impact items (files to touch, contract changes, acceptance criteria) |
| `docs/improvement-plan-wishlist.md` | Implementation specs for the three wishlist items, grounded in the existing `cellar-diff` engine |
| `docs/improvement-plan-bugs.md` | 13-bug correctness audit — 8 verified with file:line evidence, ranked with fix approaches |

## Status baked in

Phase 1 of the backlog is already complete and merged (#57, #58, #59, #60); the docs are annotated accordingly. Bugs B1/B2/B4/B9/B13 are marked fixed; B3, B5, B6, B7, B8, B10, B11, B12 remain open and are slotted into Phases 2–4.

Phase 2 (export, query cancellation, store/effect cleanup, rows_affected surfacing) is the next workstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
