### PR TITLE
feat: harden query cancellation controls

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,8 @@
+#:schema https://conductor.build/schemas/settings.repo.schema.json
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+setup = "pnpm install --frozen-lockfile"
+run = "CELLAR_DEV_PORT=$CONDUCTOR_PORT pnpm dev"
+archive = "true"
+run_mode = "concurrent"

--- a/apps/desktop/src/components/SqlEditor.tsx
+++ b/apps/desktop/src/components/SqlEditor.tsx
@@ -48,7 +48,14 @@ export function SqlEditor({ tab }: { tab: QueryTab }) {
   const requestExplain = useBottomPanel((s) => s.requestExplain);
   const { settings } = useSettings();
 
-  const { running, errorLine, run, cancel, clearError } = useQueryRunner(tab);
+  const {
+    running,
+    cancelRequested,
+    errorLine,
+    run,
+    cancel,
+    clearError,
+  } = useQueryRunner(tab);
 
   const [caret, setCaret] = useState(0);
   // Per-editor wrap toggle overrides the global default.
@@ -151,10 +158,15 @@ export function SqlEditor({ tab }: { tab: QueryTab }) {
             <button
               className="ed-run subtle"
               onClick={cancel}
-              title="Ask the server to stop the running statement"
+              disabled={cancelRequested}
+              title={
+                cancelRequested
+                  ? "Waiting for the running statement to settle"
+                  : "Ask the server to stop the running statement"
+              }
             >
               <Icon.stop size={11} />
-              <span>Cancel</span>
+              <span>{cancelRequested ? "Cancelling…" : "Cancel"}</span>
               <span className="kbd">⌘.</span>
             </button>
           )}

