### PR TITLE
chore: bump version to 0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cellar",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "Cellar — open-source desktop database client",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bumps the root package version from 0.2.0 to 0.2.1 in `package.json`.

## Test plan
- [ ] Confirm `package.json` reports version 0.2.1
- [ ] Verify release/build tooling picks up the updated version


Made with [Cursor](https://cursor.com)