### PR TITLE
feat: in-app auto-updater + 0.2.0 version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,8 @@ jobs:
           APPLE_API_KEY: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
           APPLE_API_KEY_PATH: ${{ runner.temp }}/AuthKey_${{ secrets.APP_STORE_CONNECT_KEY_ID }}.p8
           APPLE_SIGNING_IDENTITY: ${{ secrets.DEVELOPER_ID_APPLICATION_IDENTITY }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           projectPath: apps/desktop
           tagName: ${{ steps.release.outputs.tag }}
@@ -146,6 +148,7 @@ jobs:
           releaseBody: See the assets below to download Cellar for your platform.
           releaseDraft: true
           prerelease: ${{ steps.release.outputs.prerelease }}
+          updaterJsonPreferNsis: false
           args: ${{ matrix.args }}
 
       - name: Upload stable direct-download asset

--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,9 @@ apps/desktop/src-tauri/gen/
 # env
 .env
 .env.local
+.opencode/plugins/emdash-notifications.js
 
+# updater signing keys (never commit)
+*.updater.key
+*.updater.key.pub
+tauri-signing-key*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,6 +431,8 @@ dependencies = [
  "sqlx",
  "tauri",
  "tauri-build",
+ "tauri-plugin-process",
+ "tauri-plugin-updater",
  "tauri-specta",
  "tempfile",
  "thiserror 1.0.69",
@@ -825,6 +836,17 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2105,6 +2127,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2374,6 +2426,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -2654,6 +2712,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2667,6 +2726,18 @@ dependencies = [
  "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2749,6 +2820,20 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "pango"
@@ -3399,15 +3484,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3558,6 +3648,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls 0.23.40",
+ "rustls-native-certs 0.8.3",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.13",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -3965,6 +4082,22 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple_asn1"
@@ -4484,7 +4617,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -4518,6 +4651,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4540,7 +4684,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -4638,6 +4782,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74be5dd4bed9afbd145e5716b5fa2ec28cbc29c34ffa61c258c9273d896c8020"
+dependencies = [
+ "anyhow",
+ "glob",
+ "plist",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs 6.0.0",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest 0.13.4",
+ "rustls 0.23.40",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4647,7 +4850,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -4670,7 +4873,7 @@ checksum = "b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -4718,9 +4921,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.9.2"
+version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092379df9a707631978e6c56b1bc2401d387f01e2d4a3c123360d167bbb9aa95"
+checksum = "3e176a18e67764923c4f1ce66f25ae4abe5f688384d5eb1a0fa6c77f3d90f887"
 dependencies = [
  "anyhow",
  "brotli",
@@ -5677,6 +5880,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6392,7 +6604,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",
@@ -6564,6 +6776,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "cellar-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -414,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "cellar-desktop"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "cellar-core",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "cellar-diff"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "specta",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "cellar-driver-firestore"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "cellar-core",
@@ -463,7 +463,7 @@ dependencies = [
 
 [[package]]
 name = "cellar-driver-postgres"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "cellar-core",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "cellar-driver-sqlserver"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "cellar-core",
@@ -495,15 +495,15 @@ dependencies = [
 
 [[package]]
 name = "cellar-drivers"
-version = "0.1.0"
+version = "0.2.0"
 
 [[package]]
 name = "cellar-plugin-host"
-version = "0.1.0"
+version = "0.2.0"
 
 [[package]]
 name = "cellar-secrets"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cellar-core",
  "keyring",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "cellar-sql"
-version = "0.1.0"
+version = "0.2.0"
 
 [[package]]
 name = "cesu8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/nzmrl/cellar"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cellar/desktop",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -19,6 +19,8 @@
     "@cellar/ipc": "workspace:*",
     "@cellar/sql-editor": "workspace:*",
     "@tauri-apps/api": "^2.0.0",
+    "@tauri-apps/plugin-process": "^2.0.0",
+    "@tauri-apps/plugin-updater": "^2.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "zustand": "^4.5.0"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -36,6 +36,8 @@ sqlx = { version = "0.8", default-features = false, features = [
 specta = { version = "=2.0.0-rc.22", features = ["derive", "chrono", "uuid", "serde_json"] }
 specta-typescript = "=0.0.9"
 tauri-specta = { version = "=2.0.0-rc.21", features = ["derive", "typescript"] }
+tauri-plugin-updater = "2"
+tauri-plugin-process = "2"
 cellar-core = { path = "../../../crates/cellar-core" }
 cellar-driver-firestore = { path = "../../../crates/cellar-drivers/firestore" }
 cellar-driver-postgres = { path = "../../../crates/cellar-drivers/postgres" }

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -8,6 +8,8 @@
     "core:event:allow-listen",
     "core:event:allow-unlisten",
     "core:window:allow-start-dragging",
-    "core:window:allow-toggle-maximize"
+    "core:window:allow-toggle-maximize",
+    "updater:default",
+    "process:default"
   ]
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -17,6 +17,8 @@ pub fn run() {
     tauri::Builder::default()
         .manage(registry)
         .manage(history)
+        .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_process::init())
         .invoke_handler(invoke_handler)
         .setup(move |app| {
             builder.mount_events(app);

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Cellar",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "identifier": "com.cellar.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev:web",

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -33,6 +33,14 @@
       "csp": null
     }
   },
+  "plugins": {
+    "updater": {
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEU1QjRGMjE3RTI1ODYwOEQKUldTTllGamlGL0swNWRCNnE5enNpTUZycE5wZU9CWDlpbm9EcEFxQzFYN3BBZ3pCQ0hvMWV5SHQK",
+      "endpoints": [
+        "https://github.com/MRL-00/cellar/releases/latest/download/latest.json"
+      ]
+    }
+  },
   "bundle": {
     "active": true,
     "targets": "all",

--- a/apps/desktop/src/components/modals/settingsSystemPanels.tsx
+++ b/apps/desktop/src/components/modals/settingsSystemPanels.tsx
@@ -1,6 +1,7 @@
 import { Icon } from "../icons";
 import { Row, Section, StaticSegment, Toggle } from "./settingsPrimitives";
 import { useConnections } from "../../state/connections";
+import { useUpdater } from "../../lib/updater";
 
 export function SettingsPrivacy() {
   const connectionCount = useConnections((s) => s.connections.length);
@@ -59,29 +60,80 @@ export function SettingsPrivacy() {
 }
 
 export function SettingsUpdates() {
+  const { appVersion, status, lastChecked, checkForUpdate, downloadAndInstall } = useUpdater();
+
+  const versionLabel = appVersion ? `v${appVersion}` : "v0.0.0";
+  const lastCheckedLabel = lastChecked
+    ? `last checked ${new Date(lastChecked).toLocaleString()}`
+    : "last checked never";
+
+  const statusText = (() => {
+    switch (status.kind) {
+      case "idle":
+        return "Ready";
+      case "checking":
+        return "Checking…";
+      case "available":
+        return `Update available: v${status.version}`;
+      case "up-to-date":
+        return "Up to date";
+      case "downloading":
+        return `Downloading… ${Math.round(status.fraction * 100)}%`;
+      case "installing":
+        return "Installing…";
+      case "error":
+        return `Error: ${status.message}`;
+    }
+  })();
+
+  const isBusy =
+    status.kind === "checking" ||
+    status.kind === "downloading" ||
+    status.kind === "installing";
+  const canCheck = !isBusy && status.kind !== "available";
+  const canInstall = status.kind === "available";
+
   return (
     <div className="flex-1 overflow-y-auto pb-6 pt-1">
       <Section title="Updates">
         <div className="mb-2 flex items-center justify-between rounded-[5px] border border-border-default bg-bg-inset px-3 py-2.5">
           <div className="flex items-center gap-2.5">
             <span className="font-mono text-[13px] font-semibold text-fg-0">
-              v0.1.0-alpha
+              {versionLabel}
             </span>
             <span className="inline-flex items-center gap-1 text-[11px]">
               <Icon.info size={11} stroke="var(--fg-2)" />
-              <span className="text-fg-2">Updater not configured</span>
+              <span className="text-fg-2">{statusText}</span>
             </span>
-            <span className="text-[11px] text-fg-3">last checked never</span>
+            <span className="text-[11px] text-fg-3">{lastCheckedLabel}</span>
           </div>
-          <button
-            type="button"
-            disabled
-            title="Updater checks are not wired yet"
-            className="inline-flex h-[26px] cursor-not-allowed items-center gap-1 rounded-[4px] border border-border-default bg-bg-2 px-2 text-[11px] text-fg-2 opacity-70"
-          >
-            <Icon.power size={11} />
-            <span>Check now</span>
-          </button>
+          <div className="flex items-center gap-1.5">
+            {canInstall && (
+              <button
+                type="button"
+                onClick={downloadAndInstall}
+                disabled={isBusy}
+                className="inline-flex h-[26px] items-center gap-1 rounded-[4px] border border-accent-line bg-accent-soft px-2 text-[11px] font-medium text-accent hover:bg-accent/20"
+              >
+                <Icon.download size={11} />
+                <span>Download &amp; install</span>
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={checkForUpdate}
+              disabled={!canCheck}
+              title={canCheck ? "Check for updates" : "Update check in progress"}
+              className={
+                canCheck
+                  ? "inline-flex h-[26px] items-center gap-1 rounded-[4px] border border-border-default bg-bg-2 px-2 text-[11px] text-fg-1 hover:bg-bg-3"
+                  : "inline-flex h-[26px] cursor-not-allowed items-center gap-1 rounded-[4px] border border-border-default bg-bg-2 px-2 text-[11px] text-fg-2 opacity-70"
+              }
+            >
+              <Icon.power size={11} />
+              <span>Check now</span>
+            </button>
+          </div>
         </div>
         <Row label="Channel">
           <StaticSegment values={["stable", "beta", "nightly"]} activeIdx={0} />

--- a/apps/desktop/src/lib/updater.ts
+++ b/apps/desktop/src/lib/updater.ts
@@ -1,0 +1,103 @@
+import { useCallback, useEffect, useState } from "react";
+import { check, type Update } from "@tauri-apps/plugin-updater";
+import { relaunch } from "@tauri-apps/plugin-process";
+import { getVersion } from "@tauri-apps/api/app";
+
+export type UpdaterStatus =
+  | { kind: "idle" }
+  | { kind: "checking" }
+  | { kind: "available"; version: string; update: Update }
+  | { kind: "up-to-date" }
+  | { kind: "downloading"; fraction: number }
+  | { kind: "installing" }
+  | { kind: "error"; message: string };
+
+const LAST_CHECKED_KEY = "cellar.updater.lastChecked";
+
+function readLastChecked(): string | null {
+  try {
+    return localStorage.getItem(LAST_CHECKED_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function writeLastChecked(value: string) {
+  try {
+    localStorage.setItem(LAST_CHECKED_KEY, value);
+  } catch {
+    /* ignore quota / private mode */
+  }
+}
+
+export function useUpdater() {
+  const [appVersion, setAppVersion] = useState<string>("");
+  const [status, setStatus] = useState<UpdaterStatus>({ kind: "idle" });
+  const [lastChecked, setLastChecked] = useState<string | null>(() => readLastChecked());
+
+  useEffect(() => {
+    getVersion()
+      .then(setAppVersion)
+      .catch(() => setAppVersion(""));
+  }, []);
+
+  const checkForUpdate = useCallback(async () => {
+    setStatus({ kind: "checking" });
+    try {
+      const update = await check();
+      const now = new Date().toISOString();
+      writeLastChecked(now);
+      setLastChecked(now);
+      if (update?.available) {
+        setStatus({ kind: "available", version: update.version, update });
+      } else {
+        setStatus({ kind: "up-to-date" });
+      }
+    } catch (err) {
+      setStatus({
+        kind: "error",
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }, []);
+
+  const downloadAndInstall = useCallback(async () => {
+    if (status.kind !== "available") return;
+    const { update } = status;
+    try {
+      setStatus({ kind: "downloading", fraction: 0 });
+      let total = 0;
+      let downloaded = 0;
+      await update.downloadAndInstall((event) => {
+        switch (event.event) {
+          case "Started":
+            total = event.data.contentLength ?? 0;
+            break;
+          case "Progress":
+            downloaded += event.data.chunkLength;
+            if (total > 0) {
+              setStatus({ kind: "downloading", fraction: downloaded / total });
+            }
+            break;
+          case "Finished":
+            setStatus({ kind: "installing" });
+            break;
+        }
+      });
+      await relaunch();
+    } catch (err) {
+      setStatus({
+        kind: "error",
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }, [status]);
+
+  return {
+    appVersion,
+    status,
+    lastChecked,
+    checkForUpdate,
+    downloadAndInstall,
+  };
+}

--- a/docs/release.md
+++ b/docs/release.md
@@ -46,6 +46,17 @@ To publish an already-created draft manually:
 gh release edit 0.1.0 --draft=false
 ```
 
+## In-app auto-updates
+
+Cellar ships with the Tauri updater plugin enabled. Each release build signs
+its update bundle with an Ed25519 private key; the matching public key is
+embedded in `tauri.conf.json` so the app can verify updates before installing.
+
+The frontend "Check now" button in Settings → Updates calls the updater, and
+"Download & install" applies the signed bundle and relaunches the app.
+
+### Required GitHub Actions secrets
+
 Release signing and notarization require these GitHub Actions secrets:
 
 - `DEVELOPER_ID_CERTIFICATE_BASE64` - base64-encoded `.p12` export of the
@@ -57,6 +68,27 @@ Release signing and notarization require these GitHub Actions secrets:
   key `.p8` file.
 - `APP_STORE_CONNECT_KEY_ID` - App Store Connect API key ID.
 - `APP_STORE_CONNECT_ISSUER_ID` - App Store Connect issuer ID.
+- `TAURI_SIGNING_PRIVATE_KEY` - the contents of the Tauri updater private key
+  (generated with `tauri signer generate`). Keep a backup off-repo.
+- `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` - the password for the private key, or
+  empty if the key was generated without one.
+
+### How the manifest is published
+
+`tauri-action` generates and uploads a `latest.json` manifest to each GitHub
+Release. The app fetches it from
+`https://github.com/MRL-00/cellar/releases/latest/download/latest.json`.
+Prereleases are excluded from the `/releases/latest` redirect, so only stable
+releases are served to the updater. The manifest maps each platform target
+(`aarch64-apple-darwin`, `x86_64-apple-darwin`) to its signed bundle URL.
+
+### Rotating or losing the signing key
+
+The public key is baked into every shipped build. If the private key is lost,
+already-installed builds cannot verify updates from a new keypair. Keep the
+private key backed up in a secure location (for example, a password manager
+or secrets vault). A new keypair only takes effect for builds shipped after
+the public key is swapped in `tauri.conf.json`.
 
 ## Website downloads
 
@@ -84,4 +116,5 @@ Only macOS builds are published today; Windows and Linux should be added after t
 - Windows: code-signing certificate.
 - Linux: package metadata review for AppImage/deb/rpm outputs.
 
-Do not enable Tauri auto-update until release signing keys and updater metadata are deliberately configured.
+Do not enable Tauri auto-update on Windows/Linux until those platforms have
+tested signed bundles and matching manifest entries in `latest.json`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cellar",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "Cellar — open-source desktop database client",
   "license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,12 @@ importers:
       '@tauri-apps/api':
         specifier: ^2.0.0
         version: 2.11.0
+      '@tauri-apps/plugin-process':
+        specifier: ^2.0.0
+        version: 2.3.1
+      '@tauri-apps/plugin-updater':
+        specifier: ^2.0.0
+        version: 2.10.1
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -703,6 +709,12 @@ packages:
     resolution: {integrity: sha512-bk3HemqvGRoy+5D/dVMUQHKMYLglD0jVnMm/0iGMH6ufZ+p8r14m6BpIixwij3PBvZdvORUp1YifTD8QxVZ1Nw==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-process@2.3.1':
+    resolution: {integrity: sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==}
+
+  '@tauri-apps/plugin-updater@2.10.1':
+    resolution: {integrity: sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==}
 
   '@turbo/darwin-64@2.9.14':
     resolution: {integrity: sha512-t7QiPflaEyBE4oayeZtSmu4mEfjgIrcNlNNl1z1dmIVPqEdtA7+CfTf8d7KXsOGPh6aNgWjKxyvQg9uGfDQF+A==}
@@ -1649,6 +1661,14 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.11.2
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.2
       '@tauri-apps/cli-win32-x64-msvc': 2.11.2
+
+  '@tauri-apps/plugin-process@2.3.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
+
+  '@tauri-apps/plugin-updater@2.10.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
 
   '@turbo/darwin-64@2.9.14':
     optional: true


### PR DESCRIPTION
## Summary

Wires up the Tauri updater plugin so users can check for updates and auto-install signed releases from inside the app.

### Changes
- **Rust**: adds `tauri-plugin-updater` + `tauri-plugin-process`, registers plugins, adds `updater:default` and `process:default` capabilities
- **Tauri config**: configures updater with Ed25519 public key + GitHub Releases endpoint (`/releases/latest/download/latest.json`)
- **Frontend**: new `useUpdater()` hook (`lib/updater.ts`) with check / download-and-install / relaunch / progress / last-checked persistence
- **Settings → Updates**: live app version, real status text, working Check now button, Download & install button when update available
- **CI**: release workflow passes `TAURI_SIGNING_PRIVATE_KEY` + `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` to tauri-action so update bundles are signed and `latest.json` is uploaded
- **Docs**: `docs/release.md` documents updater config, required secrets, and key rotation
- **Version**: bumps all version files to `0.2.0` (`package.json`, `apps/desktop/package.json`, `tauri.conf.json`, `Cargo.toml`, `Cargo.lock`)

### Required GitHub Actions secrets (before tagging)
- `TAURI_SIGNING_PRIVATE_KEY` — contents of the updater private key
- `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` — empty (key generated without password)

### Validation
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm test` ✅ (123 TS tests)
- `cargo check --workspace` ✅
- `cargo test --workspace` ✅ (35 Rust tests)
- `pnpm build` ✅

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds update download/install and relaunch paths that depend on CI signing secrets and manifest correctness; misconfiguration could break updates or ship unsigned bundles, but verification uses embedded pubkey and existing macOS release signing.
> 
> **Overview**
> Enables **signed in-app updates** for the desktop Tauri shell and bumps the monorepo to **0.2.0**.
> 
> The Rust shell registers `tauri-plugin-updater` and `tauri-plugin-process`, grants updater/process capabilities, and configures an Ed25519 public key plus a GitHub `latest.json` endpoint in `tauri.conf.json`. A new `useUpdater()` hook drives check, download progress, install, and relaunch; **Settings → Updates** replaces the placeholder UI with live version, status, **Check now**, and **Download & install**.
> 
> Release CI passes `TAURI_SIGNING_*` secrets into `tauri-action` (with `updaterJsonPreferNsis: false`) so signed bundles and the updater manifest ship with releases. `.gitignore` blocks updater key material; `docs/release.md` documents secrets, manifest publishing, and key rotation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcc88564ff5db79415aed2542cf61a0c99da45ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->