### PR TITLE
fix: apply configured font size on open

### DIFF
--- a/apps/desktop/src/lib/settings.test.ts
+++ b/apps/desktop/src/lib/settings.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULTS, applySettingsSideEffects } from "./settings";
+
+describe("applySettingsSideEffects", () => {
+  let originalDocument: typeof globalThis.document;
+  let originalWindow: typeof globalThis.window;
+
+  beforeEach(() => {
+    originalDocument = globalThis.document;
+    originalWindow = globalThis.window;
+
+    const documentElement = fakeElement();
+    const body = fakeElement();
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: { documentElement, body },
+    });
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: {
+        matchMedia: vi.fn(() => ({
+          matches: false,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+        })),
+      },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: originalDocument,
+    });
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow,
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("maps the default 13.5px font setting to a visible startup scale", () => {
+    applySettingsSideEffects(DEFAULTS);
+
+    expect(document.documentElement.style.getPropertyValue("--ui-scale")).toBe(
+      "1.125",
+    );
+    expect(document.body.style.width).toBe("88.88888888888889vw");
+    expect(document.body.style.height).toBe("88.88888888888889vh");
+    expect((document.body.style as CSSStyleDeclaration & { zoom?: string }).zoom).toBe(
+      "1.125",
+    );
+  });
+});
+
+function fakeElement() {
+  const attributes = new Map<string, string>();
+  return {
+    style: fakeStyle(),
+    setAttribute: (name: string, value: string) => attributes.set(name, value),
+  };
+}
+
+function fakeStyle() {
+  const properties = new Map<string, string>();
+  return {
+    width: "",
+    height: "",
+    zoom: "",
+    setProperty: (name: string, value: string) => properties.set(name, value),
+    getPropertyValue: (name: string) => properties.get(name) ?? "",
+  };
+}

--- a/apps/desktop/src/lib/settings.tsx
+++ b/apps/desktop/src/lib/settings.tsx
@@ -72,7 +72,9 @@ export const DEFAULTS: Settings = {
 };
 
 const STORAGE_KEY = "cellar.settings.v1";
-const FONT_SIZE_BASELINE = 13.5;
+// Most compact UI labels are authored around 10-12px. Treat the user's setting
+// as the target readable size, so the default 13.5px setting is not a no-op.
+const FONT_SIZE_BASELINE = 12;
 export const FONT_SIZE_MIN = 10;
 export const FONT_SIZE_MAX = 22;
 
@@ -116,7 +118,7 @@ export function sanitize(s: Settings): Settings {
   };
 }
 
-function applySideEffects(s: Settings) {
+export function applySettingsSideEffects(s: Settings) {
   const html = document.documentElement;
   const body = document.body;
 
@@ -177,7 +179,7 @@ const SettingsContext = createContext<Ctx | null>(null);
 export function SettingsProvider({ children }: { children: ReactNode }) {
   const [settings, setSettings] = useState<Settings>(() => {
     const initial = load();
-    applySideEffects(initial);
+    applySettingsSideEffects(initial);
     return initial;
   });
 
@@ -185,7 +187,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     setSettings((prev) => {
       const next = sanitize({ ...prev, [key]: value });
       localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
-      applySideEffects(next);
+      applySettingsSideEffects(next);
       return next;
     });
   }, []);
@@ -197,7 +199,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         editor: { ...prev.editor, ...patch },
       });
       localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
-      applySideEffects(next);
+      applySettingsSideEffects(next);
       return next;
     });
   }, []);
@@ -209,7 +211,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         grid: { ...prev.grid, ...patch },
       });
       localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
-      applySideEffects(next);
+      applySettingsSideEffects(next);
       return next;
     });
   }, []);
@@ -223,21 +225,21 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         grid: { ...prev.grid, ...(partial.grid ?? {}) },
       });
       localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
-      applySideEffects(next);
+      applySettingsSideEffects(next);
       return next;
     });
   }, []);
 
   const reset = useCallback(() => {
     localStorage.removeItem(STORAGE_KEY);
-    applySideEffects(DEFAULTS);
+    applySettingsSideEffects(DEFAULTS);
     setSettings(DEFAULTS);
   }, []);
 
   useEffect(() => {
     if (settings.theme !== "system") return;
     const mq = window.matchMedia("(prefers-color-scheme: light)");
-    const onChange = () => applySideEffects(settings);
+    const onChange = () => applySettingsSideEffects(settings);
     mq.addEventListener("change", onChange);
     return () => mq.removeEventListener("change", onChange);
   }, [settings]);


### PR DESCRIPTION
## Summary

Applies the saved interface font-size setting on startup using the authored 12px UI baseline, so the default 13.5px setting visibly scales the compact UI instead of becoming a no-op. This fixes the first-open behavior where Settings could show 13.5px while the interface still appeared closer to the smaller authored text sizes.

## Validation

Ran `pnpm --filter @cellar/desktop test` and `pnpm --filter @cellar/desktop typecheck`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized desktop settings/UI scaling logic with a regression test; no auth, data, or API changes.
> 
> **Overview**
> Fixes **first-open UI scaling** so the default **13.5px** interface font setting visibly enlarges the compact UI instead of behaving like a no-op.
> 
> **`FONT_SIZE_BASELINE`** is lowered from **13.5** to **12**, matching how compact labels are authored (~10–12px). Scale is still `fontSizePx / baseline`, so defaults now yield **`--ui-scale` 1.125**, body **`zoom`**, and the existing viewport compensation (`width`/`height` in vw/vh).
> 
> Renames the internal helper to **`applySettingsSideEffects`** and **exports** it so startup scaling is covered by a new Vitest case asserting those DOM side effects for **`DEFAULTS`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f591ac41f8eb8a83a98471a0f6e8c1c13cc738f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->