### PR TITLE
chore: config

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "desktop-web",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--dir", "apps/desktop", "dev:web"],
+      "port": 1430
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Developer-only config file with no runtime, security, or production impact.
> 
> **Overview**
> Adds **`.claude/launch.json`** so Claude Code (or compatible tooling) can start the desktop app’s **web-only dev server** via `pnpm --dir apps/desktop dev:web` on **port 1430**, aligned with the existing Tauri `devUrl`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 057086a9af3bf794d17d34234ca5ef08cb45d1f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->