### PR TITLE
feat: polish grid editing flow

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -15,6 +15,7 @@
         "title": "Cellar",
         "width": 1440,
         "height": 900,
+        "dragDropEnabled": false,
         "minWidth": 960,
         "minHeight": 600,
         "decorations": true,

--- a/apps/desktop/src/components/SidebarConnectionList.tsx
+++ b/apps/desktop/src/components/SidebarConnectionList.tsx
@@ -199,6 +199,13 @@ export function SidebarConnectionList({
     }
   };
 
+  // WebKit only allows a drop when dragenter is cancelled too, not just
+  // dragover; one bubbling-phase handler here covers every row.
+  const onListDragEnter = (e: React.DragEvent) => {
+    if (!drag || !canDrag) return;
+    e.preventDefault();
+  };
+
   const onListDragOver = (e: React.DragEvent) => {
     if (!drag || !canDrag) return;
     e.preventDefault();
@@ -325,6 +332,7 @@ export function SidebarConnectionList({
     <div
       ref={rootRef}
       className="flex-1"
+      onDragEnter={onListDragEnter}
       onDragOver={onListDragOver}
       onDragLeave={onListDragLeave}
       onDrop={commitDrop}

--- a/apps/desktop/src/styles/grid.css
+++ b/apps/desktop/src/styles/grid.css
@@ -460,6 +460,10 @@
   color: var(--fg-0);
   font-size: 11.5px;
 }
+.cell-edit-input[aria-invalid="true"] {
+  background: color-mix(in oklab, var(--delete-bg) 82%, var(--bg-2));
+  box-shadow: inset 0 0 0 1px var(--delete);
+}
 .cell-edit-enum {
   display: flex;
   align-items: center;

--- a/crates/cellar-drivers/postgres/src/query.rs
+++ b/crates/cellar-drivers/postgres/src/query.rs
@@ -156,7 +156,11 @@ pub async fn execute_query(conn: &PgConnection, query: &Query) -> CellarResult<Q
     // (INSERT/UPDATE/DELETE/DDL without RETURNING). For row-returning
     // statements the tag count is just the row count and the UI would
     // mislabel a SELECT as "N rows affected".
-    let rows_affected = if columns.is_none() { rows_affected } else { None };
+    let rows_affected = if columns.is_none() {
+        rows_affected
+    } else {
+        None
+    };
 
     Ok(QueryResult {
         columns: columns.unwrap_or_default(),

--- a/crates/cellar-drivers/postgres/tests/integration.rs
+++ b/crates/cellar-drivers/postgres/tests/integration.rs
@@ -322,7 +322,9 @@ async fn cancel_query_stops_a_running_statement() {
     // pg_cancel_backend only interrupts a statement that is already running.
     for _ in 0..300 {
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        let _ = driver.cancel_query(conn.as_ref().as_ref(), "cancel-me").await;
+        let _ = driver
+            .cancel_query(conn.as_ref().as_ref(), "cancel-me")
+            .await;
         if runner.is_finished() {
             break;
         }
@@ -367,7 +369,9 @@ async fn execute_query_reports_rows_affected_for_dml_only() {
     let update = driver
         .execute_query(
             conn.as_ref(),
-            &Query::new("UPDATE customers SET email = email || '.x' WHERE email LIKE '%@example.com'"),
+            &Query::new(
+                "UPDATE customers SET email = email || '.x' WHERE email LIKE '%@example.com'",
+            ),
         )
         .await
         .expect("update");

--- a/packages/data-grid/src/Cell.test.ts
+++ b/packages/data-grid/src/Cell.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { resolveBlurAction, resolveEnterAction } from "./Cell";
+import { parseCellInput, resolveBlurAction, resolveEnterAction } from "./Cell";
 
 // ---------------------------------------------------------------------------
 // resolveEnterAction — used by the Enter key handler (text editor)
@@ -135,3 +135,134 @@ describe("CellEditor state machine — text editor", () => {
     expect(resolveBlurAction(settled, dirty)).toBe("commit");
   });
 });
+
+describe("parseCellInput", () => {
+  it("coerces boolean values", () => {
+    expect(parseCellInput(column("active", "bool"), "true")).toEqual({
+      ok: true,
+      value: true,
+    });
+    expect(parseCellInput(column("active", "bool"), "0")).toEqual({
+      ok: true,
+      value: false,
+    });
+  });
+
+  it("rejects non-boolean values for boolean columns", () => {
+    expect(parseCellInput(column("active", "bool"), "sometimes")).toEqual({
+      ok: false,
+      message: "Enter TRUE or FALSE",
+    });
+  });
+
+  it("coerces integer values and rejects fractional input", () => {
+    expect(parseCellInput(column("count", "int4"), "42")).toEqual({
+      ok: true,
+      value: 42,
+    });
+    expect(parseCellInput(column("count", "int4"), "4.2")).toEqual({
+      ok: false,
+      message: "Enter a whole number",
+    });
+  });
+
+  it("keeps large integer values as strings to avoid precision loss", () => {
+    expect(parseCellInput(column("id", "int8"), "9007199254740993")).toEqual({
+      ok: true,
+      value: "9007199254740993",
+    });
+  });
+
+  it("keeps numeric decimals as strings to avoid precision loss", () => {
+    expect(parseCellInput(column("amount", "numeric"), "123.45")).toEqual({
+      ok: true,
+      value: "123.45",
+    });
+  });
+
+  it("validates JSON and GUID fields", () => {
+    expect(parseCellInput(column("payload", "jsonb"), '{"ok":true}')).toEqual({
+      ok: true,
+      value: '{"ok":true}',
+    });
+    expect(parseCellInput(column("payload", "jsonb"), "{oops")).toEqual({
+      ok: false,
+      message: "Enter valid JSON",
+    });
+    expect(
+      parseCellInput(
+        column("id", "uuid"),
+        "018f61b3-4f51-7f5a-9db8-0c7b1b7b3930",
+      ),
+    ).toEqual({
+      ok: true,
+      value: "018f61b3-4f51-7f5a-9db8-0c7b1b7b3930",
+    });
+    expect(
+      parseCellInput(
+        column("id", "uuid"),
+        "018f61b3-4f51-7f5a-9db8",
+      ),
+    ).toEqual({
+      ok: false,
+      message: "Enter a valid GUID",
+    });
+    expect(parseCellInput(column("Id", "guid"), "aaa")).toEqual({
+      ok: false,
+      message: "Enter a valid GUID",
+    });
+    expect(parseCellInput(column("Id", "uniqueidentifier"), "aaa")).toEqual({
+      ok: false,
+      message: "Enter a valid GUID",
+    });
+  });
+
+  it("maps blank nullable non-text values to NULL", () => {
+    expect(parseCellInput(column("due_at", "timestamptz", true), "")).toEqual({
+      ok: true,
+      value: null,
+    });
+  });
+
+  it("rejects blank non-null non-text values", () => {
+    expect(parseCellInput(column("due_at", "timestamptz", false), "")).toEqual({
+      ok: false,
+      message: "due_at cannot be NULL",
+    });
+  });
+
+  it("allows empty strings for text columns", () => {
+    expect(parseCellInput(column("name", "text", false), "")).toEqual({
+      ok: true,
+      value: "",
+    });
+  });
+
+  it("requires enum values to match the column options", () => {
+    expect(
+      parseCellInput(
+        { ...column("status", "text"), enum: ["new", "done"] },
+        "done",
+      ),
+    ).toEqual({ ok: true, value: "done" });
+    expect(
+      parseCellInput(
+        { ...column("status", "text"), enum: ["new", "done"] },
+        "stuck",
+      ),
+    ).toEqual({
+      ok: false,
+      message: "Choose one of: new, done",
+    });
+  });
+});
+
+function column(name: string, type: string, nullable = true) {
+  return {
+    key: name,
+    name,
+    type,
+    width: 120,
+    nullable,
+  };
+}

--- a/packages/data-grid/src/Cell.tsx
+++ b/packages/data-grid/src/Cell.tsx
@@ -32,6 +32,160 @@ export function resolveBlurAction(
   return dirty ? "commit" : "cancel";
 }
 
+export type ParsedCellValue =
+  | { ok: true; value: GridValue }
+  | { ok: false; message: string };
+
+export function parseCellInput(col: GridColumn, raw: string): ParsedCellValue {
+  if (col.enum) {
+    return col.enum.includes(raw)
+      ? { ok: true, value: raw }
+      : { ok: false, message: `Choose one of: ${col.enum.join(", ")}` };
+  }
+
+  const type = normalizeType(col.type);
+  const trimmed = raw.trim();
+
+  if (trimmed === "" && type !== "text") {
+    if (col.nullable) return { ok: true, value: null };
+    return { ok: false, message: `${col.name} cannot be NULL` };
+  }
+
+  if (type === "bool") {
+    const lower = trimmed.toLowerCase();
+    if (["true", "t", "1", "yes", "y"].includes(lower)) {
+      return { ok: true, value: true };
+    }
+    if (["false", "f", "0", "no", "n"].includes(lower)) {
+      return { ok: true, value: false };
+    }
+    return { ok: false, message: "Enter TRUE or FALSE" };
+  }
+
+  if (type === "integer") {
+    if (!/^[+-]?\d+$/.test(trimmed)) {
+      return { ok: false, message: "Enter a whole number" };
+    }
+    const value = Number(trimmed);
+    return { ok: true, value: Number.isSafeInteger(value) ? value : trimmed };
+  }
+
+  if (type === "float") {
+    const value = Number(trimmed);
+    if (!Number.isFinite(value)) {
+      return { ok: false, message: "Enter a valid number" };
+    }
+    return { ok: true, value };
+  }
+
+  if (type === "numeric") {
+    if (!/^[+-]?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?$/i.test(trimmed)) {
+      return { ok: false, message: "Enter a valid numeric value" };
+    }
+    return { ok: true, value: trimmed };
+  }
+
+  if (type === "guid") {
+    if (
+      !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+        trimmed,
+      )
+    ) {
+      return { ok: false, message: "Enter a valid GUID" };
+    }
+    return { ok: true, value: trimmed };
+  }
+
+  if (type === "json") {
+    try {
+      JSON.parse(trimmed);
+      return { ok: true, value: trimmed };
+    } catch {
+      return { ok: false, message: "Enter valid JSON" };
+    }
+  }
+
+  if (type === "date") {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(trimmed) || Number.isNaN(Date.parse(trimmed))) {
+      return { ok: false, message: "Use YYYY-MM-DD" };
+    }
+    return { ok: true, value: trimmed };
+  }
+
+  if (type === "time") {
+    if (!/^\d{2}:\d{2}(?::\d{2}(?:\.\d{1,6})?)?(?:[+-]\d{2}(?::?\d{2})?)?$/.test(trimmed)) {
+      return { ok: false, message: "Use HH:MM[:SS]" };
+    }
+    return { ok: true, value: trimmed };
+  }
+
+  if (type === "timestamp") {
+    if (Number.isNaN(Date.parse(trimmed))) {
+      return { ok: false, message: "Enter a valid timestamp" };
+    }
+    return { ok: true, value: trimmed };
+  }
+
+  if (type === "bytea") {
+    if (!/^\\x(?:[0-9a-f]{2})*$/i.test(trimmed)) {
+      return { ok: false, message: "Use hex bytea format, e.g. \\x0a2b" };
+    }
+    return { ok: true, value: trimmed };
+  }
+
+  return { ok: true, value: raw };
+}
+
+function normalizeType(type: string):
+  | "bool"
+  | "bytea"
+  | "date"
+  | "float"
+  | "integer"
+  | "json"
+  | "numeric"
+  | "text"
+  | "time"
+  | "timestamp"
+  | "guid"
+  | "unknown" {
+  const t = type.toLowerCase().replace(/\(.+\)$/, "").trim();
+  if (["bool", "boolean"].includes(t)) return "bool";
+  if (["bytea", "binary", "varbinary", "blob"].includes(t)) return "bytea";
+  if (t === "date") return "date";
+  if (["float4", "float8", "real", "double precision"].includes(t)) {
+    return "float";
+  }
+  if (
+    ["int2", "int4", "int8", "smallint", "integer", "bigint", "serial", "bigserial", "oid"].includes(
+      t,
+    )
+  ) {
+    return "integer";
+  }
+  if (["json", "jsonb"].includes(t)) return "json";
+  if (["numeric", "decimal", "money"].includes(t)) return "numeric";
+  if (
+    ["text", "varchar", "char", "bpchar", "citext", "name", "character varying", "character"].includes(
+      t,
+    )
+  ) {
+    return "text";
+  }
+  if (["time", "timetz", "time without time zone", "time with time zone"].includes(t)) {
+    return "time";
+  }
+  if (
+    ["timestamp", "timestamptz", "timestamp without time zone", "timestamp with time zone"].includes(
+      t,
+    )
+  ) {
+    return "timestamp";
+  }
+  if (["uuid", "guid", "uniqueidentifier"].includes(t)) return "guid";
+  return "unknown";
+}
+
 export function CellValue({
   col,
   value,
@@ -83,6 +237,7 @@ export type CellEditorProps = {
 export function CellEditor({ col, value, onCommit, onCancel }: CellEditorProps) {
   const initialValue = value == null ? "" : String(value);
   const [v, setV] = useState<string>(initialValue);
+  const [error, setError] = useState<string | null>(null);
   const ref = useRef<HTMLInputElement | null>(null);
   // Tracks whether Enter or Escape has already been handled so that the
   // subsequent blur event does not fire a second commit or override a cancel.
@@ -97,6 +252,20 @@ export function CellEditor({ col, value, onCommit, onCancel }: CellEditorProps) 
     ref.current?.focus();
     ref.current?.select();
   }, []);
+
+  const commitRawValue = () => {
+    const parsed = parseCellInput(col, v);
+    if (!parsed.ok) {
+      settledRef.current = false;
+      setError(parsed.message);
+      window.setTimeout(() => {
+        ref.current?.focus();
+        ref.current?.select();
+      }, 0);
+      return;
+    }
+    onCommit(parsed.value);
+  };
 
   if (col.enum) {
     return (
@@ -151,6 +320,7 @@ export function CellEditor({ col, value, onCommit, onCancel }: CellEditorProps) 
       value={v}
       onChange={(e) => {
         dirtyRef.current = true;
+        setError(null);
         setV(e.target.value);
       }}
       onKeyDown={(e) => {
@@ -158,7 +328,7 @@ export function CellEditor({ col, value, onCommit, onCancel }: CellEditorProps) 
           settledRef.current = true;
           const decision = resolveEnterAction(dirtyRef.current);
           if (decision === "commit") {
-            onCommit(v);
+            commitRawValue();
           } else {
             onCancel();
           }
@@ -173,11 +343,13 @@ export function CellEditor({ col, value, onCommit, onCancel }: CellEditorProps) 
         if (decision === "noop") return;
         settledRef.current = true;
         if (decision === "commit") {
-          onCommit(v);
+          commitRawValue();
         } else {
           onCancel();
         }
       }}
+      aria-invalid={error ? true : undefined}
+      title={error ?? undefined}
     />
   );
 }

--- a/packages/data-grid/src/DataGrid.tsx
+++ b/packages/data-grid/src/DataGrid.tsx
@@ -192,6 +192,7 @@ export function DataGrid({
   const resizingRef = useRef<ColumnResizeState | null>(null);
   const suppressNextSortRef = useRef(false);
   const measureCanvasRef = useRef<HTMLCanvasElement | null>(null);
+  const insertCounterRef = useRef(0);
 
   const renderedColumns = useMemo(
     () => layoutForColumns(columns, activeColumnLayout),
@@ -204,10 +205,27 @@ export function DataGrid({
     return filterRows(rows, renderedColumns, filters, changes);
   }, [rows, renderedColumns, filters, changes]);
 
-  const visibleRows = useMemo(
-    () => sortGridRows(filteredRows, renderedColumns, activeSort, changes),
-    [filteredRows, renderedColumns, activeSort, changes],
-  );
+  const insertedRows = useMemo(() => {
+    const existingIds = new Set(rows.map((row) => row.id));
+    return Object.entries(changes)
+      .filter(
+        ([rowId, change]) => change.kind === "insert" && !existingIds.has(rowId),
+      )
+      .map(([rowId, change]) => {
+        const row: GridRow = { id: rowId };
+        for (const column of renderedColumns) {
+          row[column.key] = change.edits[column.key]?.to ?? null;
+        }
+        return row;
+      });
+  }, [changes, renderedColumns, rows]);
+
+  const visibleRows = useMemo(() => {
+    return [
+      ...sortGridRows(filteredRows, renderedColumns, activeSort, changes),
+      ...insertedRows,
+    ];
+  }, [activeSort, changes, filteredRows, insertedRows, renderedColumns]);
 
   const minTableWidth = useMemo(
     () => renderedColumns.reduce((acc, c) => acc + c.width, ROWNO_WIDTH + 8),
@@ -381,7 +399,7 @@ export function DataGrid({
     ): CellAddress | null => {
       if (!address) return null;
       const row = before[address.row];
-      if (!row) return null;
+      if (!row) return after[address.row] ? address : null;
       const nextRow = after.findIndex((candidate) => candidate.id === row.id);
       if (nextRow === -1) return null;
       return { row: nextRow, col: address.col };
@@ -530,6 +548,33 @@ export function DataGrid({
     },
     [changes, onChange],
   );
+
+  const handleInsertRow = useCallback(() => {
+    if (readOnly || renderedColumns.length === 0) return;
+    insertCounterRef.current += 1;
+    const rowId = `insert:${Date.now()}:${insertCounterRef.current}`;
+    onChange({
+      ...changes,
+      [rowId]: { kind: "insert", edits: {} },
+    });
+    const nextRowIndex = visibleRows.length;
+    onSelect({ row: nextRowIndex, col: 0 });
+    onEdit({ row: nextRowIndex, col: 0 });
+    window.requestAnimationFrame(() => {
+      scrollRef.current?.scrollTo({
+        top: scrollRef.current.scrollHeight,
+        behavior: "smooth",
+      });
+    });
+  }, [
+    changes,
+    onChange,
+    onEdit,
+    onSelect,
+    readOnly,
+    renderedColumns.length,
+    visibleRows.length,
+  ]);
 
   return (
     <div
@@ -705,7 +750,19 @@ export function DataGrid({
             })}
           </div>
           {!readOnly && (
-            <div className="grid-row grid-row-add">
+            <div
+              className="grid-row grid-row-add"
+              role="button"
+              tabIndex={0}
+              onClick={handleInsertRow}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  handleInsertRow();
+                }
+              }}
+              title="Insert new row"
+            >
               <div className="grid-cell grid-cell-rowno">
                 <GridIcon.plus size={9} stroke="var(--fg-3)" />
               </div>

--- a/packages/ipc/src/index.test.ts
+++ b/packages/ipc/src/index.test.ts
@@ -68,6 +68,7 @@ describe("@cellar/ipc", () => {
       null,
       null,
       null,
+      null,
     );
     expect(result.status).toBe("ok");
     if (result.status === "ok") {

--- a/packages/ipc/src/mock.ts
+++ b/packages/ipc/src/mock.ts
@@ -61,6 +61,7 @@ export const mockCommands = {
     _offset: number | null,
     _database: string | null,
     _tabId: string | null,
+    _queryId: string | null,
   ): Promise<Result<QueryResult, CellarError>> =>
     ok({
       columns: [],


### PR DESCRIPTION
## Summary
- add type-aware parsing and validation for grid cell edits
- make inserted grid rows appear in the editable flow
- tighten sidebar/Tauri drag handling and sync IPC mock/test signatures
- apply Rust formatting cleanup required by lint

## User impact
- grid edits now preserve typed values for booleans, numbers, JSON, GUIDs, dates, timestamps, bytea, enums, and nullability
- editable grids expose a keyboard/click path for adding a row
- sidebar connection drag/drop behaves more consistently in WebKit/Tauri

## Validation
- pnpm lint
- pnpm test
- pnpm build
- cargo check --workspace

## Known warnings
- Vite still reports the existing desktop JS chunk-size warning during `pnpm build`.
