### PR TITLE
fix: stabilize SQL editor layout

### DIFF
--- a/apps/desktop/src/components/Workspace.tsx
+++ b/apps/desktop/src/components/Workspace.tsx
@@ -62,7 +62,11 @@ export function Workspace({ onCommit }: { onCommit?: () => void } = {}) {
     }
   }
 
-  return renderTab(active, onCommit);
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      {renderTab(active, onCommit)}
+    </div>
+  );
 }
 
 function SplitPane({

--- a/apps/desktop/src/styles/editor.css
+++ b/apps/desktop/src/styles/editor.css
@@ -9,6 +9,7 @@
 .ed-root {
   display: flex;
   flex-direction: column;
+  width: 100%;
   height: 100%;
   background: var(--bg-inset);
   font-size: var(--fs-md);
@@ -150,6 +151,7 @@
   line-height: 1.55;
 }
 .cellar-cm .cm-content {
+  min-width: 100%;
   min-height: 100%;
   padding: 6px 0 60px;
   caret-color: var(--fg-0);


### PR DESCRIPTION
## Summary

Stabilizes the SQL editor workspace layout so the bottom results panel remains resizable and the editor fills the available width.

## What changed

- Wraps the single-tab workspace render path in a flex column container with `min-h-0` and `overflow-hidden`.
- Makes the SQL editor root fill the available width.
- Ensures CodeMirror content spans at least the scroller width.

## User impact

- Bottom results/messages panel no longer shifts while typing in the SQL editor.
- Bottom panel resize handle remains usable in query tabs.
- Removes the empty right-side gap next to the SQL editor content.

## Validation

- `pnpm typecheck`

## Known warnings or follow-ups

- SQL Server query drafts still need dialect-aware starter SQL; the reported `LIMIT 100` syntax error is separate from this editor layout fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS and layout-wrapper changes only; no query execution, data, or auth logic touched.
> 
> **Overview**
> Fixes **SQL editor layout instability** in single-tab query views by wrapping the active tab in the same **flex column** container (`min-h-0`, `overflow-hidden`) already used in split mode, so nested resizable panels (e.g. bottom results) keep a stable height budget while typing.
> 
> **Editor sizing:** `.ed-root` now uses **`width: 100%`**, and CodeMirror **`.cm-content`** gets **`min-width: 100%`** so the editor fills the pane and avoids empty space beside the text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38cf6a0a30c266bdd38f69917ebb6ea9d675dfd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->