--- a/apps/desktop/src/hooks/useQueryRunner.ts
+++ b/apps/desktop/src/hooks/useQueryRunner.ts
@@ -4,6 +4,9 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { queryResultToGrid } from "../lib/gridMapping";
 import {
+  buildRunCancelErrorMessage,
+  buildRunCancelRequestedMessage,
+  buildRunCancelResultMessage,
   buildRunErrorMessage,
   buildRunResultMessages,
   buildRunStartedMessage,
@@ -29,6 +32,8 @@ export interface RunOptions {
 
 export interface QueryRunner {
   running: boolean;
+  /** `true` after a cancel request is sent and before the run settles. */
+  cancelRequested: boolean;
   /** 1-based editor line to squiggle, or null when the last run was clean. */
   errorLine: number | null;
   /** Whether more rows can be fetched (driver truncated the last result). */
@@ -53,6 +58,7 @@ export interface QueryRunner {
  */
 export function useQueryRunner(tab: QueryTab): QueryRunner {
   const [running, setRunning] = useState(false);
+  const [cancelRequested, setCancelRequested] = useState(false);
   const [errorLine, setErrorLine] = useState<number | null>(null);
   const [canLoadMore, setCanLoadMore] = useState(false);
   const runToken = useRef(0);
@@ -61,7 +67,11 @@ export function useQueryRunner(tab: QueryTab): QueryRunner {
   const loadMoreRef = useRef<{ sql: string; offset: number } | null>(null);
   // Cancellation handle for the in-flight run, passed to the backend so a
   // cancel call can find the statement's connection.
-  const activeQueryId = useRef<string | null>(null);
+  const activeRun = useRef<{
+    queryId: string;
+    context: QueryRunContext;
+    cancelRequested: boolean;
+  } | null>(null);
 
   useEffect(() => {
     mounted.current = true;
@@ -102,6 +112,7 @@ export function useQueryRunner(tab: QueryTab): QueryRunner {
       };
 
       setRunning(true);
+      setCancelRequested(false);
       setErrorLine(null);
       if (!append) {
         useTabResults.getState().setLoading(tab.id, source);
@@ -111,7 +122,7 @@ export function useQueryRunner(tab: QueryTab): QueryRunner {
       }
 
       const queryId = crypto.randomUUID();
-      activeQueryId.current = queryId;
+      activeRun.current = { queryId, context, cancelRequested: false };
 
       void (async () => {
         try {
@@ -216,6 +227,8 @@ export function useQueryRunner(tab: QueryTab): QueryRunner {
           if (!mounted.current || token !== runToken.current) return;
           noteConnectionIssue(tab.connectionId, err);
           const message = err instanceof Error ? err.message : String(err);
+          loadMoreRef.current = null;
+          setCanLoadMore(false);
           if (!append) {
             useTabResults.getState().setError(tab.id, source, message);
           }
@@ -224,11 +237,12 @@ export function useQueryRunner(tab: QueryTab): QueryRunner {
             .addMessage(buildRunErrorMessage(context, err));
           setErrorLine(opts.errorLine ?? null);
         } finally {
-          if (activeQueryId.current === queryId) {
-            activeQueryId.current = null;
+          if (activeRun.current?.queryId === queryId) {
+            activeRun.current = null;
           }
           if (mounted.current && token === runToken.current) {
             setRunning(false);
+            setCancelRequested(false);
           }
         }
       })();
@@ -253,33 +267,33 @@ export function useQueryRunner(tab: QueryTab): QueryRunner {
   }, [running, executeQuery]);
 
   const cancel = useCallback(() => {
-    const queryId = activeQueryId.current;
-    if (!queryId) return;
-    const note = (severity: "info" | "warning", text: string) => {
-      useQueryMessages.getState().addMessage({
-        tabId: tab.id,
-        connectionId: tab.connectionId,
-        database: tab.database || undefined,
-        severity,
-        source: "client",
-        text,
-      });
-    };
-    void unwrap(commands.cancelQuery(tab.connectionId, queryId))
+    const run = activeRun.current;
+    if (!run || run.cancelRequested) return;
+    run.cancelRequested = true;
+    setCancelRequested(true);
+    useQueryMessages
+      .getState()
+      .addMessage(buildRunCancelRequestedMessage(run.context));
+    void unwrap(commands.cancelQuery(tab.connectionId, run.queryId))
       .then((cancelled) => {
-        if (cancelled) {
-          note("warning", "Cancel requested — the server was asked to stop the running statement.");
-        } else {
-          note("info", "Nothing to cancel — the statement had already finished.");
+        useQueryMessages
+          .getState()
+          .addMessage(buildRunCancelResultMessage(run.context, cancelled));
+        if (!cancelled && activeRun.current?.queryId === run.queryId) {
+          activeRun.current.cancelRequested = false;
+          setCancelRequested(false);
         }
       })
       .catch((err) => {
-        note(
-          "warning",
-          `Could not cancel the running statement: ${err instanceof Error ? err.message : String(err)}`,
-        );
+        useQueryMessages
+          .getState()
+          .addMessage(buildRunCancelErrorMessage(run.context, err));
+        if (activeRun.current?.queryId === run.queryId) {
+          activeRun.current.cancelRequested = false;
+          setCancelRequested(false);
+        }
       });
-  }, [tab.connectionId, tab.database, tab.id]);
+  }, [tab.connectionId]);
 
   // Keep the tabResults store in sync with the load-more callback so the
   // bottom panel's result grid can surface the "Load more" button without
@@ -291,7 +305,16 @@ export function useQueryRunner(tab: QueryTab): QueryRunner {
     );
   }, [tab.id, canLoadMore, loadMore]);
 
-  return { running, errorLine, canLoadMore, run, loadMore, cancel, clearError };
+  return {
+    running,
+    cancelRequested,
+    errorLine,
+    canLoadMore,
+    run,
+    loadMore,
+    cancel,
+    clearError,
+  };
 }
 
 // Re-export for callers that only need the type.

--- a/apps/desktop/src/lib/queryMessages.test.ts
+++ b/apps/desktop/src/lib/queryMessages.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from "vitest";
 import type { QueryResult } from "@cellar/ipc";
 import {
+  buildRunCancelErrorMessage,
+  buildRunCancelRequestedMessage,
+  buildRunCancelResultMessage,
   buildQueryErrorMessage,
   buildQueryResultMessages,
   buildTableLoadStartedMessage,
   formatDuration,
   severityCounts,
+  type QueryRunContext,
   type QueryMessage,
   type TableQueryContext,
 } from "./queryMessages";
@@ -29,6 +33,15 @@ const result: QueryResult = {
   duration_ms: 12,
   truncated: false,
   total_rows: null,
+};
+
+const runContext: QueryRunContext = {
+  tabId: "query-tab-1",
+  connectionId: "conn-1",
+  database: "app",
+  label: "statement",
+  sql: "SELECT pg_sleep(30)",
+  maxRows: 1000,
 };
 
 describe("query message builders", () => {
@@ -72,6 +85,20 @@ describe("query message builders", () => {
     expect(message.severity).toBe("error");
     expect(message.source).toBe("driver");
     expect(message.text).toContain("permission denied");
+  });
+
+  it("builds cancellation status messages for running statements", () => {
+    const requested = buildRunCancelRequestedMessage(runContext);
+    const accepted = buildRunCancelResultMessage(runContext, true);
+    const missed = buildRunCancelResultMessage(runContext, false);
+    const failed = buildRunCancelErrorMessage(runContext, new Error("not connected"));
+
+    expect(requested.text).toContain("Cancel requested");
+    expect(accepted.severity).toBe("warning");
+    expect(accepted.text).toContain("accepted");
+    expect(missed.severity).toBe("info");
+    expect(missed.text).toContain("already finished");
+    expect(failed.text).toContain("not connected");
   });
 
   it("counts severities for rendering filters", () => {

--- a/apps/desktop/src/lib/queryMessages.ts
+++ b/apps/desktop/src/lib/queryMessages.ts
@@ -196,6 +196,52 @@ export function buildRunErrorMessage(
   };
 }
 
+export function buildRunCancelRequestedMessage(
+  context: QueryRunContext,
+): PendingQueryMessage {
+  return {
+    tabId: context.tabId,
+    connectionId: context.connectionId,
+    database: context.database,
+    severity: "warning",
+    source: "client",
+    text: `Cancel requested for ${context.label}; waiting for the server to stop the statement.`,
+    sql: context.sql,
+  };
+}
+
+export function buildRunCancelResultMessage(
+  context: QueryRunContext,
+  cancelled: boolean,
+): PendingQueryMessage {
+  return {
+    tabId: context.tabId,
+    connectionId: context.connectionId,
+    database: context.database,
+    severity: cancelled ? "warning" : "info",
+    source: "client",
+    text: cancelled
+      ? "The server accepted the cancel request; the running statement will settle shortly."
+      : "Nothing to cancel; the statement had already finished.",
+    sql: context.sql,
+  };
+}
+
+export function buildRunCancelErrorMessage(
+  context: QueryRunContext,
+  error: unknown,
+): PendingQueryMessage {
+  return {
+    tabId: context.tabId,
+    connectionId: context.connectionId,
+    database: context.database,
+    severity: "warning",
+    source: "client",
+    text: `Could not cancel ${context.label}: ${errorMessage(error)}`,
+    sql: context.sql,
+  };
+}
+
 export function formatDuration(ms: number): string {
   if (ms < 1000) return `${ms} ms`;
   return `${(ms / 1000).toFixed(ms < 10_000 ? 2 : 1)} s`;

--- a/packages/ipc/src/index.test.ts
+++ b/packages/ipc/src/index.test.ts
@@ -20,6 +20,7 @@ describe("@cellar/ipc", () => {
         "aiLoadKey",
         "aiStoreKey",
         "browseTable",
+        "cancelQuery",
         "commitTableChanges",
         "connect",
         "deleteConnection",
@@ -83,6 +84,11 @@ describe("@cellar/ipc", () => {
         truncated: false,
       });
     }
+  });
+
+  it("cancelQuery is available in mock mode", async () => {
+    const result = await commands.cancelQuery("any", "query-1");
+    expect(result).toEqual({ status: "ok", data: false });
   });
 
   it("returns empty query history in mock mode", async () => {

--- a/packages/ipc/src/mock.ts
+++ b/packages/ipc/src/mock.ts
@@ -77,6 +77,11 @@ export const mockCommands = {
       total_rows: null,
     }),
 
+  cancelQuery: async (
+    _connectionId: string,
+    _queryId: string,
+  ): Promise<Result<boolean, CellarError>> => ok(false),
+
   explainQuery: async (
     _connectionId: string,
     sql: string,


### PR DESCRIPTION
## Summary

Harden the SQL editor cancellation flow and add shared Conductor workspace settings for the repo.

## What changed

- Add `.conductor/settings.toml` with shared setup, run, archive, and concurrent run-mode scripts.
- Track active query run context in the desktop query runner so cancel requests are tied to the current query ID.
- Add a disabled `Cancelling...` state to prevent duplicate cancel requests while the server settles the running statement.
- Add cancellation-specific query messages for requested, accepted, missed, and failed cancel attempts.
- Keep the IPC mock command surface aligned with generated IPC by adding `cancelQuery`.

## User impact

Users get clearer feedback when cancelling a long-running statement and cannot accidentally spam duplicate cancel requests. Conductor workspaces can also run the desktop app on their allocated port with the shared repo config.

## Validation

- `pnpm --filter @cellar/desktop test`
- `pnpm --filter @cellar/ipc test`
- `pnpm typecheck`
- `git diff --check origin/main...HEAD`
- Fast-forwarded local `main` to `origin/main` and checked this branch merges cleanly against latest `main`.

## Known warnings or follow-ups

- Free-form query results are still materialized/page-loaded through IPC; the next milestone is streamed/page-style Tauri events keyed by query ID.
