### PR TITLE
Add full-row selection to the data grid

### DIFF
--- a/apps/desktop/src/components/BottomPanel.tsx
+++ b/apps/desktop/src/components/BottomPanel.tsx
@@ -18,6 +18,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type KeyboardEvent as ReactKeyboardEvent,
   type MutableRefObject,
   type ReactNode,
 } from "react";
@@ -455,39 +456,53 @@ function ReadOnlyResultGrid({
     };
   }, [exportViewRef, result.columns, visibleRows]);
 
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
   const copy = (text: string) => {
     if (!navigator.clipboard) return;
     void navigator.clipboard.writeText(text);
   };
 
   // ⌘/Ctrl+C copies the selected row as TSV (pastes cleanly into spreadsheets),
-  // or the selected single cell's value. Native text selections are left alone.
-  useEffect(() => {
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (!(event.metaKey || event.ctrlKey) || event.key.toLowerCase() !== "c") {
-        return;
-      }
-      if (!window.getSelection()?.isCollapsed) return;
-      if (grid.selectedRow !== null) {
-        const row = visibleRows[grid.selectedRow];
-        if (!row) return;
-        event.preventDefault();
-        copy(toTsv(result.columns, [row], { header: false }).trimEnd());
-      } else if (grid.selection) {
-        const column = result.columns[grid.selection.col];
-        const row = visibleRows[grid.selection.row];
-        if (!column || !row) return;
-        const cell = row[column.key];
-        event.preventDefault();
-        copy(cell == null ? "" : String(cell));
-      }
-    };
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [grid.selectedRow, grid.selection, result.columns, visibleRows]);
+  // or the selected single cell's value. Scoped to the grid container's focus so
+  // it never hijacks copy from the SQL editor or another pane, and leaves native
+  // text selections (and copies from inline editors) alone.
+  const handleCopyKey = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (!(event.metaKey || event.ctrlKey) || event.key.toLowerCase() !== "c") {
+      return;
+    }
+    const active = document.activeElement;
+    if (
+      active instanceof HTMLElement &&
+      (active.tagName === "INPUT" ||
+        active.tagName === "TEXTAREA" ||
+        active.isContentEditable)
+    ) {
+      return;
+    }
+    if (!window.getSelection()?.isCollapsed) return;
+    if (grid.selectedRow !== null) {
+      const row = visibleRows[grid.selectedRow];
+      if (!row) return;
+      event.preventDefault();
+      copy(toTsv(result.columns, [row], { header: false }).trimEnd());
+    } else if (grid.selection) {
+      const column = result.columns[grid.selection.col];
+      const row = visibleRows[grid.selection.row];
+      if (!column || !row) return;
+      const cell = row[column.key];
+      event.preventDefault();
+      copy(cell == null ? "" : String(cell));
+    }
+  };
 
   return (
-    <div className="flex h-full min-h-0 flex-col overflow-hidden">
+    <div
+      ref={containerRef}
+      tabIndex={-1}
+      onKeyDown={handleCopyKey}
+      className="flex h-full min-h-0 flex-col overflow-hidden outline-none"
+    >
       <div className="min-h-0 flex-1 overflow-hidden">
         <DataGrid
           columns={result.columns}
@@ -496,7 +511,11 @@ function ReadOnlyResultGrid({
           changes={grid.changes}
           onChange={grid.setChanges}
           selection={grid.selection}
-          onSelect={grid.setSelection}
+          onSelect={(next) => {
+            grid.setSelection(next);
+            // Pull keyboard focus into the grid so ⌘C targets this pane.
+            if (next) containerRef.current?.focus({ preventScroll: true });
+          }}
           editing={grid.editing}
           onEdit={grid.setEditing}
           filters={grid.filters}
@@ -507,7 +526,12 @@ function ReadOnlyResultGrid({
           nullDisplay={settings.grid.nullDisplay}
           stripeRows={settings.grid.stripeRows}
           selectedRow={grid.selectedRow}
-          onRowSelect={(rowIndex) => grid.setSelectedRow(rowIndex)}
+          onRowSelect={(rowIndex) => {
+            grid.setSelectedRow(rowIndex);
+            if (rowIndex !== null) {
+              containerRef.current?.focus({ preventScroll: true });
+            }
+          }}
           onRowContextMenu={(event, row) => {
             event.preventDefault();
             setCopyMenu({
@@ -527,6 +551,10 @@ function ReadOnlyResultGrid({
                     copy(
                       toTsv(result.columns, [row], { header: false }).trimEnd(),
                     ),
+                },
+                {
+                  label: "Copy row as JSON",
+                  onClick: () => copy(toJson(result.columns, [row]).trimEnd()),
                 },
                 {
                   label: "Copy row as SQL INSERT",
@@ -574,6 +602,10 @@ function ReadOnlyResultGrid({
                     copy(
                       toTsv(result.columns, [row], { header: false }).trimEnd(),
                     ),
+                },
+                {
+                  label: "Copy row as JSON",
+                  onClick: () => copy(toJson(result.columns, [row]).trimEnd()),
                 },
                 {
                   label: "Copy row as SQL INSERT",

--- a/apps/desktop/src/components/BottomPanel.tsx
+++ b/apps/desktop/src/components/BottomPanel.tsx
@@ -432,33 +432,59 @@ function ReadOnlyResultGrid({
   const onLoadMore = result.onLoadMore ?? null;
   const [copyMenu, setCopyMenu] = useState<ContextMenuState | null>(null);
 
-  const visibleRows = () =>
-    sortGridRows(
-      filterRows(result.rows, result.columns, grid.filters, grid.changes),
-      result.columns,
-      grid.sort,
-      grid.changes,
-    );
-
-  useEffect(() => {
-    exportViewRef.current = () => ({
-      columns: result.columns,
-      rows: sortGridRows(
+  // The rows in the exact order the grid shows them (local filter + sort). Row
+  // selection indexes into this list, so it must match the grid's own order.
+  const visibleRows = useMemo(
+    () =>
+      sortGridRows(
         filterRows(result.rows, result.columns, grid.filters, grid.changes),
         result.columns,
         grid.sort,
         grid.changes,
       ),
+    [result.rows, result.columns, grid.filters, grid.sort, grid.changes],
+  );
+
+  useEffect(() => {
+    exportViewRef.current = () => ({
+      columns: result.columns,
+      rows: visibleRows,
     });
     return () => {
       exportViewRef.current = null;
     };
-  });
+  }, [exportViewRef, result.columns, visibleRows]);
 
   const copy = (text: string) => {
     if (!navigator.clipboard) return;
     void navigator.clipboard.writeText(text);
   };
+
+  // ⌘/Ctrl+C copies the selected row as TSV (pastes cleanly into spreadsheets),
+  // or the selected single cell's value. Native text selections are left alone.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!(event.metaKey || event.ctrlKey) || event.key.toLowerCase() !== "c") {
+        return;
+      }
+      if (!window.getSelection()?.isCollapsed) return;
+      if (grid.selectedRow !== null) {
+        const row = visibleRows[grid.selectedRow];
+        if (!row) return;
+        event.preventDefault();
+        copy(toTsv(result.columns, [row], { header: false }).trimEnd());
+      } else if (grid.selection) {
+        const column = result.columns[grid.selection.col];
+        const row = visibleRows[grid.selection.row];
+        if (!column || !row) return;
+        const cell = row[column.key];
+        event.preventDefault();
+        copy(cell == null ? "" : String(cell));
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [grid.selectedRow, grid.selection, result.columns, visibleRows]);
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden">
@@ -480,6 +506,50 @@ function ReadOnlyResultGrid({
           readOnly
           nullDisplay={settings.grid.nullDisplay}
           stripeRows={settings.grid.stripeRows}
+          selectedRow={grid.selectedRow}
+          onRowSelect={(rowIndex) => grid.setSelectedRow(rowIndex)}
+          onRowContextMenu={(event, row) => {
+            event.preventDefault();
+            setCopyMenu({
+              x: event.clientX,
+              y: event.clientY,
+              items: [
+                {
+                  label: "Copy row as CSV",
+                  onClick: () =>
+                    copy(
+                      toCsv(result.columns, [row], { header: false }).trimEnd(),
+                    ),
+                },
+                {
+                  label: "Copy row as TSV",
+                  onClick: () =>
+                    copy(
+                      toTsv(result.columns, [row], { header: false }).trimEnd(),
+                    ),
+                },
+                {
+                  label: "Copy row as SQL INSERT",
+                  onClick: () =>
+                    copy(toSqlInserts(result.columns, [row]).trimEnd()),
+                },
+                {
+                  label: "Copy all rows as CSV",
+                  onClick: () => copy(toCsv(result.columns, visibleRows).trimEnd()),
+                },
+                {
+                  label: "Copy all rows as JSON",
+                  onClick: () =>
+                    copy(toJson(result.columns, visibleRows).trimEnd()),
+                },
+                {
+                  label: "Copy all rows as SQL INSERT",
+                  onClick: () =>
+                    copy(toSqlInserts(result.columns, visibleRows).trimEnd()),
+                },
+              ],
+            });
+          }}
           onCellContextMenu={(event, row, column) => {
             event.preventDefault();
             const cell = row[column.key];
@@ -512,18 +582,17 @@ function ReadOnlyResultGrid({
                 },
                 {
                   label: "Copy all rows as CSV",
-                  onClick: () =>
-                    copy(toCsv(result.columns, visibleRows()).trimEnd()),
+                  onClick: () => copy(toCsv(result.columns, visibleRows).trimEnd()),
                 },
                 {
                   label: "Copy all rows as JSON",
                   onClick: () =>
-                    copy(toJson(result.columns, visibleRows()).trimEnd()),
+                    copy(toJson(result.columns, visibleRows).trimEnd()),
                 },
                 {
                   label: "Copy all rows as SQL INSERT",
                   onClick: () =>
-                    copy(toSqlInserts(result.columns, visibleRows()).trimEnd()),
+                    copy(toSqlInserts(result.columns, visibleRows).trimEnd()),
                 },
               ],
             });

--- a/apps/desktop/src/components/Workspace.tsx
+++ b/apps/desktop/src/components/Workspace.tsx
@@ -4,7 +4,13 @@ import {
   type GridRow,
   type PendingChanges,
 } from "@cellar/data-grid";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from "react";
 
 import { SqlEditor } from "./SqlEditor";
 import { ContextMenu, type ContextMenuState } from "./ContextMenu";
@@ -182,28 +188,36 @@ function TableTabPane({
     () => clearTableChanges(tab.id),
     [clearTableChanges, tab.id],
   );
+  const containerRef = useRef<HTMLDivElement | null>(null);
   const copyText = useCallback((text: string) => {
     if (!navigator.clipboard) return;
     void navigator.clipboard.writeText(text);
   }, []);
 
   // ⌘/Ctrl+C copies the selected row as TSV (drops cleanly into spreadsheets).
-  // Native text selections are left to the browser.
-  useEffect(() => {
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (!(event.metaKey || event.ctrlKey) || event.key.toLowerCase() !== "c") {
-        return;
-      }
-      if (!window.getSelection()?.isCollapsed) return;
-      if (!selectedRowData) return;
-      event.preventDefault();
-      copyText(
-        toTsv(data.columns, [selectedRowData], { header: false }).trimEnd(),
-      );
-    };
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [copyText, data.columns, selectedRowData]);
+  // Scoped to the grid container's focus so it never hijacks copy from the SQL
+  // editor or another pane; native text selections and inline editors are left
+  // to the browser.
+  const handleCopyKey = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (!(event.metaKey || event.ctrlKey) || event.key.toLowerCase() !== "c") {
+      return;
+    }
+    const active = document.activeElement;
+    if (
+      active instanceof HTMLElement &&
+      (active.tagName === "INPUT" ||
+        active.tagName === "TEXTAREA" ||
+        active.isContentEditable)
+    ) {
+      return;
+    }
+    if (!window.getSelection()?.isCollapsed) return;
+    if (!selectedRowData) return;
+    event.preventDefault();
+    copyText(
+      toTsv(data.columns, [selectedRowData], { header: false }).trimEnd(),
+    );
+  };
   const pagination = useMemo(
     () => ({
       offset: data.offset,
@@ -246,7 +260,12 @@ function TableTabPane({
   }
 
   return (
-    <div className="flex flex-1 min-h-0 overflow-hidden">
+    <div
+      ref={containerRef}
+      tabIndex={-1}
+      onKeyDown={handleCopyKey}
+      className="flex flex-1 min-h-0 overflow-hidden outline-none"
+    >
       <DataGrid
         columns={data.columns}
         rows={data.rows}
@@ -272,6 +291,9 @@ function TableTabPane({
         onRowSelect={(rowIndex, row) => {
           grid.setSelectedRow(rowIndex);
           setSelectedRowData(row);
+          if (rowIndex !== null) {
+            containerRef.current?.focus({ preventScroll: true });
+          }
         }}
         onRowContextMenu={(event, row) => {
           event.preventDefault();

--- a/apps/desktop/src/components/Workspace.tsx
+++ b/apps/desktop/src/components/Workspace.tsx
@@ -1,15 +1,18 @@
 import {
   DataGrid,
   useGridState,
+  type GridRow,
   type PendingChanges,
 } from "@cellar/data-grid";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { SqlEditor } from "./SqlEditor";
+import { ContextMenu, type ContextMenuState } from "./ContextMenu";
 import { Icon } from "./icons";
 import { useTabs, type TableTab, type WorkspaceTab } from "../state/tabs";
 import { useTableData } from "../hooks/useTableData";
 import { useSettings } from "../lib/settings";
+import { toCsv, toJson, toSqlInserts, toTsv } from "../lib/export";
 
 const EMPTY_CHANGES: PendingChanges = {};
 const TABLE_PAGE_SIZE_OPTIONS = [100, 250, 500, 1000, 2000] as const;
@@ -167,6 +170,10 @@ function TableTabPane({
     pageSize,
   );
   const grid = useGridState();
+  const [rowMenu, setRowMenu] = useState<ContextMenuState | null>(null);
+  // The grid hands back the row object on selection, so copy never has to
+  // re-derive the grid's filter/sort/insert order.
+  const [selectedRowData, setSelectedRowData] = useState<GridRow | null>(null);
   const handleGridChange = useCallback(
     (next: PendingChanges) => setTableChanges(tab.id, next),
     [setTableChanges, tab.id],
@@ -175,6 +182,28 @@ function TableTabPane({
     () => clearTableChanges(tab.id),
     [clearTableChanges, tab.id],
   );
+  const copyText = useCallback((text: string) => {
+    if (!navigator.clipboard) return;
+    void navigator.clipboard.writeText(text);
+  }, []);
+
+  // ⌘/Ctrl+C copies the selected row as TSV (drops cleanly into spreadsheets).
+  // Native text selections are left to the browser.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!(event.metaKey || event.ctrlKey) || event.key.toLowerCase() !== "c") {
+        return;
+      }
+      if (!window.getSelection()?.isCollapsed) return;
+      if (!selectedRowData) return;
+      event.preventDefault();
+      copyText(
+        toTsv(data.columns, [selectedRowData], { header: false }).trimEnd(),
+      );
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [copyText, data.columns, selectedRowData]);
   const pagination = useMemo(
     () => ({
       offset: data.offset,
@@ -239,7 +268,45 @@ function TableTabPane({
         onRevert={handleRevert}
         nullDisplay={settings.grid.nullDisplay}
         stripeRows={settings.grid.stripeRows}
+        selectedRow={grid.selectedRow}
+        onRowSelect={(rowIndex, row) => {
+          grid.setSelectedRow(rowIndex);
+          setSelectedRowData(row);
+        }}
+        onRowContextMenu={(event, row) => {
+          event.preventDefault();
+          setRowMenu({
+            x: event.clientX,
+            y: event.clientY,
+            items: [
+              {
+                label: "Copy row as CSV",
+                onClick: () =>
+                  copyText(
+                    toCsv(data.columns, [row], { header: false }).trimEnd(),
+                  ),
+              },
+              {
+                label: "Copy row as TSV",
+                onClick: () =>
+                  copyText(
+                    toTsv(data.columns, [row], { header: false }).trimEnd(),
+                  ),
+              },
+              {
+                label: "Copy row as JSON",
+                onClick: () => copyText(toJson(data.columns, [row]).trimEnd()),
+              },
+              {
+                label: "Copy row as SQL INSERT",
+                onClick: () =>
+                  copyText(toSqlInserts(data.columns, [row]).trimEnd()),
+              },
+            ],
+          });
+        }}
       />
+      <ContextMenu state={rowMenu} onClose={() => setRowMenu(null)} />
     </div>
   );
 }

--- a/apps/desktop/src/styles/grid.css
+++ b/apps/desktop/src/styles/grid.css
@@ -297,6 +297,16 @@
 .grid-row.is-insert .grid-cell-rowno { background: color-mix(in oklab, var(--insert-bg) 60%, var(--bg-1)); }
 .grid-row.is-delete .grid-cell-rowno { background: color-mix(in oklab, var(--delete-bg) 60%, var(--bg-1)); }
 .grid-rowno-num { font-variant-numeric: tabular-nums; }
+.grid-cell-rowno.is-interactive { cursor: pointer; }
+.grid-cell-rowno.is-interactive:hover {
+  background: var(--bg-2);
+  color: var(--fg-1);
+}
+.grid-cell-rowno.is-interactive:focus-visible {
+  outline: 1.5px solid var(--accent);
+  outline-offset: -1.5px;
+  z-index: 4;
+}
 .grid-gutter-mark {
   position: absolute;
   left: 0;
@@ -404,6 +414,36 @@
   z-index: 3;
 }
 .grid-cell.is-editing { outline: 2px solid var(--accent); padding: 0; }
+
+/* ── full-row selection (row-number gutter) ───────────────────
+   Placed after the stripe/change/hover rules so it wins by source order at
+   equal specificity. The gutter cell becomes a solid accent "handle" and the
+   rest of the row picks up the soft accent tint, including frozen cells. */
+.grid-row.is-row-selected { background: var(--accent-soft); }
+.grid-row.is-row-selected:hover {
+  background: color-mix(in oklab, var(--accent-soft) 82%, var(--bg-3));
+}
+/* Frozen cells are opaque (they overlap scrolled content), so the tint must be
+   composited over their own --bg-inset base — NOT layered on top of the row's
+   translucent tint, which would double the alpha and over-saturate these
+   columns. The gradient paints one accent-soft layer over an opaque base. */
+.grid-row.is-row-selected .grid-cell.frozen {
+  background:
+    linear-gradient(var(--accent-soft), var(--accent-soft)), var(--bg-inset);
+}
+.grid-row.is-row-selected:hover .grid-cell.frozen {
+  background:
+    linear-gradient(
+      color-mix(in oklab, var(--accent-soft) 82%, var(--bg-3)),
+      color-mix(in oklab, var(--accent-soft) 82%, var(--bg-3))
+    ),
+    var(--bg-inset);
+}
+.grid-row.is-row-selected .grid-cell-rowno {
+  background: var(--accent);
+  color: var(--accent-fg);
+}
+.grid-cell-rowno.is-active .grid-rowno-num { font-weight: 600; }
 .grid-cell.is-edited { background: var(--update-bg); }
 .grid-row.is-update .grid-cell.is-edited {
   background: color-mix(in oklab, var(--update) 18%, transparent);

--- a/packages/data-grid/src/DataGrid.tsx
+++ b/packages/data-grid/src/DataGrid.tsx
@@ -603,6 +603,9 @@ export function DataGrid({
       [rowId]: { kind: "insert", edits: {} },
     });
     const nextRowIndex = visibleRows.length;
+    // Inserting starts editing a cell, so clear any full-row selection to keep
+    // row- and cell-selection mutually exclusive.
+    onRowSelect?.(null, null);
     onSelect({ row: nextRowIndex, col: 0 });
     onEdit({ row: nextRowIndex, col: 0 });
     window.requestAnimationFrame(() => {
@@ -615,6 +618,7 @@ export function DataGrid({
     changes,
     onChange,
     onEdit,
+    onRowSelect,
     onSelect,
     readOnly,
     renderedColumns.length,

--- a/packages/data-grid/src/DataGrid.tsx
+++ b/packages/data-grid/src/DataGrid.tsx
@@ -146,6 +146,22 @@ export type DataGridProps = {
     row: GridRow,
     column: GridColumn,
   ) => void;
+
+  /**
+   * Full-row selection, driven by clicking the row-number gutter. Independent of
+   * the single-cell `selection` (the two are mutually exclusive). The index is
+   * into the grid's current visible (filtered + sorted) order; the callback also
+   * hands back the row object so the host can copy it without re-deriving order.
+   */
+  selectedRow?: number | null;
+  onRowSelect?: (rowIndex: number | null, row: GridRow | null) => void;
+
+  /** Right-click on the row-number gutter. Selects the row, then notifies. */
+  onRowContextMenu?: (
+    event: ReactMouseEvent<HTMLDivElement>,
+    row: GridRow,
+    rowIndex: number,
+  ) => void;
 };
 
 /**
@@ -179,6 +195,9 @@ export function DataGrid({
   nullDisplay = "NULL",
   stripeRows = false,
   onCellContextMenu,
+  selectedRow = null,
+  onRowSelect,
+  onRowContextMenu,
 }: DataGridProps) {
   const [internalSort, setInternalSort] = useState<SortState>(null);
   const [internalColumnLayout, setInternalColumnLayout] =
@@ -413,6 +432,21 @@ export function DataGrid({
     [],
   );
 
+  const translateRow = useCallback(
+    (
+      index: number | null,
+      before: readonly GridRow[],
+      after: readonly GridRow[],
+    ): number | null => {
+      if (index === null) return null;
+      const row = before[index];
+      if (!row) return after[index] ? index : null;
+      const nextRow = after.findIndex((candidate) => candidate.id === row.id);
+      return nextRow === -1 ? null : nextRow;
+    },
+    [],
+  );
+
   const previousVisibleRows = useRef<readonly GridRow[]>(visibleRows);
   useEffect(() => {
     const before = previousVisibleRows.current;
@@ -423,13 +457,24 @@ export function DataGrid({
     const nextEditing = translateAddress(editing, before, visibleRows);
     if (!sameAddress(nextSelection, selection)) onSelect(nextSelection);
     if (!sameAddress(nextEditing, editing)) onEdit(nextEditing);
+
+    const nextSelectedRow = translateRow(selectedRow, before, visibleRows);
+    if (nextSelectedRow !== selectedRow) {
+      onRowSelect?.(
+        nextSelectedRow,
+        nextSelectedRow === null ? null : visibleRows[nextSelectedRow] ?? null,
+      );
+    }
   }, [
     editing,
     onEdit,
+    onRowSelect,
     onSelect,
     sameAddress,
+    selectedRow,
     selection,
     translateAddress,
+    translateRow,
     visibleRows,
   ]);
 
@@ -731,6 +776,7 @@ export function DataGrid({
                   columns={renderedColumns}
                   change={change}
                   selected={selection?.row === ri ? selection : null}
+                  rowSelected={selectedRow === ri}
                   editing={editing?.row === ri ? editing : null}
                   frozenCount={frozenCount}
                   readOnly={readOnly}
@@ -745,6 +791,8 @@ export function DataGrid({
                   onEdit={onEdit}
                   onCellEdit={handleCellEdit}
                   onCellContextMenu={onCellContextMenu}
+                  onRowSelect={onRowSelect}
+                  onRowContextMenu={onRowContextMenu}
                 />
               );
             })}
@@ -792,6 +840,7 @@ type GridRowViewProps = {
   columns: readonly GridColumn[];
   change: PendingChange | undefined;
   selected: CellAddress | null;
+  rowSelected: boolean;
   editing: CellAddress | null;
   frozenCount: number;
   readOnly: boolean;
@@ -807,6 +856,8 @@ type GridRowViewProps = {
     next: CellChange["to"],
   ) => void;
   onCellContextMenu: DataGridProps["onCellContextMenu"];
+  onRowSelect: DataGridProps["onRowSelect"];
+  onRowContextMenu: DataGridProps["onRowContextMenu"];
 };
 
 const GridRowView = memo(function GridRowView({
@@ -816,6 +867,7 @@ const GridRowView = memo(function GridRowView({
   columns,
   change,
   selected,
+  rowSelected,
   editing,
   frozenCount,
   readOnly,
@@ -826,9 +878,16 @@ const GridRowView = memo(function GridRowView({
   onEdit,
   onCellEdit,
   onCellContextMenu,
+  onRowSelect,
+  onRowContextMenu,
 }: GridRowViewProps) {
   const kind = change?.kind;
-  const rowSelected = selected !== null;
+  // A single selected cell gives the row a faint tint; clicking the row-number
+  // gutter selects the whole row (a stronger highlight). The two are mutually
+  // exclusive — selecting one clears the other in the handlers below.
+  const cellInRow = selected !== null;
+  const rowGutterInteractive = onRowSelect !== undefined;
+
   // Compute stripe class from absolute rowIndex so it stays correct in virtual
   // scroll mode (where nth-child reflects only the current render window).
   // Only apply the stripe when there is no pending-change tint (is-update,
@@ -841,11 +900,58 @@ const GridRowView = memo(function GridRowView({
         "grid-row" +
         (kind ? " is-" + kind : "") +
         (isStripe ? " is-stripe" : "") +
-        (rowSelected ? " is-selected-row" : "")
+        (cellInRow ? " is-selected-row" : "") +
+        (rowSelected ? " is-row-selected" : "")
       }
       style={top === undefined ? undefined : { top }}
     >
-      <div className="grid-cell grid-cell-rowno">
+      <div
+        className={
+          "grid-cell grid-cell-rowno" +
+          (rowGutterInteractive ? " is-interactive" : "") +
+          (rowSelected ? " is-active" : "")
+        }
+        role={rowGutterInteractive ? "button" : undefined}
+        tabIndex={rowGutterInteractive ? 0 : undefined}
+        aria-pressed={rowGutterInteractive ? rowSelected : undefined}
+        title={rowGutterInteractive ? "Select row" : undefined}
+        onClick={
+          rowGutterInteractive
+            ? () => {
+                onSelect(null);
+                onEdit(null);
+                onRowSelect?.(
+                  rowSelected ? null : rowIndex,
+                  rowSelected ? null : row,
+                );
+              }
+            : undefined
+        }
+        onKeyDown={
+          rowGutterInteractive
+            ? (event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  onSelect(null);
+                  onEdit(null);
+                  onRowSelect?.(
+                    rowSelected ? null : rowIndex,
+                    rowSelected ? null : row,
+                  );
+                }
+              }
+            : undefined
+        }
+        onContextMenu={
+          onRowContextMenu &&
+          ((event) => {
+            onSelect(null);
+            onEdit(null);
+            onRowSelect?.(rowIndex, row);
+            onRowContextMenu(event, row, rowIndex);
+          })
+        }
+      >
         <span className="grid-rowno-num tnum">{rowNumber}</span>
         {kind === "update" && (
           <span
@@ -887,13 +993,17 @@ const GridRowView = memo(function GridRowView({
               (isEdit ? " is-editing" : "")
             }
             style={{ width: c.width, flexBasis: c.width }}
-            onClick={() => onSelect({ row: rowIndex, col: ci })}
+            onClick={() => {
+              if (rowSelected) onRowSelect?.(null, null);
+              onSelect({ row: rowIndex, col: ci });
+            }}
             onDoubleClick={() => {
               if (!readOnly) onEdit({ row: rowIndex, col: ci });
             }}
             onContextMenu={
               onCellContextMenu &&
               ((event) => {
+                if (rowSelected) onRowSelect?.(null, null);
                 onSelect({ row: rowIndex, col: ci });
                 onCellContextMenu(event, row, c);
               })
@@ -1035,6 +1145,7 @@ export function useGridState({
   const [sort, setSort] = useState<SortState>(initialSort);
   const [selection, setSelection] = useState<CellAddress | null>(null);
   const [editing, setEditing] = useState<CellAddress | null>(null);
+  const [selectedRow, setSelectedRow] = useState<number | null>(null);
 
   const revert = useCallback(() => setChanges({}), []);
 
@@ -1049,6 +1160,8 @@ export function useGridState({
     setSelection,
     editing,
     setEditing,
+    selectedRow,
+    setSelectedRow,
     revert,
   };
 }


### PR DESCRIPTION
Adds full-row selection to Cellar's data grid: clicking the row-number gutter selects the entire row (accent highlight, with the gutter as a solid accent handle), and clicking again or clicking any cell clears it. With a row selected, ⌘/Ctrl+C copies it as TSV (a selected single cell copies its value), and right-clicking the gutter offers Copy row as CSV/TSV/JSON/SQL INSERT. Row selection is a generic, opt-in capability in `@cellar/data-grid` (`selectedRow`/`onRowSelect`/`onRowContextMenu`) wired into both the query-result grid and the table browser; cell and row selection are mutually exclusive and the selection tracks its row across re-sorts and filters. Frozen columns composite the tint over their opaque base so they don't stack the translucent alpha and over-saturate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop UI and clipboard behavior only; no auth, persistence, or server changes. Main review surface is keyboard/copy focus scoping and selection index staying aligned with visible row order.
> 
> **Overview**
> Adds **opt-in full-row selection** to `@cellar/data-grid` via `selectedRow`, `onRowSelect`, and `onRowContextMenu`, with `useGridState` tracking `selectedRow`. Row-number gutter clicks (and keyboard on the gutter) select the whole row; that mode is **mutually exclusive** with single-cell selection and editing, including on insert-row. When filter/sort changes reorder visible rows, row and cell selections are **re-mapped by row id**.
> 
> **Workspace** and **BottomPanel** wire the API into the table browser and query-results grid: focusable containers, scoped **⌘/Ctrl+C** (row → TSV, single cell → value; skips inputs and non-collapsed text selection), gutter **context menus** for copy-as formats, and in results a memoized `visibleRows` aligned with export/copy-all.
> 
> **grid.css** adds interactive row-number styling and **full-row highlight** (`is-row-selected`), including composited tint on frozen columns so selection doesn’t double-stack translucency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5a692b769c3fd0a6d8c8d63d29a0366742cb730. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->