### PR TITLE
Phase 2: query cancellation, result export, rows_affected, store cleanup

### DIFF
--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -29,6 +29,7 @@ pub fn builder() -> Builder<tauri::Wry> {
         connection::disconnect,
         schema::introspect,
         query::run_query,
+        query::cancel_query,
         query::explain_query,
         query::browse_table,
         transaction::preview_table_changes,

--- a/apps/desktop/src-tauri/src/commands/query.rs
+++ b/apps/desktop/src-tauri/src/commands/query.rs
@@ -18,6 +18,7 @@ pub async fn run_query(
     offset: Option<u32>,
     database: Option<String>,
     tab_id: Option<String>,
+    query_id: Option<String>,
 ) -> Result<QueryResult, CellarError> {
     let mut query = Query::new(sql);
     if let Some(n) = max_rows {
@@ -28,6 +29,9 @@ pub async fn run_query(
     }
     if let Some(db) = database {
         query = query.with_database(db);
+    }
+    if let Some(qid) = query_id {
+        query = query.with_query_id(qid);
     }
     let history_sql = query.sql.clone();
     let history_database = query.database.clone();
@@ -51,7 +55,7 @@ pub async fn run_query(
             row_count: query_result
                 .rows_affected
                 .map(|n| n.min(i64::MAX as u64) as i64)
-                .or_else(|| Some(query_result.rows.len() as i64)),
+                .or(Some(query_result.rows.len() as i64)),
             truncated: query_result.truncated,
             error_summary: None,
         },
@@ -72,6 +76,19 @@ pub async fn run_query(
     let _ = history.insert(record).await;
 
     result
+}
+
+/// Cancel a running query previously started through [`run_query`] with a
+/// `query_id`. Returns `true` when a running statement was found and
+/// signalled, `false` when it had already finished.
+#[tauri::command]
+#[specta::specta]
+pub async fn cancel_query(
+    registry: State<'_, ConnectionRegistry>,
+    connection_id: String,
+    query_id: String,
+) -> Result<bool, CellarError> {
+    registry.cancel_query(&connection_id, &query_id).await
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -238,6 +238,22 @@ impl ConnectionRegistry {
         }
     }
 
+    /// Best-effort cancel of a query started with a `query_id`. Failures pass
+    /// through verbatim — a failed cancel must not mark the connection broken
+    /// (the original query is still running and reports its own outcome).
+    pub async fn cancel_query(&self, id: &str, query_id: &str) -> CellarResult<bool> {
+        let (engine, connection) = {
+            let inner = self.inner.read().await;
+            let open = inner
+                .open
+                .get(id)
+                .ok_or_else(|| CellarError::NotConnected(format!("no open connection for {id}")))?;
+            (open.config.engine, Arc::clone(&open.connection))
+        };
+        let driver = driver_for(engine)?;
+        driver.cancel_query(connection.as_ref(), query_id).await
+    }
+
     pub async fn browse_table(&self, request: TableBrowseRequest) -> CellarResult<QueryResult> {
         let target_database = self.target_database_for(&request).await?;
         let dbs = self.introspect(&request.connection_id, false).await?;

--- a/apps/desktop/src/components/BottomPanel.tsx
+++ b/apps/desktop/src/components/BottomPanel.tsx
@@ -5,9 +5,34 @@ import {
   type NoticeSeverity,
   type QueryHistoryRecord,
 } from "@cellar/ipc";
-import { DataGrid, useGridState } from "@cellar/data-grid";
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import {
+  DataGrid,
+  filterRows,
+  sortGridRows,
+  useGridState,
+  type GridColumn,
+  type GridRow,
+} from "@cellar/data-grid";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MutableRefObject,
+  type ReactNode,
+} from "react";
 import { useSettings } from "../lib/settings";
+import {
+  downloadText,
+  exportFilename,
+  exportText,
+  EXPORT_FORMATS,
+  toCsv,
+  toJson,
+  toSqlInserts,
+  toTsv,
+} from "../lib/export";
+import { ContextMenu, type ContextMenuState } from "./ContextMenu";
 
 import {
   countNoticeSeverities,
@@ -54,6 +79,14 @@ const BASE_TABS: Omit<BPTab, "count">[] = [
   { id: "notices", label: "Notices", icon: <Icon.warn size={11} />, enabled: true },
 ];
 
+/**
+ * The rows/columns as the user currently sees them — after the result grid's
+ * local filters and sort. Registered by ReadOnlyResultGrid so the Export
+ * button (which lives outside the grid) exports what is on screen.
+ */
+type ExportView = { columns: readonly GridColumn[]; rows: readonly GridRow[] };
+type ExportViewRef = MutableRefObject<(() => ExportView) | null>;
+
 export function BottomPanel({ onClose }: { onClose: () => void }) {
   const active = useBottomPanel((s) => s.active);
   const setActive = useBottomPanel((s) => s.setActive);
@@ -90,6 +123,14 @@ export function BottomPanel({ onClose }: { onClose: () => void }) {
     useNotices((s) => s.byScope[scopeKey]) ?? emptyNoticeEntry();
   const clearNotices = useNotices((s) => s.clear);
   const setRetain = useNotices((s) => s.setRetain);
+  const exportViewRef: ExportViewRef = useRef(null);
+  const [exportMenu, setExportMenu] = useState<ContextMenuState | null>(null);
+  const exportable =
+    result?.status === "ready" &&
+    result.source.kind === "query" &&
+    result.columns.length > 0
+      ? result
+      : null;
   const bottomTabs: BPTab[] = BASE_TABS.map((tab) => ({
     ...tab,
     count:
@@ -146,7 +187,39 @@ export function BottomPanel({ onClose }: { onClose: () => void }) {
           <HeaderMeta activeTab={activeTab} result={result} />
         </div>
         <div className="flex items-center gap-px">
-          <button className="icon-btn opacity-45" disabled title="Export not implemented yet">
+          <button
+            className={"icon-btn" + (exportable ? "" : " opacity-45")}
+            disabled={!exportable}
+            title={
+              exportable
+                ? "Export results…"
+                : "Export — run a query that returns rows first"
+            }
+            onClick={(e) => {
+              if (!exportable) return;
+              const rect = e.currentTarget.getBoundingClientRect();
+              const label =
+                activeTab?.kind === "query" ? activeTab.title : "result";
+              setExportMenu({
+                x: rect.right,
+                y: rect.bottom + 4,
+                items: EXPORT_FORMATS.map(({ format, label: name }) => ({
+                  label: `Export as ${name}`,
+                  onClick: () => {
+                    const view = exportViewRef.current?.() ?? {
+                      columns: exportable.columns,
+                      rows: exportable.rows,
+                    };
+                    downloadText(
+                      exportFilename(label, format),
+                      format,
+                      exportText(format, view.columns, view.rows),
+                    );
+                  },
+                })),
+              });
+            }}
+          >
             <Icon.fileText size={11} />
           </button>
           <button className="icon-btn opacity-45" disabled title="Pop out not implemented yet">
@@ -158,9 +231,15 @@ export function BottomPanel({ onClose }: { onClose: () => void }) {
         </div>
       </div>
 
+      <ContextMenu state={exportMenu} onClose={() => setExportMenu(null)} />
+
       <div className="min-h-0 flex-1 overflow-hidden">
         {active === "results" ? (
-          <ResultsBody activeTab={activeTab} result={result} />
+          <ResultsBody
+            activeTab={activeTab}
+            result={result}
+            exportViewRef={exportViewRef}
+          />
         ) : active === "messages" ? (
           <MessagesView
             messages={activeMessages}
@@ -235,6 +314,13 @@ function headerItems(
   if (result.status === "error") {
     return [context, "failed"];
   }
+  if (result.columns.length === 0 && result.rowsAffected != null) {
+    return [
+      context,
+      `${result.rowsAffected.toLocaleString("en-US")} affected`,
+      `${result.durationMs} ms`,
+    ];
+  }
   return [
     context,
     rowCountLabel(result.rowCount, result.truncated),
@@ -246,9 +332,11 @@ function headerItems(
 function ResultsBody({
   activeTab,
   result,
+  exportViewRef,
 }: {
   activeTab: ReturnType<typeof useTabs.getState>["tabs"][number] | null;
   result: TabResult | null;
+  exportViewRef: ExportViewRef;
 }) {
   if (!activeTab) {
     return (
@@ -307,23 +395,70 @@ function ResultsBody({
   if (result.columns.length === 0) {
     return (
       <EmptyPanel
-        title="Statement returned no columns"
-        detail="Rows-affected messages are not surfaced in the bottom panel yet."
+        title={
+          result.rowsAffected != null
+            ? `Query OK — ${result.rowsAffected.toLocaleString("en-US")} ${
+                result.rowsAffected === 1 ? "row" : "rows"
+              } affected`
+            : "Statement returned no columns"
+        }
+        detail={
+          result.rowsAffected != null
+            ? `Completed in ${result.durationMs} ms. The statement did not return a result set.`
+            : "The statement completed without producing a result set."
+        }
       />
     );
   }
 
-  return <ReadOnlyResultGrid key={result.tabId} result={result} />;
+  return (
+    <ReadOnlyResultGrid
+      key={result.tabId}
+      result={result}
+      exportViewRef={exportViewRef}
+    />
+  );
 }
 
 function ReadOnlyResultGrid({
   result,
+  exportViewRef,
 }: {
   result: Extract<TabResult, { status: "ready" }>;
+  exportViewRef: ExportViewRef;
 }) {
   const grid = useGridState();
   const { settings } = useSettings();
   const onLoadMore = result.onLoadMore ?? null;
+  const [copyMenu, setCopyMenu] = useState<ContextMenuState | null>(null);
+
+  const visibleRows = () =>
+    sortGridRows(
+      filterRows(result.rows, result.columns, grid.filters, grid.changes),
+      result.columns,
+      grid.sort,
+      grid.changes,
+    );
+
+  useEffect(() => {
+    exportViewRef.current = () => ({
+      columns: result.columns,
+      rows: sortGridRows(
+        filterRows(result.rows, result.columns, grid.filters, grid.changes),
+        result.columns,
+        grid.sort,
+        grid.changes,
+      ),
+    });
+    return () => {
+      exportViewRef.current = null;
+    };
+  });
+
+  const copy = (text: string) => {
+    if (!navigator.clipboard) return;
+    void navigator.clipboard.writeText(text);
+  };
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden">
@@ -340,11 +475,62 @@ function ReadOnlyResultGrid({
           onEdit={grid.setEditing}
           filters={grid.filters}
           onFiltersChange={grid.setFilters}
+          sort={grid.sort}
+          onSortChange={grid.setSort}
           readOnly
           nullDisplay={settings.grid.nullDisplay}
           stripeRows={settings.grid.stripeRows}
+          onCellContextMenu={(event, row, column) => {
+            event.preventDefault();
+            const cell = row[column.key];
+            setCopyMenu({
+              x: event.clientX,
+              y: event.clientY,
+              items: [
+                {
+                  label: "Copy cell",
+                  onClick: () => copy(cell == null ? "" : String(cell)),
+                },
+                {
+                  label: "Copy row as CSV",
+                  onClick: () =>
+                    copy(
+                      toCsv(result.columns, [row], { header: false }).trimEnd(),
+                    ),
+                },
+                {
+                  label: "Copy row as TSV",
+                  onClick: () =>
+                    copy(
+                      toTsv(result.columns, [row], { header: false }).trimEnd(),
+                    ),
+                },
+                {
+                  label: "Copy row as SQL INSERT",
+                  onClick: () =>
+                    copy(toSqlInserts(result.columns, [row]).trimEnd()),
+                },
+                {
+                  label: "Copy all rows as CSV",
+                  onClick: () =>
+                    copy(toCsv(result.columns, visibleRows()).trimEnd()),
+                },
+                {
+                  label: "Copy all rows as JSON",
+                  onClick: () =>
+                    copy(toJson(result.columns, visibleRows()).trimEnd()),
+                },
+                {
+                  label: "Copy all rows as SQL INSERT",
+                  onClick: () =>
+                    copy(toSqlInserts(result.columns, visibleRows()).trimEnd()),
+                },
+              ],
+            });
+          }}
         />
       </div>
+      <ContextMenu state={copyMenu} onClose={() => setCopyMenu(null)} />
       {result.truncated && (
         <div className="flex shrink-0 items-center justify-between border-t border-border-default bg-bg-1 px-3 py-1.5 text-[11px] text-fg-3">
           <span>

--- a/apps/desktop/src/components/BottomPlanPanel.tsx
+++ b/apps/desktop/src/components/BottomPlanPanel.tsx
@@ -54,9 +54,19 @@ export function PlanPanel({ activeTab }: { activeTab: WorkspaceTab | null }) {
     };
   }, []);
 
+  // Stale-guard: a plan resolved after the user switched tabs (or re-ran)
+  // must not land on the panel. Bumping the token invalidates in-flight runs.
+  const planToken = useRef(0);
+  const queryTabId = queryTab?.id ?? null;
+  useEffect(() => {
+    planToken.current++;
+    setLoading(false);
+  }, [queryTabId]);
+
   async function loadPlan(nextMode = mode) {
     if (!queryTab || unavailable) return;
     if (nextMode === "analyze" && !confirmAnalyze()) return;
+    const token = ++planToken.current;
     setLoading(true);
     setError(null);
     try {
@@ -68,12 +78,14 @@ export function PlanPanel({ activeTab }: { activeTab: WorkspaceTab | null }) {
           queryTab.database,
         ),
       );
+      if (token !== planToken.current) return;
       setPlan(next);
     } catch (err) {
       noteConnectionIssue(queryTab.connectionId, err);
+      if (token !== planToken.current) return;
       setError(err instanceof Error ? err.message : String(err));
     } finally {
-      setLoading(false);
+      if (token === planToken.current) setLoading(false);
     }
   }
 

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -18,7 +18,12 @@ import {
   type SchemaVisibilityState,
   type SidebarNode,
 } from "./SidebarTree";
+import { SidebarConnectionList } from "./SidebarConnectionList";
 import { useConnections } from "../state/connections";
+import {
+  useSidebarLayout,
+  type SidebarFolderItem,
+} from "../state/sidebarLayout";
 import { useTabs } from "../state/tabs";
 import { qualifiedName, selectAllStatement } from "../lib/sqlIdent";
 
@@ -61,6 +66,16 @@ export function Sidebar({
   const newQueryTab = useTabs((s) => s.newQueryTab);
   const setQuerySql = useTabs((s) => s.setQuerySql);
   const activeTabId = useTabs((s) => s.activeId);
+  const layoutItems = useSidebarLayout((s) => s.items);
+  const reconcileLayout = useSidebarLayout((s) => s.reconcile);
+  const createFolder = useSidebarLayout((s) => s.createFolder);
+  const renameFolder = useSidebarLayout((s) => s.renameFolder);
+  const removeFolder = useSidebarLayout((s) => s.removeFolder);
+  const toggleFolder = useSidebarLayout((s) => s.toggleFolder);
+  const moveConnection = useSidebarLayout((s) => s.moveConnection);
+  const moveFolder = useSidebarLayout((s) => s.moveFolder);
+  const moveToFolder = useSidebarLayout((s) => s.moveToFolder);
+  const [renamingFolderId, setRenamingFolderId] = useState<string | null>(null);
 
   useEffect(() => {
     if (!loaded) {
@@ -69,13 +84,22 @@ export function Sidebar({
   }, [loaded, load]);
 
   useEffect(() => {
+    if (loaded) reconcileLayout(connections.map((c) => c.id));
+  }, [loaded, connections, reconcileLayout]);
+
+  useEffect(() => {
     saveSchemaVisibility(schemaVisibility);
   }, [schemaVisibility]);
 
-  const filtered = useMemo(() => {
+  const configById = useMemo(
+    () => new Map(connections.map((c) => [c.id, c] as const)),
+    [connections],
+  );
+
+  const matchCount = useMemo(() => {
     const q = filter.trim().toLowerCase();
-    if (!q) return connections;
-    return connections.filter((c) => c.name.toLowerCase().includes(q));
+    if (!q) return connections.length;
+    return connections.filter((c) => c.name.toLowerCase().includes(q)).length;
   }, [filter, connections]);
 
   const copyText = (text: string) => {
@@ -295,6 +319,42 @@ export function Sidebar({
     setSchemaManager({ connectionId, database, schemas });
   };
 
+  const startNewFolder = (connectionId?: string) => {
+    const id = createFolder("New folder");
+    if (connectionId) moveToFolder(connectionId, id);
+    setRenamingFolderId(id);
+  };
+
+  const commitFolderRename = (folderId: string, name: string) => {
+    renameFolder(folderId, name);
+    setRenamingFolderId(null);
+  };
+
+  const openFolderMenu = (e: React.MouseEvent, folder: SidebarFolderItem) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setMenu({
+      x: e.clientX,
+      y: e.clientY,
+      items: [
+        {
+          label: "Rename folder",
+          icon: <Icon.edit size={12} />,
+          onClick: () => setRenamingFolderId(folder.id),
+        },
+        {
+          label:
+            folder.children.length > 0
+              ? "Remove folder (keep connections)"
+              : "Remove folder",
+          icon: <Icon.trash size={12} />,
+          danger: true,
+          onClick: () => removeFolder(folder.id),
+        },
+      ],
+    });
+  };
+
   const openConnectionMenu = (e: React.MouseEvent, config: ConnectionConfig) => {
     e.preventDefault();
     e.stopPropagation();
@@ -325,6 +385,31 @@ export function Sidebar({
         onClick: () => onDuplicateConnection?.(config),
       },
     ];
+    const folders = layoutItems.filter(
+      (it): it is SidebarFolderItem => it.kind === "folder",
+    );
+    const currentFolder =
+      folders.find((f) => f.children.includes(config.id)) ?? null;
+    for (const f of folders) {
+      if (f.id === currentFolder?.id) continue;
+      items.push({
+        label: `Move to "${f.name}"`,
+        icon: <Icon.folder size={12} />,
+        onClick: () => moveToFolder(config.id, f.id),
+      });
+    }
+    items.push({
+      label: "Move to new folder",
+      icon: <Icon.folderPlus size={12} />,
+      onClick: () => startNewFolder(config.id),
+    });
+    if (currentFolder) {
+      items.push({
+        label: "Remove from folder",
+        icon: <Icon.folderOpen size={12} />,
+        onClick: () => moveToFolder(config.id, null),
+      });
+    }
     if (status === "connected" || status === "error") {
       items.push({
         label: status === "error" ? "Retry connection" : "Reconnect",
@@ -385,6 +470,11 @@ export function Sidebar({
           onClick: () => onNewConnection?.(),
         },
         {
+          label: "New folder",
+          icon: <Icon.folderPlus size={12} />,
+          onClick: () => startNewFolder(),
+        },
+        {
           label: "Refresh connected schemas",
           icon: <Icon.history size={12} />,
           disabled: connected.length === 0,
@@ -436,7 +526,7 @@ export function Sidebar({
         <span className="kbd">⌘F</span>
       </div>
 
-      <div className="flex-1 overflow-y-auto pb-3">
+      <div className="flex flex-1 flex-col overflow-y-auto pb-3">
         <button
           type="button"
           onClick={onNewConnection}
@@ -446,37 +536,48 @@ export function Sidebar({
           <span>New connection</span>
         </button>
 
-        {filtered.length === 0 && (
+        {matchCount === 0 && (
           <div className="px-3 py-5 text-center text-[11px] text-fg-3">
-            no connections yet
+            {connections.length === 0 ? "no connections yet" : "no matches"}
           </div>
         )}
-        {filtered.map((c) => {
-          const state = byId[c.id];
-          return (
-            <ConnectionRow
-              key={c.id}
-              config={c}
-              status={state?.status ?? "disconnected"}
-              expanded={state?.expanded ?? false}
-              loadingSchema={state?.loadingSchema ?? false}
-              databases={state?.databases ?? []}
-              error={state?.error ?? null}
-              onToggle={() => toggleExpand(c.id)}
-              onReconnect={() => void reconnect(c.id)}
-              onDisconnect={() => void disconnect(c.id)}
-              onContextMenu={(e) => openConnectionMenu(e, c)}
-              onNodeContextMenu={openNodeMenu}
-              onOpenTable={(database, schema, table) =>
-                openTable(c.id, database, schema, table)
-              }
-              activeTabId={activeTabId}
-              schemaVisibility={schemaVisibility}
-              onManageSchemas={openSchemaManager}
-            />
-          );
-        })}
-
+        <SidebarConnectionList
+          items={layoutItems}
+          configs={configById}
+          filter={filter}
+          renamingFolderId={renamingFolderId}
+          onCommitRename={commitFolderRename}
+          onCancelRename={() => setRenamingFolderId(null)}
+          onToggleFolder={toggleFolder}
+          onFolderContextMenu={openFolderMenu}
+          onMoveConnection={moveConnection}
+          onMoveFolder={moveFolder}
+          renderConnection={(c, drag) => {
+            const state = byId[c.id];
+            return (
+              <ConnectionRow
+                config={c}
+                status={state?.status ?? "disconnected"}
+                expanded={state?.expanded ?? false}
+                loadingSchema={state?.loadingSchema ?? false}
+                databases={state?.databases ?? []}
+                error={state?.error ?? null}
+                onToggle={() => toggleExpand(c.id)}
+                onReconnect={() => void reconnect(c.id)}
+                onDisconnect={() => void disconnect(c.id)}
+                onContextMenu={(e) => openConnectionMenu(e, c)}
+                onNodeContextMenu={openNodeMenu}
+                onOpenTable={(database, schema, table) =>
+                  openTable(c.id, database, schema, table)
+                }
+                activeTabId={activeTabId}
+                schemaVisibility={schemaVisibility}
+                onManageSchemas={openSchemaManager}
+                drag={drag}
+              />
+            );
+          }}
+        />
       </div>
 
       <div className="flex shrink-0 items-center border-t border-border-default px-2 py-1.5">

--- a/apps/desktop/src/components/SidebarConnectionList.tsx
+++ b/apps/desktop/src/components/SidebarConnectionList.tsx
@@ -1,0 +1,476 @@
+import { Fragment, useRef, useState, type ReactNode } from "react";
+import type { ConnectionConfig } from "@cellar/ipc";
+
+import { Icon } from "./icons";
+import {
+  ICON_SLOT,
+  META,
+  ROW_BASE,
+  TWISTY,
+  type ConnectionDragHandles,
+} from "./SidebarTree";
+import type {
+  SidebarContainer,
+  SidebarFolderItem,
+  SidebarItem,
+} from "../state/sidebarLayout";
+
+type DragItem = { type: "connection" | "folder"; id: string };
+
+type DropSpot = {
+  container: SidebarContainer;
+  index: number;
+  anchorKey: string;
+  edge: "before" | "after" | "into";
+};
+
+const END_KEY = "__end__";
+
+export interface SidebarConnectionListProps {
+  items: SidebarItem[];
+  configs: Map<string, ConnectionConfig>;
+  filter: string;
+  renamingFolderId: string | null;
+  onCommitRename: (folderId: string, name: string) => void;
+  onCancelRename: () => void;
+  onToggleFolder: (folderId: string) => void;
+  onFolderContextMenu: (e: React.MouseEvent, folder: SidebarFolderItem) => void;
+  onMoveConnection: (
+    connectionId: string,
+    container: SidebarContainer,
+    index: number,
+  ) => void;
+  onMoveFolder: (folderId: string, index: number) => void;
+  renderConnection: (
+    config: ConnectionConfig,
+    drag: ConnectionDragHandles | undefined,
+  ) => ReactNode;
+}
+
+/**
+ * Orders the sidebar's connections according to the persisted layout: a root
+ * sequence of connection rows and single-level folders, all reorderable via
+ * native drag and drop. Dragging is disabled while a filter is active since
+ * drop positions would be ambiguous against the full list.
+ */
+export function SidebarConnectionList({
+  items,
+  configs,
+  filter,
+  renamingFolderId,
+  onCommitRename,
+  onCancelRename,
+  onToggleFolder,
+  onFolderContextMenu,
+  onMoveConnection,
+  onMoveFolder,
+  renderConnection,
+}: SidebarConnectionListProps) {
+  const [drag, setDrag] = useState<DragItem | null>(null);
+  const [drop, setDrop] = useState<DropSpot | null>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  const q = filter.trim().toLowerCase();
+  const filtering = q.length > 0;
+  const canDrag = !filtering;
+  const matches = (config: ConnectionConfig) =>
+    config.name.toLowerCase().includes(q);
+
+  const updateDrop = (next: DropSpot) =>
+    setDrop((cur) =>
+      cur &&
+      cur.container === next.container &&
+      cur.index === next.index &&
+      cur.anchorKey === next.anchorKey &&
+      cur.edge === next.edge
+        ? cur
+        : next,
+    );
+
+  const clearDragState = () => {
+    setDrag(null);
+    setDrop(null);
+  };
+
+  const commitDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    const dragged = drag;
+    const spot = drop;
+    clearDragState();
+    if (!dragged || !spot) return;
+    if (dragged.type === "connection") {
+      onMoveConnection(dragged.id, spot.container, spot.index);
+    } else if (spot.container === null) {
+      onMoveFolder(dragged.id, spot.index);
+    }
+  };
+
+  const connectionDrag = (
+    id: string,
+    container: SidebarContainer,
+    index: number,
+    key: string,
+  ): ConnectionDragHandles | undefined => {
+    if (!canDrag) return undefined;
+    return {
+      draggable: true,
+      onDragStart: (e) => {
+        e.dataTransfer.effectAllowed = "move";
+        // WebKit needs data set for the drag to start at all.
+        e.dataTransfer.setData("text/plain", id);
+        setDrag({ type: "connection", id });
+      },
+      onDragOver: (e) => {
+        if (!drag) return;
+        if (drag.type === "folder" && container !== null) return;
+        e.preventDefault();
+        e.stopPropagation();
+        if (drag.id === id) {
+          setDrop(null);
+          return;
+        }
+        e.dataTransfer.dropEffect = "move";
+        const rect = e.currentTarget.getBoundingClientRect();
+        const before = e.clientY < rect.top + rect.height / 2;
+        updateDrop({
+          container,
+          index: before ? index : index + 1,
+          anchorKey: key,
+          edge: before ? "before" : "after",
+        });
+      },
+      onDragEnd: clearDragState,
+      dropIndicator:
+        drop && drop.anchorKey === key && drop.edge !== "into"
+          ? drop.edge
+          : null,
+    };
+  };
+
+  const onFolderDragOver = (
+    e: React.DragEvent,
+    folder: SidebarFolderItem,
+    rootIndex: number,
+    key: string,
+  ) => {
+    if (!drag || !canDrag) return;
+    e.preventDefault();
+    e.stopPropagation();
+    if (drag.type === "folder" && drag.id === folder.id) {
+      setDrop(null);
+      return;
+    }
+    e.dataTransfer.dropEffect = "move";
+    const rect = e.currentTarget.getBoundingClientRect();
+    const y = e.clientY - rect.top;
+    if (drag.type === "folder") {
+      const before = y < rect.height / 2;
+      updateDrop({
+        container: null,
+        index: before ? rootIndex : rootIndex + 1,
+        anchorKey: key,
+        edge: before ? "before" : "after",
+      });
+      return;
+    }
+    if (y < rect.height * 0.25) {
+      updateDrop({
+        container: null,
+        index: rootIndex,
+        anchorKey: key,
+        edge: "before",
+      });
+    } else if (folder.collapsed && y > rect.height * 0.75) {
+      updateDrop({
+        container: null,
+        index: rootIndex + 1,
+        anchorKey: key,
+        edge: "after",
+      });
+    } else {
+      // Expanded folders insert at the top so the drop lands in view;
+      // collapsed folders append.
+      updateDrop({
+        container: folder.id,
+        index: folder.collapsed ? folder.children.length : 0,
+        anchorKey: key,
+        edge: "into",
+      });
+    }
+  };
+
+  const onListDragOver = (e: React.DragEvent) => {
+    if (!drag || !canDrag) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+    updateDrop({
+      container: null,
+      index: items.length,
+      anchorKey: END_KEY,
+      edge: "after",
+    });
+  };
+
+  const onListDragLeave = (e: React.DragEvent) => {
+    const related = e.relatedTarget as Node | null;
+    if (!related || !rootRef.current?.contains(related)) setDrop(null);
+  };
+
+  const rows: ReactNode[] = [];
+  items.forEach((item, rootIndex) => {
+    if (item.kind === "connection") {
+      const config = configs.get(item.id);
+      if (!config || (filtering && !matches(config))) return;
+      const key = `conn:${item.id}`;
+      rows.push(
+        <Fragment key={key}>
+          {renderConnection(config, connectionDrag(item.id, null, rootIndex, key))}
+        </Fragment>,
+      );
+      return;
+    }
+
+    const childConfigs = item.children
+      .map((id) => configs.get(id))
+      .filter((c): c is ConnectionConfig => c != null);
+    const visibleChildren = filtering ? childConfigs.filter(matches) : childConfigs;
+    if (filtering && visibleChildren.length === 0) return;
+    const expanded = filtering || !item.collapsed;
+    const key = `folder:${item.id}`;
+    const isDropInto =
+      drop?.edge === "into" &&
+      drop.anchorKey !== END_KEY &&
+      drop.container === item.id;
+
+    rows.push(
+      <FolderRow
+        key={key}
+        folder={item}
+        expanded={expanded}
+        count={visibleChildren.length}
+        renaming={renamingFolderId === item.id}
+        draggable={canDrag && renamingFolderId !== item.id}
+        dropInto={isDropInto}
+        dropIndicator={
+          drop && drop.anchorKey === key && drop.edge !== "into"
+            ? drop.edge
+            : null
+        }
+        onToggle={() => onToggleFolder(item.id)}
+        onContextMenu={(e) => onFolderContextMenu(e, item)}
+        onCommitRename={(name) => onCommitRename(item.id, name)}
+        onCancelRename={onCancelRename}
+        onDragStart={(e) => {
+          e.dataTransfer.effectAllowed = "move";
+          e.dataTransfer.setData("text/plain", item.id);
+          setDrag({ type: "folder", id: item.id });
+        }}
+        onDragOver={(e) => onFolderDragOver(e, item, rootIndex, key)}
+        onDragEnd={clearDragState}
+      />,
+    );
+
+    if (expanded) {
+      rows.push(
+        <div
+          key={`children:${item.id}`}
+          className="ml-[13px] border-l border-border-default"
+        >
+          {visibleChildren.length === 0 ? (
+            <div
+              className={
+                "mx-2 my-0.5 rounded-[4px] border border-dashed px-2 py-1 text-[10.5px] " +
+                (isDropInto
+                  ? "border-accent-line bg-accent-soft text-accent"
+                  : "border-border-default text-fg-3")
+              }
+              onDragOver={(e) => {
+                if (!drag || drag.type !== "connection") return;
+                e.preventDefault();
+                e.stopPropagation();
+                updateDrop({
+                  container: item.id,
+                  index: 0,
+                  anchorKey: key,
+                  edge: "into",
+                });
+              }}
+            >
+              {drag ? "drop here" : "empty folder"}
+            </div>
+          ) : (
+            visibleChildren.map((config) => {
+              const childKey = `conn:${config.id}`;
+              return (
+                <Fragment key={childKey}>
+                  {renderConnection(
+                    config,
+                    connectionDrag(
+                      config.id,
+                      item.id,
+                      item.children.indexOf(config.id),
+                      childKey,
+                    ),
+                  )}
+                </Fragment>
+              );
+            })
+          )}
+        </div>,
+      );
+    }
+  });
+
+  return (
+    <div
+      ref={rootRef}
+      className="flex-1"
+      onDragOver={onListDragOver}
+      onDragLeave={onListDragLeave}
+      onDrop={commitDrop}
+    >
+      {rows}
+      {drop?.anchorKey === END_KEY && (
+        <div
+          className="mx-2 h-[2px] rounded"
+          style={{ background: "var(--accent)" }}
+        />
+      )}
+    </div>
+  );
+}
+
+function FolderRow({
+  folder,
+  expanded,
+  count,
+  renaming,
+  draggable,
+  dropInto,
+  dropIndicator,
+  onToggle,
+  onContextMenu,
+  onCommitRename,
+  onCancelRename,
+  onDragStart,
+  onDragOver,
+  onDragEnd,
+}: {
+  folder: SidebarFolderItem;
+  expanded: boolean;
+  count: number;
+  renaming: boolean;
+  draggable: boolean;
+  dropInto: boolean;
+  dropIndicator: "before" | "after" | null;
+  onToggle: () => void;
+  onContextMenu: (e: React.MouseEvent) => void;
+  onCommitRename: (name: string) => void;
+  onCancelRename: () => void;
+  onDragStart: React.DragEventHandler;
+  onDragOver: React.DragEventHandler;
+  onDragEnd: () => void;
+}) {
+  return (
+    <div
+      className={
+        ROW_BASE +
+        " h-[26px] pl-1 font-medium text-fg-0 cursor-pointer" +
+        (dropInto ? " bg-accent-soft" : "")
+      }
+      onClick={() => !renaming && onToggle()}
+      onContextMenu={onContextMenu}
+      draggable={draggable}
+      onDragStart={onDragStart}
+      onDragOver={onDragOver}
+      onDragEnd={onDragEnd}
+    >
+      {dropIndicator && (
+        <span
+          className={
+            "pointer-events-none absolute inset-x-0 z-10 h-[2px] rounded " +
+            (dropIndicator === "before" ? "top-0" : "bottom-0")
+          }
+          style={{ background: "var(--accent)" }}
+        />
+      )}
+      <button
+        type="button"
+        className={TWISTY}
+        onClick={(e) => {
+          e.stopPropagation();
+          onToggle();
+        }}
+        aria-label={expanded ? "Collapse folder" : "Expand folder"}
+      >
+        {expanded ? (
+          <Icon.chevronDown size={10} />
+        ) : (
+          <Icon.chevronRight size={10} />
+        )}
+      </button>
+      <span className={ICON_SLOT} style={{ color: "var(--fg-2)" }}>
+        {expanded ? <Icon.folderOpen size={12} /> : <Icon.folder size={12} />}
+      </span>
+      {renaming ? (
+        <FolderRenameInput
+          initial={folder.name}
+          onCommit={onCommitRename}
+          onCancel={onCancelRename}
+        />
+      ) : (
+        <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[12px] font-medium">
+          {folder.name}
+        </span>
+      )}
+      <span className={META + " font-mono"}>{count}</span>
+      <button
+        type="button"
+        className="icon-btn ml-1 opacity-0 transition-opacity duration-100 group-hover:opacity-100"
+        title="Folder actions"
+        onClick={(e) => {
+          e.stopPropagation();
+          onContextMenu(e);
+        }}
+      >
+        <Icon.more size={11} />
+      </button>
+    </div>
+  );
+}
+
+/** Mounted only while a rename is active so each session starts fresh. */
+function FolderRenameInput({
+  initial,
+  onCommit,
+  onCancel,
+}: {
+  initial: string;
+  onCommit: (name: string) => void;
+  onCancel: () => void;
+}) {
+  const done = useRef(false);
+  const commit = (value: string) => {
+    if (done.current) return;
+    done.current = true;
+    onCommit(value);
+  };
+
+  return (
+    <input
+      autoFocus
+      defaultValue={initial}
+      onFocus={(e) => e.currentTarget.select()}
+      onClick={(e) => e.stopPropagation()}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") commit(e.currentTarget.value);
+        if (e.key === "Escape") {
+          done.current = true;
+          onCancel();
+        }
+      }}
+      onBlur={(e) => commit(e.currentTarget.value)}
+      className="min-w-0 flex-1 rounded-[3px] border border-accent-line bg-bg-inset px-1 py-px text-[12px] font-medium text-fg-0 outline-none"
+    />
+  );
+}

--- a/apps/desktop/src/components/SidebarTree.tsx
+++ b/apps/desktop/src/components/SidebarTree.tsx
@@ -41,21 +41,31 @@ export type SchemaVisibilityState = Record<string, SchemaVisibilityPrefs>;
 
 const SCHEMA_VISIBILITY_STORAGE_KEY = "cellar.schemaVisibility.v1";
 
-const ROW_BASE =
+export const ROW_BASE =
   "group relative flex h-[22px] select-none items-center gap-1 pr-1.5 text-fg-1 cursor-default hover:bg-bg-2";
 
 const ROW_ACTIVE = "bg-accent-soft text-accent [&_.sb-icon-slot]:!text-accent";
 
-const ICON_SLOT =
+export const ICON_SLOT =
   "sb-icon-slot inline-flex h-[14px] w-[14px] shrink-0 items-center justify-center";
 
-const TWISTY =
+export const TWISTY =
   "inline-flex h-[14px] w-[14px] shrink-0 items-center justify-center text-fg-3 hover:text-fg-1";
 
-const META = "ml-auto pr-1 whitespace-nowrap text-[10px] text-fg-3 shrink-0";
+export const META =
+  "ml-auto pr-1 whitespace-nowrap text-[10px] text-fg-3 shrink-0";
 
 const PILL =
   "ml-1 rounded-[3px] bg-bg-2 px-1 py-px font-mono text-[9px] text-fg-3";
+
+/** Drag/drop wiring the sidebar list attaches to a connection header row. */
+export interface ConnectionDragHandles {
+  draggable: boolean;
+  onDragStart: React.DragEventHandler;
+  onDragOver: React.DragEventHandler;
+  onDragEnd: () => void;
+  dropIndicator: "before" | "after" | null;
+}
 
 export interface ConnectionRowProps {
   config: ConnectionConfig;
@@ -77,6 +87,7 @@ export interface ConnectionRowProps {
     database: string,
     schemas: Schema[],
   ) => void;
+  drag?: ConnectionDragHandles;
 }
 
 export function ConnectionRow({
@@ -95,6 +106,7 @@ export function ConnectionRow({
   activeTabId,
   schemaVisibility,
   onManageSchemas,
+  drag,
 }: ConnectionRowProps) {
   const accent = config.color ?? engineDefaultColor(config.engine as Engine);
   return (
@@ -110,7 +122,20 @@ export function ConnectionRow({
         }}
         onClick={onToggle}
         onContextMenu={onContextMenu}
+        draggable={drag?.draggable}
+        onDragStart={drag?.onDragStart}
+        onDragOver={drag?.onDragOver}
+        onDragEnd={drag?.onDragEnd}
       >
+        {drag?.dropIndicator && (
+          <span
+            className={
+              "pointer-events-none absolute inset-x-0 z-10 h-[2px] rounded " +
+              (drag.dropIndicator === "before" ? "top-0" : "bottom-0")
+            }
+            style={{ background: "var(--accent)" }}
+          />
+        )}
         <button
           type="button"
           className={TWISTY}

--- a/apps/desktop/src/components/SqlEditor.tsx
+++ b/apps/desktop/src/components/SqlEditor.tsx
@@ -48,7 +48,7 @@ export function SqlEditor({ tab }: { tab: QueryTab }) {
   const requestExplain = useBottomPanel((s) => s.requestExplain);
   const { settings } = useSettings();
 
-  const { running, errorLine, run, clearError } = useQueryRunner(tab);
+  const { running, errorLine, run, cancel, clearError } = useQueryRunner(tab);
 
   const [caret, setCaret] = useState(0);
   // Per-editor wrap toggle overrides the global default.
@@ -92,6 +92,20 @@ export function SqlEditor({ tab }: { tab: QueryTab }) {
     if (errorLine != null) clearError();
   }, [clearError, errorLine, setQuerySql, tab.id]);
 
+  // ⌘. / Ctrl+. cancels the in-flight statement, matching the toolbar button.
+  // Window-level so it works while focus sits inside the code editor.
+  useEffect(() => {
+    if (!running) return;
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === ".") {
+        e.preventDefault();
+        cancel();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [running, cancel]);
+
   useEffect(() => {
     if (!connected || loadingSchema || databases.length > 0) return;
     void refreshSchema(tab.connectionId);
@@ -133,6 +147,17 @@ export function SqlEditor({ tab }: { tab: QueryTab }) {
             <span>{running ? "Running…" : "Run"}</span>
             <span className="kbd">⌘⏎</span>
           </button>
+          {running && (
+            <button
+              className="ed-run subtle"
+              onClick={cancel}
+              title="Ask the server to stop the running statement"
+            >
+              <Icon.stop size={11} />
+              <span>Cancel</span>
+              <span className="kbd">⌘.</span>
+            </button>
+          )}
           <button
             className="ed-run subtle"
             onClick={runAll}

--- a/apps/desktop/src/components/icons.tsx
+++ b/apps/desktop/src/components/icons.tsx
@@ -77,6 +77,24 @@ export const Icon = {
   schema: (p: IconProps) => (
     <I {...p} d="M3 6h7l2 2h9v11a1 1 0 01-1 1H3a1 1 0 01-1-1V7a1 1 0 011-1z" />
   ),
+  folder: (p: IconProps) => (
+    <I
+      {...p}
+      d="M20 20a2 2 0 002-2V8a2 2 0 00-2-2h-7.9a2 2 0 01-1.69-.9L9.6 3.9A2 2 0 007.93 3H4a2 2 0 00-2 2v13a2 2 0 002 2z"
+    />
+  ),
+  folderOpen: (p: IconProps) => (
+    <I
+      {...p}
+      d="M6 14l1.45-2.9A2 2 0 019.24 10H20a2 2 0 011.94 2.5l-1.55 6a2 2 0 01-1.94 1.5H4a2 2 0 01-2-2V5a2 2 0 012-2h3.93a2 2 0 011.66.9l.82 1.2a2 2 0 001.66.9H18a2 2 0 012 2v2"
+    />
+  ),
+  folderPlus: (p: IconProps) => (
+    <I {...p}>
+      <path d="M20 20a2 2 0 002-2V8a2 2 0 00-2-2h-7.9a2 2 0 01-1.69-.9L9.6 3.9A2 2 0 007.93 3H4a2 2 0 00-2 2v13a2 2 0 002 2z" />
+      <path d="M12 10v6M9 13h6" />
+    </I>
+  ),
 
   plus: (p: IconProps) => <I {...p} d="M12 5v14M5 12h14" />,
   close: (p: IconProps) => <I {...p} d="M6 6l12 12M18 6L6 18" />,
@@ -268,6 +286,9 @@ export const Icon = {
   ),
   playSm: (p: IconProps) => (
     <I {...p} fill="currentColor" stroke="none" d="M8 5.5v13l10-6.5z" />
+  ),
+  stop: (p: IconProps) => (
+    <I {...p} fill="currentColor" stroke="none" d="M6.5 6.5h11v11h-11z" />
   ),
   format: (p: IconProps) => (
     <I {...p} d="M4 6h16M4 10h10M4 14h16M4 18h8" />

--- a/apps/desktop/src/hooks/useQueryRunner.ts
+++ b/apps/desktop/src/hooks/useQueryRunner.ts
@@ -36,6 +36,12 @@ export interface QueryRunner {
   run: (sql: string, opts: RunOptions) => void;
   /** Fetch the next page and append it to the current result grid. */
   loadMore: () => void;
+  /**
+   * Ask the server to stop the in-flight statement (best effort). The run
+   * itself still settles through its own error path — Postgres reports
+   * SQLSTATE 57014 "canceling statement due to user request".
+   */
+  cancel: () => void;
   clearError: () => void;
 }
 
@@ -53,6 +59,9 @@ export function useQueryRunner(tab: QueryTab): QueryRunner {
   const mounted = useRef(true);
   // Track the current SQL and next offset for "Load more" appends.
   const loadMoreRef = useRef<{ sql: string; offset: number } | null>(null);
+  // Cancellation handle for the in-flight run, passed to the backend so a
+  // cancel call can find the statement's connection.
+  const activeQueryId = useRef<string | null>(null);
 
   useEffect(() => {
     mounted.current = true;
@@ -101,6 +110,9 @@ export function useQueryRunner(tab: QueryTab): QueryRunner {
           .replaceForTab(tab.id, [buildRunStartedMessage(context)]);
       }
 
+      const queryId = crypto.randomUUID();
+      activeQueryId.current = queryId;
+
       void (async () => {
         try {
           const result = await unwrap(
@@ -111,6 +123,7 @@ export function useQueryRunner(tab: QueryTab): QueryRunner {
               offset,
               database,
               tab.id,
+              queryId,
             ),
           );
           if (!mounted.current || token !== runToken.current) return;
@@ -134,6 +147,7 @@ export function useQueryRunner(tab: QueryTab): QueryRunner {
                 rowCount: combined.length,
                 truncated: result.truncated,
                 durationMs: result.duration_ms,
+                rowsAffected: existing.rowsAffected,
                 onLoadMore: existing.onLoadMore,
               });
             } else {
@@ -155,6 +169,7 @@ export function useQueryRunner(tab: QueryTab): QueryRunner {
               rowCount: rows.length,
               truncated: result.truncated,
               durationMs: result.duration_ms,
+              rowsAffected: result.rows_affected,
             });
           }
 
@@ -209,6 +224,9 @@ export function useQueryRunner(tab: QueryTab): QueryRunner {
             .addMessage(buildRunErrorMessage(context, err));
           setErrorLine(opts.errorLine ?? null);
         } finally {
+          if (activeQueryId.current === queryId) {
+            activeQueryId.current = null;
+          }
           if (mounted.current && token === runToken.current) {
             setRunning(false);
           }
@@ -234,6 +252,35 @@ export function useQueryRunner(tab: QueryTab): QueryRunner {
     void executeQuery(sql, { label: "Load more" }, offset, true);
   }, [running, executeQuery]);
 
+  const cancel = useCallback(() => {
+    const queryId = activeQueryId.current;
+    if (!queryId) return;
+    const note = (severity: "info" | "warning", text: string) => {
+      useQueryMessages.getState().addMessage({
+        tabId: tab.id,
+        connectionId: tab.connectionId,
+        database: tab.database || undefined,
+        severity,
+        source: "client",
+        text,
+      });
+    };
+    void unwrap(commands.cancelQuery(tab.connectionId, queryId))
+      .then((cancelled) => {
+        if (cancelled) {
+          note("warning", "Cancel requested — the server was asked to stop the running statement.");
+        } else {
+          note("info", "Nothing to cancel — the statement had already finished.");
+        }
+      })
+      .catch((err) => {
+        note(
+          "warning",
+          `Could not cancel the running statement: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
+  }, [tab.connectionId, tab.database, tab.id]);
+
   // Keep the tabResults store in sync with the load-more callback so the
   // bottom panel's result grid can surface the "Load more" button without
   // needing a direct reference to the hook.
@@ -244,7 +291,7 @@ export function useQueryRunner(tab: QueryTab): QueryRunner {
     );
   }, [tab.id, canLoadMore, loadMore]);
 
-  return { running, errorLine, canLoadMore, run, loadMore, clearError };
+  return { running, errorLine, canLoadMore, run, loadMore, cancel, clearError };
 }
 
 // Re-export for callers that only need the type.

--- a/apps/desktop/src/lib/export.test.ts
+++ b/apps/desktop/src/lib/export.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import type { GridColumn, GridRow } from "@cellar/data-grid";
+import {
+  exportFilename,
+  toCsv,
+  toJson,
+  toSqlInserts,
+  toTsv,
+} from "./export";
+
+function col(name: string, type = "text"): GridColumn {
+  return { key: name, name, type, width: 100 };
+}
+
+describe("toCsv", () => {
+  const cols = [col("id"), col("note")];
+
+  it("quotes fields with delimiters, quotes, and newlines", () => {
+    const data: GridRow[] = [
+      { id: "row:0", note: 'say "hi", twice' },
+      { id: "row:1", note: "line1\nline2" },
+    ];
+    const csv = toCsv(cols, data);
+    expect(csv).toBe(
+      'id,note\r\nrow:0,"say ""hi"", twice"\r\nrow:1,"line1\nline2"\r\n',
+    );
+  });
+
+  it("distinguishes NULL (empty) from empty string (quoted)", () => {
+    const data: GridRow[] = [{ id: "row:0", note: null }, { id: "row:1", note: "" }];
+    const csv = toCsv(cols, data);
+    expect(csv).toBe('id,note\r\nrow:0,\r\nrow:1,""\r\n');
+  });
+});
+
+describe("toTsv", () => {
+  it("uses tabs and quotes embedded tabs", () => {
+    const cols = [col("a"), col("b")];
+    const data: GridRow[] = [{ id: "row:0", a: "x", b: "with\ttab" }];
+    expect(toTsv(cols, data)).toBe('a\tb\r\nx\t"with\ttab"\r\n');
+  });
+});
+
+describe("toJson", () => {
+  it("emits an array of objects with null for NULL", () => {
+    const data: GridRow[] = [
+      { id: "row:0", name: "Ada", active: true },
+      { id: "row:1", name: null, active: false },
+    ];
+    const cols = [col("name"), col("active", "bool")];
+    expect(JSON.parse(toJson(cols, data))).toEqual([
+      { name: "Ada", active: true },
+      { name: null, active: false },
+    ]);
+  });
+});
+
+describe("toSqlInserts", () => {
+  it("emits one runnable INSERT per row with escaped values", () => {
+    const cols = [col("id", "int8"), col("name"), col("active", "bool")];
+    const data: GridRow[] = [
+      { id: "row:0", name: "O'Brien", active: true },
+      { id: "row:1", name: null, active: false },
+    ];
+    // The grid's synthetic row id collides with a real `id` column here; the
+    // exporter reads whatever the column key resolves to, so use numbers.
+    const numbered: GridRow[] = data.map((r, i) => ({ ...r, id: String(i + 1) }));
+    const sql = toSqlInserts(cols, numbered, { table: "people" });
+    expect(sql).toBe(
+      `INSERT INTO "people" ("id", "name", "active") VALUES ('1', 'O''Brien', TRUE);\n` +
+        `INSERT INTO "people" ("id", "name", "active") VALUES ('2', NULL, FALSE);\n`,
+    );
+  });
+
+  it("doubles embedded quotes in identifiers", () => {
+    const cols = [col('we"ird')];
+    const sql = toSqlInserts(cols, [{ id: "row:0", 'we"ird': "v" }]);
+    expect(sql).toContain('INSERT INTO "results" ("we""ird") VALUES (\'v\');');
+  });
+});
+
+describe("exportFilename", () => {
+  it("slugs the tab title and appends the extension", () => {
+    expect(exportFilename("untitled-1.sql", "csv")).toBe("untitled-1.csv");
+    expect(exportFilename("My Query!", "json")).toBe("my-query.json");
+    expect(exportFilename("???", "sql")).toBe("result.sql");
+  });
+});

--- a/apps/desktop/src/lib/export.ts
+++ b/apps/desktop/src/lib/export.ts
@@ -1,0 +1,186 @@
+import type { GridColumn, GridRow, GridValue } from "@cellar/data-grid";
+
+// Pure exporters from the grid's column/row shapes into portable text formats.
+// Shared by the bottom-panel "Export" button (file download) and the result
+// grid's "Copy as" context menu (clipboard), per SPEC §9.1.
+
+export type ExportFormat = "csv" | "tsv" | "json" | "sql";
+
+export const EXPORT_FORMATS: { format: ExportFormat; label: string }[] = [
+  { format: "csv", label: "CSV" },
+  { format: "tsv", label: "TSV" },
+  { format: "json", label: "JSON" },
+  { format: "sql", label: "SQL INSERT" },
+];
+
+const EXTENSIONS: Record<ExportFormat, string> = {
+  csv: "csv",
+  tsv: "tsv",
+  json: "json",
+  sql: "sql",
+};
+
+const MIME_TYPES: Record<ExportFormat, string> = {
+  csv: "text/csv",
+  tsv: "text/tab-separated-values",
+  json: "application/json",
+  sql: "application/sql",
+};
+
+export interface SqlInsertOptions {
+  /** Target table for the generated INSERT statements. */
+  table?: string;
+}
+
+export interface DelimitedOptions {
+  /** Emit a header row of column names. Defaults to true. */
+  header?: boolean;
+}
+
+export function toCsv(
+  columns: readonly GridColumn[],
+  rows: readonly GridRow[],
+  opts: DelimitedOptions = {},
+): string {
+  return delimited(columns, rows, ",", opts);
+}
+
+export function toTsv(
+  columns: readonly GridColumn[],
+  rows: readonly GridRow[],
+  opts: DelimitedOptions = {},
+): string {
+  return delimited(columns, rows, "\t", opts);
+}
+
+/**
+ * RFC 4180-style delimited text. Fields containing the delimiter, quotes, or
+ * line breaks are quoted with embedded quotes doubled. SQL NULL becomes an
+ * unquoted empty field while an empty string is quoted (`""`), preserving the
+ * distinction the way `psql \copy ... csv` does.
+ */
+function delimited(
+  columns: readonly GridColumn[],
+  rows: readonly GridRow[],
+  delimiter: string,
+  { header = true }: DelimitedOptions = {},
+): string {
+  const escape = (value: GridValue | undefined): string => {
+    if (value === null || value === undefined) return "";
+    const text = String(value);
+    if (text === "") return '""';
+    if (
+      text.includes(delimiter) ||
+      text.includes('"') ||
+      text.includes("\n") ||
+      text.includes("\r")
+    ) {
+      return `"${text.replaceAll('"', '""')}"`;
+    }
+    return text;
+  };
+
+  const lines = header
+    ? [columns.map((c) => escape(c.name)).join(delimiter)]
+    : [];
+  for (const row of rows) {
+    lines.push(columns.map((c) => escape(row[c.key])).join(delimiter));
+  }
+  return lines.join("\r\n") + "\r\n";
+}
+
+/** Array of objects keyed by column name; SQL NULL maps to JSON null. */
+export function toJson(
+  columns: readonly GridColumn[],
+  rows: readonly GridRow[],
+): string {
+  const objects = rows.map((row) => {
+    const out: Record<string, GridValue> = {};
+    for (const c of columns) {
+      out[c.name] = row[c.key] ?? null;
+    }
+    return out;
+  });
+  return JSON.stringify(objects, null, 2) + "\n";
+}
+
+/**
+ * One runnable INSERT per row. Identifiers are double-quoted with embedded
+ * quotes doubled; string values single-quoted with embedded quotes doubled
+ * (standard-conforming literals — no backslash escapes). Numbers and booleans
+ * pass through bare; grid values that arrived as strings (numerics, temporals,
+ * uuids) are quoted, which every engine accepts for those types.
+ */
+export function toSqlInserts(
+  columns: readonly GridColumn[],
+  rows: readonly GridRow[],
+  opts: SqlInsertOptions = {},
+): string {
+  const table = quoteIdent(opts.table ?? "results");
+  const columnList = columns.map((c) => quoteIdent(c.name)).join(", ");
+  const statements = rows.map((row) => {
+    const values = columns.map((c) => sqlLiteral(row[c.key])).join(", ");
+    return `INSERT INTO ${table} (${columnList}) VALUES (${values});`;
+  });
+  return statements.join("\n") + (statements.length > 0 ? "\n" : "");
+}
+
+function quoteIdent(ident: string): string {
+  return `"${ident.replaceAll('"', '""')}"`;
+}
+
+function sqlLiteral(value: GridValue | undefined): string {
+  if (value === null || value === undefined) return "NULL";
+  if (typeof value === "boolean") return value ? "TRUE" : "FALSE";
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? String(value) : `'${String(value)}'`;
+  }
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+export function exportText(
+  format: ExportFormat,
+  columns: readonly GridColumn[],
+  rows: readonly GridRow[],
+  opts: SqlInsertOptions = {},
+): string {
+  switch (format) {
+    case "csv":
+      return toCsv(columns, rows);
+    case "tsv":
+      return toTsv(columns, rows);
+    case "json":
+      return toJson(columns, rows);
+    case "sql":
+      return toSqlInserts(columns, rows, opts);
+  }
+}
+
+/** `label` sanitized into `label.{ext}` for the download attribute. */
+export function exportFilename(label: string, format: ExportFormat): string {
+  const base =
+    label
+      .toLowerCase()
+      .replace(/\.sql$/, "")
+      .replace(/[^a-z0-9._-]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "result";
+  return `${base}.${EXTENSIONS[format]}`;
+}
+
+/** Trigger a browser-style download — same pattern as ExportSetupModal. */
+export function downloadText(
+  filename: string,
+  format: ExportFormat,
+  contents: string,
+): void {
+  const blob = new Blob([contents], { type: MIME_TYPES[format] });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  // Revoke on the next tick so the download has time to start.
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}

--- a/apps/desktop/src/state/deferredStorage.ts
+++ b/apps/desktop/src/state/deferredStorage.ts
@@ -8,6 +8,17 @@ const WRITE_DELAY_MS = 50;
  * the store.
  */
 export function deferredLocalStorage(): StateStorage {
+  // No window means a test (or SSR-like) environment: keep persisted stores
+  // functional with in-memory storage instead of warning on every write.
+  if (typeof window === "undefined") {
+    const mem = new Map<string, string>();
+    return {
+      getItem: (name) => mem.get(name) ?? null,
+      setItem: (name, value) => void mem.set(name, value),
+      removeItem: (name) => void mem.delete(name),
+    };
+  }
+
   const pending = new Map<string, string>();
   let timer: number | null = null;
 

--- a/apps/desktop/src/state/notices.test.ts
+++ b/apps/desktop/src/state/notices.test.ts
@@ -81,4 +81,17 @@ describe("notice store", () => {
     expect(entryFor(scope).notices).toEqual([]);
     expect(entryFor(other).notices).toHaveLength(1);
   });
+
+  it("drops tab-scoped entries entirely when their tabs close", () => {
+    const other = { ...scope, tabId: "conn::postgres.public.customers" };
+    useNotices.getState().appendNotice(scope, sampleNotice("orders"));
+    useNotices.getState().appendNotice(other, sampleNotice("customers"));
+
+    useNotices.getState().dropTabs([scope.tabId as string]);
+
+    expect(
+      useNotices.getState().byScope[noticeScopeKey(scope)],
+    ).toBeUndefined();
+    expect(entryFor(other).notices).toHaveLength(1);
+  });
 });

--- a/apps/desktop/src/state/notices.ts
+++ b/apps/desktop/src/state/notices.ts
@@ -20,6 +20,8 @@ interface NoticeStore {
   appendNotice: (scope: NoticeScope, notice: DatabaseNotice) => void;
   clear: (scope: NoticeScope) => void;
   setRetain: (scope: NoticeScope, retain: boolean) => void;
+  /** Remove every tab-scoped entry for the given tabs (used on tab close). */
+  dropTabs: (tabIds: string[]) => void;
 }
 
 const EMPTY_ENTRY: NoticeLogEntry = {
@@ -111,5 +113,19 @@ export const useNotices = create<NoticeStore>((set) => ({
         },
       };
     });
+  },
+
+  dropTabs(tabIds) {
+    if (tabIds.length === 0) return;
+    const dropped = new Set(
+      tabIds.map((tabId) =>
+        noticeScopeKey({ tabId, connectionId: null, database: null }),
+      ),
+    );
+    set((s) => ({
+      byScope: Object.fromEntries(
+        Object.entries(s.byScope).filter(([key]) => !dropped.has(key)),
+      ),
+    }));
   },
 }));

--- a/apps/desktop/src/state/sidebarLayout.test.ts
+++ b/apps/desktop/src/state/sidebarLayout.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  moveConnectionItem,
+  moveFolderItem,
+  reconcileItems,
+  removeFolderItem,
+  useSidebarLayout,
+  type SidebarItem,
+} from "./sidebarLayout";
+
+const conn = (id: string): SidebarItem => ({ kind: "connection", id });
+const folder = (
+  id: string,
+  children: string[],
+  extra?: Partial<{ name: string; collapsed: boolean }>,
+): SidebarItem => ({
+  kind: "folder",
+  id,
+  name: extra?.name ?? id,
+  collapsed: extra?.collapsed ?? false,
+  children,
+});
+
+describe("reconcileItems", () => {
+  it("appends unknown connections at the root", () => {
+    const out = reconcileItems([conn("a")], ["a", "b", "c"]);
+    expect(out).toEqual([conn("a"), conn("b"), conn("c")]);
+  });
+
+  it("prunes deleted connections from the root and from folders", () => {
+    const out = reconcileItems(
+      [conn("gone"), folder("f", ["kept", "removed"]), conn("kept-root")],
+      ["kept", "kept-root"],
+    );
+    expect(out).toEqual([folder("f", ["kept"]), conn("kept-root")]);
+  });
+
+  it("drops duplicate references, keeping the first occurrence", () => {
+    const out = reconcileItems(
+      [folder("f", ["a"]), conn("a"), conn("b")],
+      ["a", "b"],
+    );
+    expect(out).toEqual([folder("f", ["a"]), conn("b")]);
+  });
+
+  it("returns the same reference when nothing changed", () => {
+    const items = [folder("f", ["a"]), conn("b")];
+    expect(reconcileItems(items, ["a", "b"])).toBe(items);
+  });
+
+  it("recovers from malformed persisted data", () => {
+    const junk = [
+      null,
+      42,
+      { kind: "folder" },
+      { kind: "connection", id: "a" },
+      { kind: "folder", id: "f", children: ["b", 7] },
+    ] as unknown as SidebarItem[];
+    const out = reconcileItems(junk, ["a", "b"]);
+    expect(out).toEqual([conn("a"), folder("f", ["b"], { name: "Folder" })]);
+  });
+});
+
+describe("moveConnectionItem", () => {
+  const base = [conn("a"), conn("b"), folder("f", ["x", "y"]), conn("c")];
+
+  it("reorders within the root, moving down", () => {
+    // Visually dropping "a" after "b" → display index 2.
+    const out = moveConnectionItem(base, "a", null, 2);
+    expect(out).toEqual([conn("b"), conn("a"), folder("f", ["x", "y"]), conn("c")]);
+  });
+
+  it("reorders within the root, moving up", () => {
+    const out = moveConnectionItem(base, "c", null, 0);
+    expect(out).toEqual([conn("c"), conn("a"), conn("b"), folder("f", ["x", "y"])]);
+  });
+
+  it("moves a root connection into a folder at a position", () => {
+    const out = moveConnectionItem(base, "a", "f", 1);
+    expect(out).toEqual([conn("b"), folder("f", ["x", "a", "y"]), conn("c")]);
+  });
+
+  it("moves a folder connection back to the root", () => {
+    const out = moveConnectionItem(base, "y", null, 0);
+    expect(out).toEqual([
+      conn("y"),
+      conn("a"),
+      conn("b"),
+      folder("f", ["x"]),
+      conn("c"),
+    ]);
+  });
+
+  it("reorders within a folder with the same-container adjustment", () => {
+    const items = [folder("f", ["x", "y", "z"])];
+    const out = moveConnectionItem(items, "x", "f", 2);
+    expect(out).toEqual([folder("f", ["y", "x", "z"])]);
+  });
+
+  it("ignores moves to a folder that does not exist", () => {
+    expect(moveConnectionItem(base, "a", "nope", 0)).toBe(base);
+  });
+
+  it("ignores unknown connections", () => {
+    expect(moveConnectionItem(base, "ghost", null, 0)).toBe(base);
+  });
+
+  it("clamps out-of-range indices", () => {
+    const out = moveConnectionItem(base, "a", "f", 99);
+    expect(out).toEqual([conn("b"), folder("f", ["x", "y", "a"]), conn("c")]);
+  });
+});
+
+describe("moveFolderItem", () => {
+  const base = [conn("a"), folder("f", []), conn("b"), folder("g", [])];
+
+  it("moves a folder down past later items", () => {
+    // Dropping "f" after "b" → display index 3.
+    const out = moveFolderItem(base, "f", 3);
+    expect(out).toEqual([conn("a"), conn("b"), folder("f", []), folder("g", [])]);
+  });
+
+  it("moves a folder to the top", () => {
+    const out = moveFolderItem(base, "g", 0);
+    expect(out).toEqual([folder("g", []), conn("a"), folder("f", []), conn("b")]);
+  });
+
+  it("is a no-op for same position or unknown folder", () => {
+    expect(moveFolderItem(base, "f", 1)).toBe(base);
+    expect(moveFolderItem(base, "nope", 0)).toBe(base);
+  });
+});
+
+describe("removeFolderItem", () => {
+  it("releases children into the folder's slot", () => {
+    const out = removeFolderItem(
+      [conn("a"), folder("f", ["x", "y"]), conn("b")],
+      "f",
+    );
+    expect(out).toEqual([conn("a"), conn("x"), conn("y"), conn("b")]);
+  });
+
+  it("ignores unknown folders", () => {
+    const items = [conn("a")];
+    expect(removeFolderItem(items, "nope")).toBe(items);
+  });
+});
+
+describe("useSidebarLayout store", () => {
+  it("creates, renames, toggles, and removes folders", () => {
+    useSidebarLayout.setState({ items: [conn("a")] });
+    const store = useSidebarLayout.getState();
+
+    const id = store.createFolder("Staging");
+    expect(useSidebarLayout.getState().items[0]).toMatchObject({
+      kind: "folder",
+      id,
+      name: "Staging",
+      collapsed: false,
+      children: [],
+    });
+
+    store.moveToFolder("a", id);
+    expect(useSidebarLayout.getState().items).toEqual([
+      folder(id, ["a"], { name: "Staging" }),
+    ]);
+
+    store.renameFolder(id, "  Prod  ");
+    expect(useSidebarLayout.getState().items[0]).toMatchObject({
+      name: "Prod",
+    });
+    store.renameFolder(id, "   ");
+    expect(useSidebarLayout.getState().items[0]).toMatchObject({
+      name: "Prod",
+    });
+
+    store.toggleFolder(id);
+    expect(useSidebarLayout.getState().items[0]).toMatchObject({
+      collapsed: true,
+    });
+
+    store.removeFolder(id);
+    expect(useSidebarLayout.getState().items).toEqual([conn("a")]);
+  });
+
+  it("moves a connection back to the root end via moveToFolder(null)", () => {
+    useSidebarLayout.setState({
+      items: [folder("f", ["a"]), conn("b")],
+    });
+    useSidebarLayout.getState().moveToFolder("a", null);
+    expect(useSidebarLayout.getState().items).toEqual([
+      folder("f", []),
+      conn("b"),
+      conn("a"),
+    ]);
+  });
+});

--- a/apps/desktop/src/state/sidebarLayout.ts
+++ b/apps/desktop/src/state/sidebarLayout.ts
@@ -1,0 +1,296 @@
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+import { deferredLocalStorage } from "./deferredStorage";
+
+/**
+ * Sidebar presentation order for connections: a flat root sequence of
+ * connections and single-level folders. This is UI preference state only —
+ * connection configs themselves stay in `~/.cellar/connections.json` and the
+ * layout is reconciled against whatever the backend reports.
+ */
+export type SidebarFolderItem = {
+  kind: "folder";
+  id: string;
+  name: string;
+  collapsed: boolean;
+  /** Connection ids in display order. */
+  children: string[];
+};
+
+export type SidebarItem = { kind: "connection"; id: string } | SidebarFolderItem;
+
+/** Folder id, or null for the root list. */
+export type SidebarContainer = string | null;
+
+interface SidebarLayoutStore {
+  items: SidebarItem[];
+
+  /** Sync the layout with the saved connection list: prune ids that no
+   * longer exist (and duplicates), append newcomers at the root. */
+  reconcile: (connectionIds: string[]) => void;
+  createFolder: (name: string) => string;
+  renameFolder: (folderId: string, name: string) => void;
+  /** Remove the folder, releasing its connections to the root at its slot. */
+  removeFolder: (folderId: string) => void;
+  toggleFolder: (folderId: string) => void;
+  moveConnection: (
+    connectionId: string,
+    container: SidebarContainer,
+    index: number,
+  ) => void;
+  moveFolder: (folderId: string, index: number) => void;
+  /** Append a connection to a folder (or back to the root for null). */
+  moveToFolder: (connectionId: string, folderId: SidebarContainer) => void;
+}
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.min(Math.max(n, min), max);
+}
+
+function isFolder(item: SidebarItem): item is SidebarFolderItem {
+  return item.kind === "folder";
+}
+
+function sanitizeItems(raw: unknown): SidebarItem[] {
+  if (!Array.isArray(raw)) return [];
+  const out: SidebarItem[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== "object") continue;
+    const it = item as {
+      kind?: unknown;
+      id?: unknown;
+      name?: unknown;
+      collapsed?: unknown;
+      children?: unknown;
+    };
+    if (typeof it.id !== "string" || it.id.length === 0) continue;
+    if (it.kind === "connection") {
+      out.push({ kind: "connection", id: it.id });
+    } else if (it.kind === "folder") {
+      out.push({
+        kind: "folder",
+        id: it.id,
+        name: typeof it.name === "string" && it.name ? it.name : "Folder",
+        collapsed: Boolean(it.collapsed),
+        children: Array.isArray(it.children)
+          ? it.children.filter((c): c is string => typeof c === "string")
+          : [],
+      });
+    }
+  }
+  return out;
+}
+
+export function reconcileItems(
+  rawItems: SidebarItem[],
+  connectionIds: string[],
+): SidebarItem[] {
+  const items = sanitizeItems(rawItems);
+  const valid = new Set(connectionIds);
+  const seen = new Set<string>();
+  const out: SidebarItem[] = [];
+  let changed = items.length !== rawItems.length;
+
+  for (const item of items) {
+    if (item.kind === "connection") {
+      if (!valid.has(item.id) || seen.has(item.id)) {
+        changed = true;
+        continue;
+      }
+      seen.add(item.id);
+      out.push(item);
+    } else {
+      const children: string[] = [];
+      for (const id of item.children) {
+        if (!valid.has(id) || seen.has(id)) continue;
+        seen.add(id);
+        children.push(id);
+      }
+      if (children.length !== item.children.length) {
+        changed = true;
+        out.push({ ...item, children });
+      } else {
+        out.push(item);
+      }
+    }
+  }
+
+  for (const id of connectionIds) {
+    if (seen.has(id)) continue;
+    out.push({ kind: "connection", id });
+    changed = true;
+  }
+
+  return changed ? out : rawItems;
+}
+
+function locateConnection(
+  items: SidebarItem[],
+  connectionId: string,
+): { container: SidebarContainer; index: number } | null {
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    if (!item) continue;
+    if (item.kind === "connection" && item.id === connectionId) {
+      return { container: null, index: i };
+    }
+    if (item.kind === "folder") {
+      const ci = item.children.indexOf(connectionId);
+      if (ci >= 0) return { container: item.id, index: ci };
+    }
+  }
+  return null;
+}
+
+export function moveConnectionItem(
+  items: SidebarItem[],
+  connectionId: string,
+  container: SidebarContainer,
+  index: number,
+): SidebarItem[] {
+  const from = locateConnection(items, connectionId);
+  if (!from) return items;
+  if (container !== null && !items.some((it) => isFolder(it) && it.id === container)) {
+    return items;
+  }
+
+  // The caller's index refers to the list as currently displayed; removing
+  // the dragged row first shifts later slots in the same container down one.
+  let target = index;
+  if (from.container === container && from.index < index) target -= 1;
+
+  const without = items
+    .filter((it) => !(it.kind === "connection" && it.id === connectionId))
+    .map((it) =>
+      isFolder(it) && it.children.includes(connectionId)
+        ? { ...it, children: it.children.filter((id) => id !== connectionId) }
+        : it,
+    );
+
+  if (container === null) {
+    const at = clamp(target, 0, without.length);
+    return [
+      ...without.slice(0, at),
+      { kind: "connection", id: connectionId },
+      ...without.slice(at),
+    ];
+  }
+  return without.map((it) => {
+    if (!isFolder(it) || it.id !== container) return it;
+    const children = [...it.children];
+    children.splice(clamp(target, 0, children.length), 0, connectionId);
+    return { ...it, children };
+  });
+}
+
+export function moveFolderItem(
+  items: SidebarItem[],
+  folderId: string,
+  index: number,
+): SidebarItem[] {
+  const fromIndex = items.findIndex((it) => isFolder(it) && it.id === folderId);
+  const folder = items[fromIndex];
+  if (fromIndex < 0 || !folder) return items;
+  const target = clamp(index > fromIndex ? index - 1 : index, 0, items.length - 1);
+  if (target === fromIndex) return items;
+  const next = items.filter((_, i) => i !== fromIndex);
+  next.splice(target, 0, folder);
+  return next;
+}
+
+export function removeFolderItem(
+  items: SidebarItem[],
+  folderId: string,
+): SidebarItem[] {
+  const folder = items.find((it) => isFolder(it) && it.id === folderId);
+  if (!folder || !isFolder(folder)) return items;
+  return items.flatMap<SidebarItem>((it) =>
+    it === folder
+      ? folder.children.map((id) => ({ kind: "connection", id }))
+      : [it],
+  );
+}
+
+function newFolderId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return `folder:${crypto.randomUUID()}`;
+  }
+  return `folder:${Math.random().toString(36).slice(2)}${Date.now().toString(36)}`;
+}
+
+export const useSidebarLayout = create<SidebarLayoutStore>()(
+  persist(
+    (set, get) => ({
+      items: [],
+
+      reconcile(connectionIds) {
+        const next = reconcileItems(get().items, connectionIds);
+        if (next !== get().items) set({ items: next });
+      },
+
+      createFolder(name) {
+        const id = newFolderId();
+        set((s) => ({
+          items: [
+            { kind: "folder", id, name, collapsed: false, children: [] },
+            ...s.items,
+          ],
+        }));
+        return id;
+      },
+
+      renameFolder(folderId, name) {
+        const trimmed = name.trim();
+        if (!trimmed) return;
+        set((s) => ({
+          items: s.items.map((it) =>
+            isFolder(it) && it.id === folderId ? { ...it, name: trimmed } : it,
+          ),
+        }));
+      },
+
+      removeFolder(folderId) {
+        set((s) => ({ items: removeFolderItem(s.items, folderId) }));
+      },
+
+      toggleFolder(folderId) {
+        set((s) => ({
+          items: s.items.map((it) =>
+            isFolder(it) && it.id === folderId
+              ? { ...it, collapsed: !it.collapsed }
+              : it,
+          ),
+        }));
+      },
+
+      moveConnection(connectionId, container, index) {
+        set((s) => ({
+          items: moveConnectionItem(s.items, connectionId, container, index),
+        }));
+      },
+
+      moveFolder(folderId, index) {
+        set((s) => ({ items: moveFolderItem(s.items, folderId, index) }));
+      },
+
+      moveToFolder(connectionId, folderId) {
+        set((s) => {
+          const size =
+            folderId === null
+              ? s.items.length
+              : (s.items.find((it) => isFolder(it) && it.id === folderId) as
+                  | SidebarFolderItem
+                  | undefined)?.children.length ?? 0;
+          return {
+            items: moveConnectionItem(s.items, connectionId, folderId, size),
+          };
+        });
+      },
+    }),
+    {
+      name: "cellar.sidebarLayout.v1",
+      storage: createJSONStorage(deferredLocalStorage),
+      partialize: (s) => ({ items: s.items }),
+    },
+  ),
+);

--- a/apps/desktop/src/state/tabResults.ts
+++ b/apps/desktop/src/state/tabResults.ts
@@ -36,6 +36,8 @@ export type TabResult =
       rowCount: number;
       truncated: boolean;
       durationMs: number;
+      /** Affected-row count for DML statements with no result set. */
+      rowsAffected?: number | null;
       /** Callback set by `useQueryRunner` to load the next page of rows. */
       onLoadMore?: (() => void) | null;
     }

--- a/apps/desktop/src/state/tabs.test.ts
+++ b/apps/desktop/src/state/tabs.test.ts
@@ -1,8 +1,10 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
 import type { PendingChanges } from "@cellar/data-grid";
+import { useNotices } from "./notices";
+import { useQueryMessages } from "./queryMessages";
 import { tableResultSource, useTabResults } from "./tabResults";
-import { useTabs } from "./tabs";
+import { useTabs, type QueryTab } from "./tabs";
 
 const source = tableResultSource(
   "conn-1",
@@ -30,6 +32,8 @@ describe("tab workspace state", () => {
     });
     if (typeof localStorage !== "undefined") localStorage.clear();
     useTabResults.setState({ byTabId: {} });
+    useQueryMessages.setState({ messages: [] });
+    useNotices.setState({ byScope: {} });
   });
 
   it("splits the active tab against a neighboring tab", () => {
@@ -179,6 +183,60 @@ describe("tab workspace state", () => {
       "conn-1::app.events.devices",
       "conn-1::app.public.customers",
     ]);
+  });
+
+  it("clears the dirty flag when the buffer reverts to the last-run SQL", () => {
+    const id = useTabs.getState().newQueryTab("conn-1", "app");
+    const queryTab = () => useTabs.getState().tabs[0] as QueryTab;
+
+    // Fresh tab: type a character, then delete it — back to the baseline.
+    useTabs.getState().setQuerySql(id, "x");
+    expect(queryTab().dirty).toBe(true);
+    useTabs.getState().setQuerySql(id, "");
+    expect(queryTab().dirty).toBe(false);
+
+    // After a run, the baseline is the SQL at run time.
+    useTabs.getState().setQuerySql(id, "select 1;");
+    useTabs.getState().markQueryRun(id);
+    expect(queryTab().dirty).toBe(false);
+
+    useTabs.getState().setQuerySql(id, "select 2;");
+    expect(queryTab().dirty).toBe(true);
+    useTabs.getState().setQuerySql(id, "select 1;");
+    expect(queryTab().dirty).toBe(false);
+  });
+
+  it("drops query messages and notices for a tab when it closes", () => {
+    const id = useTabs.getState().newQueryTab("conn-1", "app");
+    const keepId = useTabs.getState().newQueryTab("conn-1", "app");
+    const message = {
+      connectionId: "conn-1",
+      severity: "info" as const,
+      source: "client" as const,
+      text: "ran",
+    };
+    useQueryMessages.getState().addMessage({ ...message, tabId: id });
+    useQueryMessages.getState().addMessage({ ...message, tabId: keepId });
+    useNotices.getState().appendNotice(
+      { tabId: id, connectionId: "conn-1", database: "app" },
+      {
+        severity: "notice",
+        code: "00000",
+        message: "hi",
+        detail: null,
+        hint: null,
+        timestamp: "2026-06-11T00:00:00Z",
+        connection_id: "conn-1",
+        database: "app",
+        query_id: "q1",
+      },
+    );
+
+    useTabs.getState().closeTab(id);
+
+    const tabIds = useQueryMessages.getState().messages.map((m) => m.tabId);
+    expect(tabIds).toEqual([keepId]);
+    expect(useNotices.getState().byScope[`tab:${id}`]).toBeUndefined();
   });
 
   it("keeps table layouts after a table tab is closed", () => {

--- a/apps/desktop/src/state/tabs.ts
+++ b/apps/desktop/src/state/tabs.ts
@@ -1,5 +1,7 @@
 import { create } from "zustand";
 import type { GridColumnLayout, PendingChanges } from "@cellar/data-grid";
+import { useNotices } from "./notices";
+import { useQueryMessages } from "./queryMessages";
 import { useTabResults } from "./tabResults";
 
 const TABLE_LAYOUTS_STORAGE_KEY = "cellar.tableLayouts.v1";
@@ -20,7 +22,9 @@ export interface QueryTab {
   database: string;
   title: string;
   sql: string;
-  /** `true` when the buffer has unsaved edits since the tab was last run. */
+  /** Buffer contents at the last run — the baseline `dirty` compares against. */
+  savedSql: string;
+  /** `true` when the buffer differs from `savedSql`. */
   dirty: boolean;
 }
 
@@ -141,7 +145,12 @@ function dropTabScopedState(
 
 function clearTabResults(ids: string[]) {
   const results = useTabResults.getState();
-  ids.forEach((id) => results.clearTab(id));
+  const messages = useQueryMessages.getState();
+  ids.forEach((id) => {
+    results.clearTab(id);
+    messages.clearForTab(id);
+  });
+  useNotices.getState().dropTabs(ids);
 }
 
 function splitForTabs(
@@ -200,6 +209,7 @@ export const useTabs = create<TabsStore>((set, get) => ({
           database,
           title,
           sql: "",
+          savedSql: "",
           dirty: false,
         },
       ],
@@ -212,7 +222,7 @@ export const useTabs = create<TabsStore>((set, get) => ({
     set((s) => ({
       tabs: s.tabs.map((t) =>
         t.id === id && t.kind === "query"
-          ? { ...t, sql, dirty: sql !== t.sql ? true : t.dirty }
+          ? { ...t, sql, dirty: sql !== t.savedSql }
           : t,
       ),
     }));
@@ -221,7 +231,9 @@ export const useTabs = create<TabsStore>((set, get) => ({
   markQueryRun(id) {
     set((s) => ({
       tabs: s.tabs.map((t) =>
-        t.id === id && t.kind === "query" ? { ...t, dirty: false } : t,
+        t.id === id && t.kind === "query"
+          ? { ...t, savedSql: t.sql, dirty: false }
+          : t,
       ),
     }));
   },

--- a/crates/cellar-core/src/driver.rs
+++ b/crates/cellar-core/src/driver.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use specta::Type;
 
-use crate::error::CellarResult;
+use crate::error::{CellarError, CellarResult};
 use crate::query::{PlanMode, Query, QueryPlan, QueryResult};
 use crate::schema::Database;
 
@@ -138,4 +138,17 @@ pub trait Driver: Send + Sync {
         query: &Query,
         mode: PlanMode,
     ) -> CellarResult<QueryPlan>;
+
+    /// Best-effort cancel of a statement started with [`Query::query_id`]
+    /// set. Returns `Ok(true)` when a running statement was found and a
+    /// cancel signal was delivered, `Ok(false)` when nothing was running
+    /// under that id (it already finished, or was started without an id).
+    /// Engines without a cancellation mechanism keep this default.
+    async fn cancel_query(&self, conn: &dyn Connection, query_id: &str) -> CellarResult<bool> {
+        let _ = (conn, query_id);
+        Err(CellarError::Query(format!(
+            "query cancellation is not supported for the {} driver",
+            self.engine().as_str()
+        )))
+    }
 }

--- a/crates/cellar-core/src/query.rs
+++ b/crates/cellar-core/src/query.rs
@@ -26,6 +26,12 @@ pub struct Query {
     /// database (the sidebar can browse several databases per connection).
     /// `None` means "use the connection's default database".
     pub database: Option<String>,
+    /// Caller-chosen handle for in-flight cancellation. When `Some`, drivers
+    /// that support [`crate::driver::Driver::cancel_query`] register the
+    /// running statement under this id so a concurrent cancel call can find
+    /// it. `None` opts out of cancellation bookkeeping.
+    #[serde(default)]
+    pub query_id: Option<String>,
 }
 
 impl Query {
@@ -35,6 +41,7 @@ impl Query {
             max_rows: None,
             offset: None,
             database: None,
+            query_id: None,
         }
     }
 
@@ -50,6 +57,11 @@ impl Query {
 
     pub fn with_database(mut self, database: impl Into<String>) -> Self {
         self.database = Some(database.into());
+        self
+    }
+
+    pub fn with_query_id(mut self, query_id: impl Into<String>) -> Self {
+        self.query_id = Some(query_id.into());
         self
     }
 }

--- a/crates/cellar-drivers/postgres/src/connect.rs
+++ b/crates/cellar-drivers/postgres/src/connect.rs
@@ -11,6 +11,14 @@ use tokio::sync::Mutex;
 
 const DEFAULT_POOL_SIZE: u32 = 4;
 
+/// Backend process running a registered query, so a concurrent cancel call
+/// can signal it with `pg_cancel_backend`.
+#[derive(Debug, Clone)]
+pub(crate) struct ActiveQuery {
+    pub pid: i32,
+    pub database: String,
+}
+
 pub struct PgConnection {
     info: DriverInfo,
     /// Pool bound to `config.database` — the database named in the connection.
@@ -24,6 +32,10 @@ pub struct PgConnection {
     /// database name. Reused across introspection and queries, closed when the
     /// connection is dropped.
     siblings: Mutex<HashMap<String, PgPool>>,
+    /// In-flight statements keyed by [`Query::query_id`], registered for the
+    /// duration of execution. A std mutex is fine: every critical section is
+    /// a map insert/remove/clone with no await inside.
+    active_queries: std::sync::Mutex<HashMap<String, ActiveQuery>>,
 }
 
 impl PgConnection {
@@ -52,6 +64,24 @@ impl PgConnection {
         let pool = build_pool(&sibling, self.password.as_deref(), DEFAULT_POOL_SIZE).await?;
         guard.insert(database.to_string(), pool.clone());
         Ok(pool)
+    }
+
+    pub(crate) fn register_query(&self, query_id: &str, pid: i32, database: &str) {
+        self.active_queries.lock().unwrap().insert(
+            query_id.to_string(),
+            ActiveQuery {
+                pid,
+                database: database.to_string(),
+            },
+        );
+    }
+
+    pub(crate) fn unregister_query(&self, query_id: &str) {
+        self.active_queries.lock().unwrap().remove(query_id);
+    }
+
+    pub(crate) fn lookup_query(&self, query_id: &str) -> Option<ActiveQuery> {
+        self.active_queries.lock().unwrap().get(query_id).cloned()
     }
 }
 
@@ -110,6 +140,7 @@ pub async fn open_pool(
         config: config.clone(),
         password: password.map(|p| p.to_string()),
         siblings: Mutex::new(HashMap::new()),
+        active_queries: std::sync::Mutex::new(HashMap::new()),
     })
 }
 

--- a/crates/cellar-drivers/postgres/src/lib.rs
+++ b/crates/cellar-drivers/postgres/src/lib.rs
@@ -79,4 +79,9 @@ impl Driver for PostgresDriver {
         let pg = connect::as_pg(conn)?;
         query::explain_query(pg, q, mode).await
     }
+
+    async fn cancel_query(&self, conn: &dyn Connection, query_id: &str) -> CellarResult<bool> {
+        let pg = connect::as_pg(conn)?;
+        query::cancel_query(pg, query_id).await
+    }
 }

--- a/crates/cellar-drivers/postgres/src/query.rs
+++ b/crates/cellar-drivers/postgres/src/query.rs
@@ -15,6 +15,38 @@ use crate::decode::decode_cell;
 
 const DEFAULT_MAX_ROWS: u32 = 500;
 
+/// Drop guard that removes a query from the connection's active-query
+/// registry on every exit path of `execute_query`.
+struct RegisteredQuery<'a> {
+    conn: &'a PgConnection,
+    query_id: &'a str,
+}
+
+impl Drop for RegisteredQuery<'_> {
+    fn drop(&mut self) {
+        self.conn.unregister_query(self.query_id);
+    }
+}
+
+/// Signal the backend running `query_id` with `pg_cancel_backend`. Runs on a
+/// second pool connection — the one executing the statement stays busy until
+/// the server acts on the signal. Returns `false` when nothing is registered
+/// under that id (the statement already finished or never started).
+pub async fn cancel_query(conn: &PgConnection, query_id: &str) -> CellarResult<bool> {
+    let Some(active) = conn.lookup_query(query_id) else {
+        return Ok(false);
+    };
+    let pool = conn.pool_for_database(&active.database).await?;
+    let cancelled: bool = sqlx::query_scalar("SELECT pg_cancel_backend($1)")
+        .bind(active.pid)
+        .fetch_one(&pool)
+        .await
+        .map_err(|e| {
+            crate::connect::map_sqlx_err_for_runtime(e, "query cancellation", CellarError::query)
+        })?;
+    Ok(cancelled)
+}
+
 pub async fn execute_query(conn: &PgConnection, query: &Query) -> CellarResult<QueryResult> {
     // Route to the pool for the query's target database so the sidebar can
     // browse and query several databases through one connection.
@@ -40,13 +72,54 @@ pub async fn execute_query(conn: &PgConnection, query: &Query) -> CellarResult<Q
     // need a parser; we cap while reading the stream instead of materializing
     // the full server result first.
     let started = Instant::now();
-    let mut stream = sqlx::query(&query.sql).fetch(pool);
+
+    // When the caller set a query_id it wants cancellation support: pin the
+    // statement to one pool connection so its backend PID is known up front,
+    // and register it so a concurrent cancel_query can signal that PID with
+    // pg_cancel_backend. The registration drops (and unregisters) on every
+    // exit path, including errors.
+    let mut pinned = None;
+    let _registration = match query.query_id.as_deref() {
+        Some(query_id) => {
+            let mut acquired = pool.acquire().await.map_err(query_sqlx_err)?;
+            let pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+                .fetch_one(&mut *acquired)
+                .await
+                .map_err(query_sqlx_err)?;
+            conn.register_query(query_id, pid, database);
+            pinned = Some(acquired);
+            Some(RegisteredQuery { conn, query_id })
+        }
+        None => None,
+    };
+
+    // fetch_many (vs fetch) also yields the CommandComplete arm, which carries
+    // the affected-row count for DML. Deprecated in sqlx 0.8 over SQLite
+    // multi-statement semantics that don't apply to a single Postgres
+    // statement; the replacement (raw_sql) would switch results to the
+    // text protocol and change every decode path.
+    #[allow(deprecated)]
+    let mut stream = match pinned.as_mut() {
+        Some(acquired) => sqlx::query(&query.sql).fetch_many(&mut **acquired),
+        None => sqlx::query(&query.sql).fetch_many(pool),
+    };
     let mut columns: Option<Vec<ColumnMeta>> = None;
     let mut materialized: Vec<Row> = Vec::with_capacity(capacity);
     let mut truncated = false;
     let mut rows_seen: usize = 0;
+    let mut rows_affected: Option<u64> = None;
 
-    while let Some(r) = stream.try_next().await.map_err(query_sqlx_err)? {
+    while let Some(item) = stream.try_next().await.map_err(query_sqlx_err)? {
+        let r = match item {
+            sqlx::Either::Left(done) => {
+                // Postgres reports the command tag's row count for every
+                // statement, including SELECT; it only means "affected" for
+                // row-returning-free statements, which is gated below.
+                rows_affected = Some(rows_affected.unwrap_or(0) + done.rows_affected());
+                continue;
+            }
+            sqlx::Either::Right(row) => row,
+        };
         if columns.is_none() {
             columns = Some(
                 r.columns()
@@ -79,6 +152,12 @@ pub async fn execute_query(conn: &PgConnection, query: &Query) -> CellarResult<Q
     }
     let duration_ms = started.elapsed().as_millis() as u64;
 
+    // Only surface an affected count for statements without a result set
+    // (INSERT/UPDATE/DELETE/DDL without RETURNING). For row-returning
+    // statements the tag count is just the row count and the UI would
+    // mislabel a SELECT as "N rows affected".
+    let rows_affected = if columns.is_none() { rows_affected } else { None };
+
     Ok(QueryResult {
         columns: columns.unwrap_or_default(),
         rows: materialized,
@@ -91,7 +170,7 @@ pub async fn execute_query(conn: &PgConnection, query: &Query) -> CellarResult<Q
         notice_capture: NoticeCapture::unsupported(
             "Postgres server notices are parsed by sqlx, but the current PgPool query path consumes NoticeResponse frames internally and exposes only log/tracing output without SQLSTATE, detail, hint, or query correlation.",
         ),
-        rows_affected: None,
+        rows_affected,
         duration_ms,
         truncated,
         // Total row count is not available for free-form queries without
@@ -305,6 +384,14 @@ fn normalize_single_statement(sql: &str) -> CellarResult<String> {
 }
 
 fn query_sqlx_err(err: sqlx::Error) -> CellarError {
+    if let sqlx::Error::Database(db) = &err {
+        // SQLSTATE 57014 query_canceled — raised by pg_cancel_backend and by
+        // statement_timeout. The server message ("canceling statement due to
+        // user request") reads better than the generic sqlx wrapper.
+        if db.code().as_deref() == Some("57014") {
+            return CellarError::Query(db.message().to_string());
+        }
+    }
     crate::connect::map_sqlx_err_for_runtime(err, "query execution", CellarError::query)
 }
 

--- a/crates/cellar-drivers/postgres/tests/integration.rs
+++ b/crates/cellar-drivers/postgres/tests/integration.rs
@@ -288,3 +288,106 @@ async fn execute_query_caps_to_default_limit() {
     assert_eq!(small.rows.len(), 10);
     assert!(!small.truncated);
 }
+
+#[tokio::test]
+async fn cancel_query_stops_a_running_statement() {
+    let live = boot().await;
+    let driver = PostgresDriver::new();
+    let conn = driver
+        .connect(&live.config, Some(&live.password))
+        .await
+        .expect("connect");
+
+    // Unknown ids are a no-op, not an error.
+    assert!(!driver
+        .cancel_query(conn.as_ref(), "never-started")
+        .await
+        .expect("cancel unknown id"));
+
+    let conn = std::sync::Arc::new(conn);
+    let runner = {
+        let conn = std::sync::Arc::clone(&conn);
+        tokio::spawn(async move {
+            PostgresDriver::new()
+                .execute_query(
+                    conn.as_ref().as_ref(),
+                    &Query::new("SELECT pg_sleep(30)").with_query_id("cancel-me"),
+                )
+                .await
+        })
+    };
+
+    // Signal repeatedly until the statement dies: the first attempts may land
+    // before the statement registers or while the backend is still idle, and
+    // pg_cancel_backend only interrupts a statement that is already running.
+    for _ in 0..300 {
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        let _ = driver.cancel_query(conn.as_ref().as_ref(), "cancel-me").await;
+        if runner.is_finished() {
+            break;
+        }
+    }
+    assert!(runner.is_finished(), "query was not cancelled within 30s");
+
+    let err = runner
+        .await
+        .expect("join runner task")
+        .expect_err("cancelled query should report an error");
+    let msg = err.to_string().to_lowercase();
+    assert!(msg.contains("cancel"), "unexpected error: {msg}");
+
+    // The registration is cleaned up after the run settles.
+    assert!(!driver
+        .cancel_query(conn.as_ref().as_ref(), "cancel-me")
+        .await
+        .expect("cancel after completion"));
+}
+
+#[tokio::test]
+async fn execute_query_reports_rows_affected_for_dml_only() {
+    let live = boot().await;
+    let driver = PostgresDriver::new();
+    let conn = driver
+        .connect(&live.config, Some(&live.password))
+        .await
+        .expect("connect");
+
+    let insert = driver
+        .execute_query(
+            conn.as_ref(),
+            &Query::new(
+                "INSERT INTO customers (email) VALUES ('a@example.com'), ('b@example.com')",
+            ),
+        )
+        .await
+        .expect("insert");
+    assert_eq!(insert.rows_affected, Some(2));
+    assert!(insert.rows.is_empty());
+
+    let update = driver
+        .execute_query(
+            conn.as_ref(),
+            &Query::new("UPDATE customers SET email = email || '.x' WHERE email LIKE '%@example.com'"),
+        )
+        .await
+        .expect("update");
+    assert_eq!(update.rows_affected, Some(2));
+
+    // Row-returning statements must not surface the command tag's count:
+    // the UI would mislabel a SELECT as "N rows affected".
+    let select = driver
+        .execute_query(conn.as_ref(), &Query::new("SELECT * FROM customers"))
+        .await
+        .expect("select");
+    assert_eq!(select.rows_affected, None);
+
+    let returning = driver
+        .execute_query(
+            conn.as_ref(),
+            &Query::new("DELETE FROM customers WHERE email LIKE '%@example.com.x' RETURNING id"),
+        )
+        .await
+        .expect("delete returning");
+    assert_eq!(returning.rows_affected, None);
+    assert_eq!(returning.rows.len(), 2);
+}

--- a/crates/cellar-drivers/sqlserver/src/query.rs
+++ b/crates/cellar-drivers/sqlserver/src/query.rs
@@ -99,6 +99,9 @@ async fn execute_sql(
         notice_capture: NoticeCapture::unsupported(
             "SQL Server informational messages are not exposed through the current tiberius query path.",
         ),
+        // tiberius's simple_query stream only yields Metadata/Row items; the
+        // DONE token's affected-row count never surfaces through QueryItem,
+        // so DML row counts are unavailable on this path.
         rows_affected: None,
         duration_ms: started.elapsed().as_millis() as u64,
         truncated,

--- a/packages/data-grid/src/DataGrid.tsx
+++ b/packages/data-grid/src/DataGrid.tsx
@@ -6,6 +6,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type MouseEvent as ReactMouseEvent,
   type PointerEvent as ReactPointerEvent,
   type UIEvent,
 } from "react";
@@ -134,6 +135,17 @@ export type DataGridProps = {
 
   /** Stripe alternating data rows. Defaults to false. */
   stripeRows?: boolean;
+
+  /**
+   * Right-click on a data cell. The host receives the row object and column so
+   * it can render its own context menu (e.g. copy-as) without depending on the
+   * grid's internal filter/sort order.
+   */
+  onCellContextMenu?: (
+    event: ReactMouseEvent<HTMLDivElement>,
+    row: GridRow,
+    column: GridColumn,
+  ) => void;
 };
 
 /**
@@ -166,6 +178,7 @@ export function DataGrid({
   readOnly = false,
   nullDisplay = "NULL",
   stripeRows = false,
+  onCellContextMenu,
 }: DataGridProps) {
   const [internalSort, setInternalSort] = useState<SortState>(null);
   const [internalColumnLayout, setInternalColumnLayout] =
@@ -686,6 +699,7 @@ export function DataGrid({
                   onSelect={onSelect}
                   onEdit={onEdit}
                   onCellEdit={handleCellEdit}
+                  onCellContextMenu={onCellContextMenu}
                 />
               );
             })}
@@ -735,6 +749,7 @@ type GridRowViewProps = {
     prev: CellChange["from"],
     next: CellChange["to"],
   ) => void;
+  onCellContextMenu: DataGridProps["onCellContextMenu"];
 };
 
 const GridRowView = memo(function GridRowView({
@@ -753,6 +768,7 @@ const GridRowView = memo(function GridRowView({
   onSelect,
   onEdit,
   onCellEdit,
+  onCellContextMenu,
 }: GridRowViewProps) {
   const kind = change?.kind;
   const rowSelected = selected !== null;
@@ -818,6 +834,13 @@ const GridRowView = memo(function GridRowView({
             onDoubleClick={() => {
               if (!readOnly) onEdit({ row: rowIndex, col: ci });
             }}
+            onContextMenu={
+              onCellContextMenu &&
+              ((event) => {
+                onSelect({ row: rowIndex, col: ci });
+                onCellContextMenu(event, row, c);
+              })
+            }
           >
             {isEdit ? (
               <CellEditor

--- a/packages/ipc/src/generated.ts
+++ b/packages/ipc/src/generated.ts
@@ -69,9 +69,22 @@ async introspect(connectionId: string, refresh: boolean | null) : Promise<Result
     else return { status: "error", error: e  as any };
 }
 },
-async runQuery(connectionId: string, sql: string, maxRows: number | null, offset: number | null, database: string | null, tabId: string | null) : Promise<Result<QueryResult, CellarError>> {
+async runQuery(connectionId: string, sql: string, maxRows: number | null, offset: number | null, database: string | null, tabId: string | null, queryId: string | null) : Promise<Result<QueryResult, CellarError>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("run_query", { connectionId, sql, maxRows, offset, database, tabId }) };
+    return { status: "ok", data: await TAURI_INVOKE("run_query", { connectionId, sql, maxRows, offset, database, tabId, queryId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Cancel a running query previously started through [`run_query`] with a
+ * `query_id`. Returns `true` when a running statement was found and
+ * signalled, `false` when it had already finished.
+ */
+async cancelQuery(connectionId: string, queryId: string) : Promise<Result<boolean, CellarError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("cancel_query", { connectionId, queryId }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };


### PR DESCRIPTION
Implements all four Phase 2 ("feels finished") items from [docs/improvement-plan-INDEX.md](docs/improvement-plan-INDEX.md).

## Query cancellation (Top 5 #2)
- `Query` gains an optional caller-chosen `query_id`; the frontend generates a UUID per run.
- The Postgres driver pins one pool connection when a `query_id` is present, reads its `pg_backend_pid()`, and registers `query_id → {pid, database}` in a registry on the connection. An RAII drop guard unregisters on success, error, and early-return paths.
- `Driver::cancel_query` (new trait method, default = clear "not supported" error per engine) looks up the PID and signals it with `SELECT pg_cancel_backend($1)` from a second connection. Returns `true` when signalled, `false` when the statement had already finished.
- SQLSTATE 57014 maps to the server's own message ("canceling statement due to user request") instead of a generic driver error, and the cancel path bypasses the connection-health handler so cancelling never marks a connection broken.
- UI: Cancel button + `⌘.` in the SQL editor while a run is in flight; outcome reported in the Messages panel.

## Result export + copy-as (Top 5 #4)
- Export button on the results panel: CSV / TSV / JSON / SQL INSERT, exporting the **visible** view (client-side filters and sort applied) via a view callback the grid registers with the panel.
- Right-click copy menu on grid cells: copy cell, copy row as CSV/TSV/SQL INSERT, copy all visible rows as CSV/JSON/SQL INSERT.
- CSV/TSV follow RFC 4180 (CRLF, NULL = unquoted empty, empty string = `""`); SQL INSERT escapes identifiers and literals.

## rows_affected surfacing (Tier 0 #3)
- DML command-tag counts flow from the Postgres driver through `QueryResult.rows_affected` to the Messages panel, status bar, and query history. Row-returning statements are excluded so a SELECT is never labeled "N rows affected". SQL Server documented as unable to supply this through tiberius `simple_query`.

## Store/effect cleanup (B6/B7/B8)
- Sidebar layout state extracted into its own store; stale-closure and effect-dependency fixes across tabs/notices stores.

## Verification
- `cargo test --workspace` clean; clippy shows only pre-existing warnings.
- Postgres integration suite (testcontainers, real Postgres 15): 8/8, including a new `cancel_query_stops_a_running_statement` test that kills a `pg_sleep(30)` in ~3s and verifies registry cleanup, plus `execute_query_reports_rows_affected_for_dml_only`.
- Desktop typecheck clean; vitest: desktop 102, data-grid 34, ai 21, ipc 11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)