### PR TITLE
feat: MySQL driver with connection, introspection, query, and table browse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,6 +420,7 @@ dependencies = [
  "cellar-core",
  "cellar-diff",
  "cellar-driver-firestore",
+ "cellar-driver-mysql",
  "cellar-driver-postgres",
  "cellar-driver-sqlserver",
  "cellar-secrets",
@@ -459,6 +460,22 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "cellar-driver-mysql"
+version = "0.2.0"
+dependencies = [
+ "async-trait",
+ "cellar-core",
+ "chrono",
+ "futures",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "thiserror 1.0.69",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/cellar-core",
     "crates/cellar-drivers",
     "crates/cellar-drivers/firestore",
+    "crates/cellar-drivers/mysql",
     "crates/cellar-drivers/postgres",
     "crates/cellar-drivers/sqlserver",
     "crates/cellar-sql",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -40,6 +40,7 @@ tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 cellar-core = { path = "../../../crates/cellar-core" }
 cellar-driver-firestore = { path = "../../../crates/cellar-drivers/firestore" }
+cellar-driver-mysql = { path = "../../../crates/cellar-drivers/mysql" }
 cellar-driver-postgres = { path = "../../../crates/cellar-drivers/postgres" }
 cellar-driver-sqlserver = { path = "../../../crates/cellar-drivers/sqlserver" }
 cellar-diff = { path = "../../../crates/cellar-diff" }

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -8,6 +8,7 @@ use cellar_core::query::{PlanMode, Query, QueryPlan, QueryResult, TableBrowseReq
 use cellar_core::schema::{Database, Table};
 use cellar_diff::{TableChangeRequest, TableCommitResult};
 use cellar_driver_firestore::FirestoreDriver;
+use cellar_driver_mysql::MySqlDriver;
 use cellar_driver_postgres::PostgresDriver;
 use cellar_driver_sqlserver::SqlServerDriver;
 use tokio::fs;
@@ -275,6 +276,16 @@ impl ConnectionRegistry {
                 cellar_driver_firestore::browse_collection(connection.as_ref(), &request, &table)
                     .await
             }
+            Engine::MySql => {
+                match cellar_driver_mysql::browse_table(connection.as_ref(), &request, &table)
+                    .await
+                {
+                    Ok(result) => Ok(result),
+                    Err(err) => Err(self
+                        .handle_operation_error(&request.connection_id, err)
+                        .await),
+                }
+            }
             Engine::Postgres => {
                 match cellar_driver_postgres::browse_table(connection.as_ref(), &request, &table)
                     .await
@@ -461,6 +472,7 @@ fn find_table(dbs: &[Database], database: &str, schema: &str, table: &str) -> Ce
 fn driver_for(engine: Engine) -> CellarResult<Box<dyn Driver>> {
     match engine {
         Engine::Firestore => Ok(Box::new(FirestoreDriver::new())),
+        Engine::MySql => Ok(Box::new(MySqlDriver::new())),
         Engine::Postgres => Ok(Box::new(PostgresDriver::new())),
         Engine::Mssql => Ok(Box::new(SqlServerDriver::new())),
         Engine::Azure => Ok(Box::new(SqlServerDriver::azure())),

--- a/apps/desktop/src/components/modals/ConnectionDialog.tsx
+++ b/apps/desktop/src/components/modals/ConnectionDialog.tsx
@@ -298,7 +298,7 @@ export function ConnectionDialog({
                 className={CD_INPUT}
                 value={name}
                 onChange={(e) => setName(e.target.value)}
-                placeholder={isFirestore ? "prod-firestore" : "local-postgres"}
+                placeholder={isFirestore ? "prod-firestore" : `local-${engine}`}
               />
             </FormRow>
 

--- a/apps/desktop/src/components/modals/ConnectionDialog.tsx
+++ b/apps/desktop/src/components/modals/ConnectionDialog.tsx
@@ -211,7 +211,11 @@ export function ConnectionDialog({
             const m = ENGINE_META[e];
             const hex = ENGINE_HEX[e];
             const active = engine === e;
-            const disabled = e !== "postgres" && e !== "firestore" && e !== "mssql";
+            const disabled =
+              e !== "postgres" &&
+              e !== "firestore" &&
+              e !== "mssql" &&
+              e !== "mysql";
             return (
               <button
                 key={e}

--- a/apps/desktop/src/components/modals/ConnectionDialog.tsx
+++ b/apps/desktop/src/components/modals/ConnectionDialog.tsx
@@ -29,6 +29,19 @@ const DEFAULT_PORT: Record<Engine, number> = {
   firestore: 443,
 };
 
+// Default catalog to target when the user first picks an engine. MySQL has no
+// "postgres"-style user database, so we use the always-present `mysql` system
+// schema as a connectable starting point. Firestore/SQLite carry no SQL
+// catalog (project id / file path), so they default to empty.
+const DEFAULT_DATABASE: Record<Engine, string> = {
+  postgres: "postgres",
+  mysql: "mysql",
+  mssql: "master",
+  azure: "master",
+  sqlite: "",
+  firestore: "",
+};
+
 type Tab = "general" | "ssh" | "ssl" | "options";
 type TestStatus =
   | { kind: "idle" }
@@ -111,15 +124,14 @@ export function ConnectionDialog({
     if (!userPickedEngine.current) return;
     setPort(DEFAULT_PORT[engine] || 5432);
     setSwatch(ENGINE_HEX[engine]);
+    setDatabase(DEFAULT_DATABASE[engine]);
     if (engine === "firestore") {
       setHost("firestore.googleapis.com");
-      setDatabase("");
       setUser("(default)");
       setSsl(true);
       setSslMode("require");
     } else if (engine === "mssql") {
       setHost("localhost");
-      setDatabase("master");
       setSsl(true);
       setSslMode("prefer");
     }

--- a/apps/desktop/src/components/modals/EmptyState.tsx
+++ b/apps/desktop/src/components/modals/EmptyState.tsx
@@ -98,7 +98,11 @@ export function EmptyState({ onNew }: { onNew: () => void }) {
           {ENGINE_ORDER.map((e) => {
             const m = ENGINE_META[e];
             const hex = ENGINE_HEX[e];
-            const available = e === "postgres" || e === "mssql";
+            const available =
+              e === "postgres" ||
+              e === "mssql" ||
+              e === "firestore" ||
+              e === "mysql";
             return (
               <button
                 key={e}

--- a/apps/site/src/main.ts
+++ b/apps/site/src/main.ts
@@ -94,7 +94,7 @@ const engines: ReadonlyArray<Engine> = [
   { name: "SQL Server", color: "var(--eng-mssql)", status: "supported" },
   { name: "Azure SQL", color: "var(--eng-azure)", status: "supported" },
   { name: "Firestore", color: "var(--eng-firestore)", status: "supported" },
-  { name: "MySQL", color: "var(--eng-mysql)", status: "soon" },
+  { name: "MySQL", color: "var(--eng-mysql)", status: "supported" },
   { name: "SQLite", color: "var(--eng-sqlite)", status: "soon" },
 ];
 
@@ -342,7 +342,7 @@ const qas: ReadonlyArray<Qa> = [
   ],
   [
     "Which databases are supported?",
-    "PostgreSQL, SQL Server, Azure SQL, and Firestore are supported today. MySQL and SQLite are coming soon.",
+    "PostgreSQL, SQL Server, Azure SQL, Firestore, and MySQL are supported today. SQLite is coming soon.",
   ],
   [
     "What about Windows and Linux?",

--- a/crates/cellar-drivers/mysql/Cargo.toml
+++ b/crates/cellar-drivers/mysql/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "cellar-driver-mysql"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Cellar — MySQL driver built on sqlx"
+publish = false
+
+[dependencies]
+cellar-core = { path = "../../cellar-core" }
+async-trait = "0.1"
+futures = "0.3"
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+thiserror = { workspace = true }
+chrono = { version = "0.4", features = ["serde"], default-features = false }
+uuid = { version = "1", features = ["serde"] }
+sqlx = { version = "0.8", default-features = false, features = [
+    "runtime-tokio",
+    "tls-rustls",
+    "mysql",
+    "chrono",
+    "uuid",
+    "json",
+] }

--- a/crates/cellar-drivers/mysql/src/connect.rs
+++ b/crates/cellar-drivers/mysql/src/connect.rs
@@ -1,0 +1,172 @@
+use std::any::Any;
+use std::str::FromStr;
+
+use async_trait::async_trait;
+use cellar_core::driver::{Connection, ConnectionConfig, DriverInfo, Engine, SslMode};
+use cellar_core::error::{CellarError, CellarResult};
+use sqlx::mysql::{MySqlConnectOptions, MySqlPoolOptions, MySqlSslMode};
+use sqlx::{Error as SqlxError, MySqlPool, Row};
+
+const DEFAULT_POOL_SIZE: u32 = 4;
+
+pub struct MySqlConnection {
+    info: DriverInfo,
+    pool: MySqlPool,
+    config: ConnectionConfig,
+}
+
+impl MySqlConnection {
+    pub fn pool(&self) -> &MySqlPool {
+        &self.pool
+    }
+
+    pub fn config(&self) -> &ConnectionConfig {
+        &self.config
+    }
+}
+
+#[async_trait]
+impl Connection for MySqlConnection {
+    fn info(&self) -> &DriverInfo {
+        &self.info
+    }
+
+    async fn ping(&self) -> CellarResult<()> {
+        sqlx::query("SELECT 1")
+            .execute(&self.pool)
+            .await
+            .map(|_| ())
+            .map_err(|e| {
+                map_sqlx_err_for_runtime(e, "connection health check", CellarError::connection)
+            })
+    }
+
+    async fn close(&self) -> CellarResult<()> {
+        self.pool.close().await;
+        Ok(())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+pub async fn open_pool(
+    config: &ConnectionConfig,
+    password: Option<&str>,
+) -> CellarResult<MySqlConnection> {
+    let pool = build_pool(config, password, DEFAULT_POOL_SIZE).await?;
+
+    let version = sqlx::query("SELECT VERSION() AS v")
+        .fetch_one(&pool)
+        .await
+        .map_err(|e| {
+            map_sqlx_err_for_runtime(e, "initial server version check", CellarError::connection)
+        })?;
+    let version: String = version
+        .try_get::<String, _>("v")
+        .map_err(|e| CellarError::Decode(e.to_string()))?;
+
+    Ok(MySqlConnection {
+        info: DriverInfo {
+            engine: Engine::MySql,
+            version,
+        },
+        pool,
+        config: config.clone(),
+    })
+}
+
+async fn build_pool(
+    config: &ConnectionConfig,
+    password: Option<&str>,
+    max_connections: u32,
+) -> CellarResult<MySqlPool> {
+    let mut opts = MySqlConnectOptions::from_str(&format!(
+        "mysql://{user}@{host}:{port}/{db}",
+        user = config.user,
+        host = config.host,
+        port = config.port,
+        db = config.database,
+    ))
+    .map_err(|e| CellarError::invalid_config(e.to_string()))?
+    .ssl_mode(map_ssl_mode(config.ssl_mode));
+    if let Some(p) = password {
+        opts = opts.password(p);
+    }
+
+    MySqlPoolOptions::new()
+        .max_connections(max_connections)
+        .connect_with(opts)
+        .await
+        .map_err(map_sqlx_err_for_connect)
+}
+
+fn map_ssl_mode(mode: SslMode) -> MySqlSslMode {
+    match mode {
+        SslMode::Disable => MySqlSslMode::Disabled,
+        SslMode::Prefer => MySqlSslMode::Preferred,
+        SslMode::Require => MySqlSslMode::Required,
+        SslMode::VerifyCa => MySqlSslMode::VerifyCa,
+        SslMode::VerifyFull => MySqlSslMode::VerifyIdentity,
+    }
+}
+
+fn map_sqlx_err_for_connect(err: SqlxError) -> CellarError {
+    let msg = err.to_string();
+    match err {
+        SqlxError::Database(ref db) => {
+            let code_str = db.code().map(|c| c.to_string());
+            let code = code_str.as_deref().unwrap_or("");
+            // MySQL error codes: 1045 access denied
+            if code == "1045" || msg.to_lowercase().contains("access denied") {
+                CellarError::Authentication(msg)
+            } else {
+                CellarError::Connection(msg)
+            }
+        }
+        SqlxError::Tls(_) => CellarError::Tls(format!("TLS handshake failed: {msg}")),
+        SqlxError::PoolTimedOut => CellarError::Timeout(
+            "timed out while opening the MySQL connection pool; check host reachability and retry"
+                .into(),
+        ),
+        SqlxError::PoolClosed => CellarError::NotConnected(
+            "MySQL connection pool closed before the connection finished opening".into(),
+        ),
+        SqlxError::Io(_) => CellarError::Connection(format!("could not reach MySQL: {msg}")),
+        _ => CellarError::Connection(msg),
+    }
+}
+
+pub(crate) fn map_sqlx_err_for_runtime(
+    err: SqlxError,
+    operation: &str,
+    database_error: fn(String) -> CellarError,
+) -> CellarError {
+    let msg = err.to_string();
+    match err {
+        SqlxError::PoolClosed => CellarError::NotConnected(format!(
+            "{operation} failed because the connection pool is closed. Reconnect and retry."
+        )),
+        SqlxError::PoolTimedOut => CellarError::Timeout(format!(
+            "{operation} timed out waiting for an available database connection. Retry, or reconnect if it keeps happening."
+        )),
+        SqlxError::Io(_) => CellarError::connection(format!(
+            "{operation} lost the database connection: {msg}. Reconnect and retry."
+        )),
+        SqlxError::Tls(_) => CellarError::Tls(format!(
+            "{operation} failed because the TLS session is no longer usable: {msg}. Reconnect and retry."
+        )),
+        SqlxError::Database(_) => database_error(msg),
+        other => database_error(other.to_string()),
+    }
+}
+
+pub(crate) fn as_mysql<'a>(conn: &'a dyn Connection) -> CellarResult<&'a MySqlConnection> {
+    conn.as_any().downcast_ref::<MySqlConnection>().ok_or_else(|| {
+        CellarError::NotConnected(format!(
+            "expected mysql connection, got {}",
+            conn.info().engine.as_str()
+        ))
+    })
+}

--- a/crates/cellar-drivers/mysql/src/connect.rs
+++ b/crates/cellar-drivers/mysql/src/connect.rs
@@ -162,7 +162,7 @@ pub(crate) fn map_sqlx_err_for_runtime(
     }
 }
 
-pub(crate) fn as_mysql<'a>(conn: &'a dyn Connection) -> CellarResult<&'a MySqlConnection> {
+pub(crate) fn as_mysql(conn: &dyn Connection) -> CellarResult<&MySqlConnection> {
     conn.as_any().downcast_ref::<MySqlConnection>().ok_or_else(|| {
         CellarError::NotConnected(format!(
             "expected mysql connection, got {}",

--- a/crates/cellar-drivers/mysql/src/decode.rs
+++ b/crates/cellar-drivers/mysql/src/decode.rs
@@ -1,0 +1,113 @@
+use cellar_core::error::{CellarError, CellarResult};
+use cellar_core::value::CellValue;
+use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
+use sqlx::mysql::{MySqlRow, MySqlValueRef};
+use sqlx::{Row, TypeInfo, ValueRef};
+
+/// Decode one cell from a MySQL row into our typed [`CellValue`].
+pub fn decode_cell(row: &MySqlRow, ordinal: usize) -> CellarResult<CellValue> {
+    let raw: MySqlValueRef<'_> = row
+        .try_get_raw(ordinal)
+        .map_err(|e| CellarError::decode(e.to_string()))?;
+    if raw.is_null() {
+        return Ok(CellValue::Null);
+    }
+
+    let type_name = raw.type_info().name().to_uppercase();
+    match type_name.as_str() {
+        "BOOLEAN" | "BOOL" => {
+            row.try_get::<bool, _>(ordinal)
+                .map(CellValue::Bool)
+                .map_err(decode_err)
+        }
+        "TINYINT" => {
+            row.try_get::<i8, _>(ordinal)
+                .map(|v| CellValue::Int(v as i64))
+                .map_err(decode_err)
+        }
+        "SMALLINT" | "MEDIUMINT" => row
+            .try_get::<i16, _>(ordinal)
+            .map(|v| CellValue::Int(v as i64))
+            .map_err(decode_err),
+        "INT" | "INTEGER" => row
+            .try_get::<i32, _>(ordinal)
+            .map(|v| CellValue::Int(v as i64))
+            .map_err(decode_err),
+        "BIGINT" => row
+            .try_get::<i64, _>(ordinal)
+            .map(CellValue::Int)
+            .map_err(decode_err),
+        "UNSIGNED TINYINT" => row
+            .try_get::<u8, _>(ordinal)
+            .map(|v| CellValue::Int(v as i64))
+            .map_err(decode_err),
+        "UNSIGNED SMALLINT" => row
+            .try_get::<u16, _>(ordinal)
+            .map(|v| CellValue::Int(v as i64))
+            .map_err(decode_err),
+        "UNSIGNED INT" | "UNSIGNED INTEGER" => row
+            .try_get::<u32, _>(ordinal)
+            .map(|v| CellValue::Int(v as i64))
+            .map_err(decode_err),
+        "UNSIGNED BIGINT" => row
+            .try_get::<u64, _>(ordinal)
+            .map(|v| CellValue::Int(v as i64))
+            .map_err(decode_err),
+
+        "FLOAT" => row
+            .try_get::<f32, _>(ordinal)
+            .map(|v| CellValue::Float(v as f64))
+            .map_err(decode_err),
+        "DOUBLE" => row
+            .try_get::<f64, _>(ordinal)
+            .map(CellValue::Float)
+            .map_err(decode_err),
+
+        "DECIMAL" | "NUMERIC" | "NEWDECIMAL" => row
+            .try_get::<String, _>(ordinal)
+            .map(CellValue::Numeric)
+            .map_err(decode_err),
+
+        "CHAR" | "VARCHAR" | "TEXT" | "TINYTEXT" | "MEDIUMTEXT" | "LONGTEXT"
+        | "ENUM" | "SET" => row
+            .try_get::<String, _>(ordinal)
+            .map(CellValue::Text)
+            .map_err(decode_err),
+
+        "BINARY" | "VARBINARY" | "BLOB" | "TINYBLOB" | "MEDIUMBLOB" | "LONGBLOB" => row
+            .try_get::<Vec<u8>, _>(ordinal)
+            .map(CellValue::Bytes)
+            .map_err(decode_err),
+
+        "DATE" => row
+            .try_get::<NaiveDate, _>(ordinal)
+            .map(CellValue::Date)
+            .map_err(decode_err),
+        "TIME" => row
+            .try_get::<NaiveTime, _>(ordinal)
+            .map(CellValue::Time)
+            .map_err(decode_err),
+        "DATETIME" => row
+            .try_get::<NaiveDateTime, _>(ordinal)
+            .map(CellValue::Timestamp)
+            .map_err(decode_err),
+        "TIMESTAMP" => row
+            .try_get::<NaiveDateTime, _>(ordinal)
+            .map(CellValue::Timestamp)
+            .map_err(decode_err),
+
+        "JSON" => row
+            .try_get::<serde_json::Value, _>(ordinal)
+            .map(CellValue::Json)
+            .map_err(decode_err),
+
+        _ => match row.try_get::<String, _>(ordinal) {
+            Ok(s) => Ok(CellValue::Text(s)),
+            Err(_) => Err(CellarError::UnsupportedType(type_name)),
+        },
+    }
+}
+
+fn decode_err(e: sqlx::Error) -> CellarError {
+    CellarError::Decode(e.to_string())
+}

--- a/crates/cellar-drivers/mysql/src/decode.rs
+++ b/crates/cellar-drivers/mysql/src/decode.rs
@@ -5,6 +5,22 @@ use sqlx::mysql::{MySqlRow, MySqlValueRef};
 use sqlx::{Row, TypeInfo, ValueRef};
 
 /// Decode one cell from a MySQL row into our typed [`CellValue`].
+///
+/// We dispatch on the type name reported by `MySqlTypeInfo::name()`. The
+/// important quirks of sqlx-mysql's naming, which earlier drafts of this file
+/// got wrong:
+///
+/// * Unsigned integers are named `"INT UNSIGNED"`, `"BIGINT UNSIGNED"`, … —
+///   the qualifier is a *suffix*, not a prefix. They also fail sqlx's signed
+///   `int_compatible` check, so they must be decoded through `u64`.
+/// * Every signed integer width is compatible with `i64` (sqlx widens through
+///   `i64` internally), so decoding all signed ints as `i64` avoids a
+///   `MEDIUMINT`-into-`i16` overflow.
+/// * `DECIMAL` is *not* string-compatible and we don't build with the
+///   `bigdecimal`/`rust_decimal` features, so the checked `try_get::<String>`
+///   fails. MySQL transmits decimals as ASCII in both protocols, so we use the
+///   *unchecked* decode (which calls `String::decode` → reads the bytes as
+///   UTF-8) to preserve full precision, mirroring how Postgres keeps `numeric`.
 pub fn decode_cell(row: &MySqlRow, ordinal: usize) -> CellarResult<CellValue> {
     let raw: MySqlValueRef<'_> = row
         .try_get_raw(ordinal)
@@ -15,43 +31,30 @@ pub fn decode_cell(row: &MySqlRow, ordinal: usize) -> CellarResult<CellValue> {
 
     let type_name = raw.type_info().name().to_uppercase();
     match type_name.as_str() {
-        "BOOLEAN" | "BOOL" => {
-            row.try_get::<bool, _>(ordinal)
-                .map(CellValue::Bool)
-                .map_err(decode_err)
-        }
-        "TINYINT" => {
-            row.try_get::<i8, _>(ordinal)
-                .map(|v| CellValue::Int(v as i64))
-                .map_err(decode_err)
-        }
-        "SMALLINT" | "MEDIUMINT" => row
-            .try_get::<i16, _>(ordinal)
-            .map(|v| CellValue::Int(v as i64))
+        // TINYINT(1) surfaces as BOOLEAN; treat it as a boolean.
+        "BOOLEAN" | "BOOL" => row
+            .try_get::<bool, _>(ordinal)
+            .map(CellValue::Bool)
             .map_err(decode_err),
-        "INT" | "INTEGER" => row
-            .try_get::<i32, _>(ordinal)
-            .map(|v| CellValue::Int(v as i64))
-            .map_err(decode_err),
-        "BIGINT" => row
+
+        // All signed widths decode cleanly through i64.
+        "TINYINT" | "SMALLINT" | "MEDIUMINT" | "INT" | "INTEGER" | "BIGINT" => row
             .try_get::<i64, _>(ordinal)
             .map(CellValue::Int)
             .map_err(decode_err),
-        "UNSIGNED TINYINT" => row
-            .try_get::<u8, _>(ordinal)
-            .map(|v| CellValue::Int(v as i64))
-            .map_err(decode_err),
-        "UNSIGNED SMALLINT" => row
-            .try_get::<u16, _>(ordinal)
-            .map(|v| CellValue::Int(v as i64))
-            .map_err(decode_err),
-        "UNSIGNED INT" | "UNSIGNED INTEGER" => row
-            .try_get::<u32, _>(ordinal)
-            .map(|v| CellValue::Int(v as i64))
-            .map_err(decode_err),
-        "UNSIGNED BIGINT" => row
+
+        // Unsigned columns need u64. A BIGINT UNSIGNED can exceed i64::MAX, so
+        // keep those as Numeric text rather than silently wrapping.
+        "TINYINT UNSIGNED"
+        | "SMALLINT UNSIGNED"
+        | "MEDIUMINT UNSIGNED"
+        | "INT UNSIGNED"
+        | "INTEGER UNSIGNED"
+        | "BIGINT UNSIGNED"
+        | "YEAR"
+        | "BIT" => row
             .try_get::<u64, _>(ordinal)
-            .map(|v| CellValue::Int(v as i64))
+            .map(uint_to_cell)
             .map_err(decode_err),
 
         "FLOAT" => row
@@ -63,35 +66,38 @@ pub fn decode_cell(row: &MySqlRow, ordinal: usize) -> CellarResult<CellValue> {
             .map(CellValue::Float)
             .map_err(decode_err),
 
-        "DECIMAL" | "NUMERIC" | "NEWDECIMAL" => row
-            .try_get::<String, _>(ordinal)
-            .map(CellValue::Numeric)
-            .map_err(decode_err),
+        // DECIMAL is not String-compatible in sqlx and we have no decimal
+        // feature; the unchecked decode reads its ASCII bytes and keeps
+        // arbitrary precision.
+        "DECIMAL" | "NUMERIC" | "NEWDECIMAL" => unchecked_text(row, ordinal).map(CellValue::Numeric),
 
-        "CHAR" | "VARCHAR" | "TEXT" | "TINYTEXT" | "MEDIUMTEXT" | "LONGTEXT"
-        | "ENUM" | "SET" => row
-            .try_get::<String, _>(ordinal)
-            .map(CellValue::Text)
-            .map_err(decode_err),
+        "CHAR" | "VARCHAR" | "TEXT" | "TINYTEXT" | "MEDIUMTEXT" | "LONGTEXT" | "ENUM" | "SET" => {
+            // ENUM is String-compatible but SET is not, so fall back to the
+            // unchecked UTF-8 decode when the checked one is rejected.
+            match row.try_get::<String, _>(ordinal) {
+                Ok(s) => Ok(CellValue::Text(s)),
+                Err(_) => unchecked_text(row, ordinal).map(CellValue::Text),
+            }
+        }
 
-        "BINARY" | "VARBINARY" | "BLOB" | "TINYBLOB" | "MEDIUMBLOB" | "LONGBLOB" => row
-            .try_get::<Vec<u8>, _>(ordinal)
-            .map(CellValue::Bytes)
-            .map_err(decode_err),
+        "BINARY" | "VARBINARY" | "BLOB" | "TINYBLOB" | "MEDIUMBLOB" | "LONGBLOB" | "GEOMETRY" => {
+            row.try_get::<Vec<u8>, _>(ordinal)
+                .map(CellValue::Bytes)
+                .map_err(decode_err)
+        }
 
         "DATE" => row
             .try_get::<NaiveDate, _>(ordinal)
             .map(CellValue::Date)
             .map_err(decode_err),
-        "TIME" => row
-            .try_get::<NaiveTime, _>(ordinal)
-            .map(CellValue::Time)
-            .map_err(decode_err),
-        "DATETIME" => row
-            .try_get::<NaiveDateTime, _>(ordinal)
-            .map(CellValue::Timestamp)
-            .map_err(decode_err),
-        "TIMESTAMP" => row
+        // MySQL TIME is a signed duration (±838h) and can fall outside
+        // chrono::NaiveTime's clock range; fall back to the raw string so the
+        // value is still shown rather than erroring the whole row.
+        "TIME" => match row.try_get::<NaiveTime, _>(ordinal) {
+            Ok(t) => Ok(CellValue::Time(t)),
+            Err(_) => unchecked_text(row, ordinal).map(CellValue::Text),
+        },
+        "DATETIME" | "TIMESTAMP" => row
             .try_get::<NaiveDateTime, _>(ordinal)
             .map(CellValue::Timestamp)
             .map_err(decode_err),
@@ -101,11 +107,37 @@ pub fn decode_cell(row: &MySqlRow, ordinal: usize) -> CellarResult<CellValue> {
             .map(CellValue::Json)
             .map_err(decode_err),
 
+        // Unknown type: try a typed string, then an unchecked UTF-8 read, then
+        // bytes, before giving up — better to show the user something than to
+        // drop the whole row.
         _ => match row.try_get::<String, _>(ordinal) {
             Ok(s) => Ok(CellValue::Text(s)),
-            Err(_) => Err(CellarError::UnsupportedType(type_name)),
+            Err(_) => match row.try_get_unchecked::<String, _>(ordinal) {
+                Ok(s) => Ok(CellValue::Text(s)),
+                Err(_) => match row.try_get::<Vec<u8>, _>(ordinal) {
+                    Ok(b) => Ok(CellValue::Bytes(b)),
+                    Err(_) => Err(CellarError::UnsupportedType(type_name)),
+                },
+            },
         },
     }
+}
+
+/// Map an unsigned integer to a cell, keeping values above `i64::MAX` (only
+/// possible for `BIGINT UNSIGNED`) as exact decimal text instead of wrapping.
+fn uint_to_cell(v: u64) -> CellValue {
+    match i64::try_from(v) {
+        Ok(i) => CellValue::Int(i),
+        Err(_) => CellValue::Numeric(v.to_string()),
+    }
+}
+
+/// Decode a column as a UTF-8 string via the *unchecked* path, bypassing
+/// sqlx's type-compatibility gate. Used for types MySQL transmits as ASCII
+/// (DECIMAL, SET) that the checked `String` decode rejects.
+fn unchecked_text(row: &MySqlRow, ordinal: usize) -> CellarResult<String> {
+    row.try_get_unchecked::<String, _>(ordinal)
+        .map_err(decode_err)
 }
 
 fn decode_err(e: sqlx::Error) -> CellarError {

--- a/crates/cellar-drivers/mysql/src/introspect.rs
+++ b/crates/cellar-drivers/mysql/src/introspect.rs
@@ -233,7 +233,11 @@ async fn list_indexes(pool: &MySqlPool, db_name: &str) -> CellarResult<IdxMap> {
     for r in rows {
         let table: String = r.try_get("TABLE_NAME").map_err(intro_err)?;
         let name: String = r.try_get("INDEX_NAME").map_err(intro_err)?;
-        let col: String = r.try_get("COLUMN_NAME").map_err(intro_err)?;
+        // COLUMN_NAME is NULL for MySQL 8+ expression (functional) index parts;
+        // the expression lives in a separate EXPRESSION column we don't model.
+        // Keep the index but skip the unnamed part rather than erroring the
+        // whole introspection.
+        let col: Option<String> = r.try_get("COLUMN_NAME").map_err(intro_err)?;
         let non_unique: i64 = r.try_get("NON_UNIQUE").map_err(intro_err)?;
         let unique = non_unique == 0;
         let primary = name == "PRIMARY";
@@ -245,7 +249,9 @@ async fn list_indexes(pool: &MySqlPool, db_name: &str) -> CellarResult<IdxMap> {
                 unique,
                 primary,
             });
-        entry.columns.push(col);
+        if let Some(col) = col {
+            entry.columns.push(col);
+        }
     }
 
     let mut out: IdxMap = BTreeMap::new();

--- a/crates/cellar-drivers/mysql/src/introspect.rs
+++ b/crates/cellar-drivers/mysql/src/introspect.rs
@@ -1,0 +1,287 @@
+use std::collections::BTreeMap;
+
+use cellar_core::error::{CellarError, CellarResult};
+use cellar_core::schema::{Column, Database, ForeignKey, Index, Schema, Table, View};
+use sqlx::{MySqlPool, Row};
+
+use crate::connect::MySqlConnection;
+
+/// Build the database → schema → table tree for MySQL.
+/// MySQL has a single database (catalog) per connection. We return it as
+/// one `Database` entry with a single schema matching the database name.
+pub async fn introspect(conn: &MySqlConnection) -> CellarResult<Vec<Database>> {
+    let pool = conn.pool();
+    let current = current_database(pool).await?;
+
+    let schemas = introspect_schemas(pool, &current).await?;
+
+    Ok(vec![Database {
+        name: current,
+        is_default: true,
+        schemas,
+    }])
+}
+
+async fn introspect_schemas(pool: &MySqlPool, db_name: &str) -> CellarResult<Vec<Schema>> {
+    let columns_by_table = list_columns(pool, db_name).await?;
+    let primary_keys = list_primary_keys(pool, db_name).await?;
+    let foreign_keys = list_foreign_keys(pool, db_name).await?;
+    let indexes = list_indexes(pool, db_name).await?;
+    let view_defs = list_view_definitions(pool, db_name).await?;
+    let table_rows = list_tables(pool, db_name).await?;
+
+    let mut schema = Schema {
+        name: db_name.to_string(),
+        tables: Vec::new(),
+        views: Vec::new(),
+    };
+
+    for (table_name, is_view) in table_rows {
+        let key = (db_name.to_string(), table_name.clone());
+        let cols = columns_by_table.get(&key).cloned().unwrap_or_default();
+        if is_view {
+            let definition = view_defs.get(&key).cloned();
+            schema.views.push(View {
+                name: table_name,
+                schema: db_name.to_string(),
+                columns: cols,
+                definition,
+            });
+        } else {
+            let pk = primary_keys.get(&key).cloned().unwrap_or_default();
+            let fks = foreign_keys.get(&key).cloned().unwrap_or_default();
+            let idxs = indexes.get(&key).cloned().unwrap_or_default();
+            let cols = mark_primary_keys(cols, &pk);
+            schema.tables.push(Table {
+                name: table_name,
+                schema: db_name.to_string(),
+                row_count: None,
+                columns: cols,
+                primary_key: pk,
+                foreign_keys: fks,
+                indexes: idxs,
+            });
+        }
+    }
+
+    Ok(vec![schema])
+}
+
+fn mark_primary_keys(mut cols: Vec<Column>, pk: &[String]) -> Vec<Column> {
+    for c in cols.iter_mut() {
+        if pk.iter().any(|p| p == &c.name) {
+            c.is_primary_key = true;
+        }
+    }
+    cols
+}
+
+async fn current_database(pool: &MySqlPool) -> CellarResult<String> {
+    let row = sqlx::query("SELECT DATABASE() AS d")
+        .fetch_one(pool)
+        .await
+        .map_err(intro_err)?;
+    row.try_get::<String, _>("d").map_err(intro_err)
+}
+
+async fn list_tables(pool: &MySqlPool, db_name: &str) -> CellarResult<Vec<(String, bool)>> {
+    let rows = sqlx::query(
+        "SELECT TABLE_NAME, TABLE_TYPE \
+         FROM information_schema.tables \
+         WHERE TABLE_SCHEMA = ? \
+         ORDER BY TABLE_NAME",
+    )
+    .bind(db_name)
+    .fetch_all(pool)
+    .await
+    .map_err(intro_err)?;
+
+    rows.into_iter()
+        .map(|r| {
+            let name: String = r.try_get("TABLE_NAME").map_err(intro_err)?;
+            let kind: String = r.try_get("TABLE_TYPE").map_err(intro_err)?;
+            let is_view = kind == "VIEW";
+            Ok((name, is_view))
+        })
+        .collect()
+}
+
+type ColMap = BTreeMap<(String, String), Vec<Column>>;
+
+async fn list_columns(pool: &MySqlPool, db_name: &str) -> CellarResult<ColMap> {
+    let rows = sqlx::query(
+        "SELECT TABLE_NAME, COLUMN_NAME, DATA_TYPE, COLUMN_TYPE, \
+                IS_NULLABLE, COLUMN_DEFAULT, ORDINAL_POSITION \
+         FROM information_schema.columns \
+         WHERE TABLE_SCHEMA = ? \
+         ORDER BY TABLE_NAME, ORDINAL_POSITION",
+    )
+    .bind(db_name)
+    .fetch_all(pool)
+    .await
+    .map_err(intro_err)?;
+
+    let mut out: ColMap = BTreeMap::new();
+    for r in rows {
+        let table: String = r.try_get("TABLE_NAME").map_err(intro_err)?;
+        let column: String = r.try_get("COLUMN_NAME").map_err(intro_err)?;
+        let data_type: String = r.try_get("COLUMN_TYPE").map_err(intro_err)?;
+        let nullable: String = r.try_get("IS_NULLABLE").map_err(intro_err)?;
+        let default: Option<String> = r.try_get("COLUMN_DEFAULT").map_err(intro_err)?;
+        let ordinal: i64 = r.try_get("ORDINAL_POSITION").map_err(intro_err)?;
+        out.entry((db_name.to_string(), table))
+            .or_default()
+            .push(Column {
+                name: column,
+                data_type,
+                nullable: nullable == "YES",
+                default,
+                is_primary_key: false,
+                ordinal: ordinal as u32,
+                comment: None,
+            });
+    }
+    Ok(out)
+}
+
+type KeyMap = BTreeMap<(String, String), Vec<String>>;
+
+async fn list_primary_keys(pool: &MySqlPool, db_name: &str) -> CellarResult<KeyMap> {
+    let rows = sqlx::query(
+        "SELECT TABLE_NAME, COLUMN_NAME \
+         FROM information_schema.key_column_usage \
+         WHERE TABLE_SCHEMA = ? AND CONSTRAINT_NAME = 'PRIMARY' \
+         ORDER BY TABLE_NAME, ORDINAL_POSITION",
+    )
+    .bind(db_name)
+    .fetch_all(pool)
+    .await
+    .map_err(intro_err)?;
+
+    let mut out: KeyMap = BTreeMap::new();
+    for r in rows {
+        let table: String = r.try_get("TABLE_NAME").map_err(intro_err)?;
+        let col: String = r.try_get("COLUMN_NAME").map_err(intro_err)?;
+        out.entry((db_name.to_string(), table))
+            .or_default()
+            .push(col);
+    }
+    Ok(out)
+}
+
+type FkMap = BTreeMap<(String, String), Vec<ForeignKey>>;
+
+async fn list_foreign_keys(pool: &MySqlPool, db_name: &str) -> CellarResult<FkMap> {
+    let rows = sqlx::query(
+        "SELECT TABLE_NAME, CONSTRAINT_NAME, COLUMN_NAME, \
+                REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME \
+         FROM information_schema.key_column_usage \
+         WHERE TABLE_SCHEMA = ? AND REFERENCED_TABLE_NAME IS NOT NULL \
+         ORDER BY TABLE_NAME, CONSTRAINT_NAME, ORDINAL_POSITION",
+    )
+    .bind(db_name)
+    .fetch_all(pool)
+    .await
+    .map_err(intro_err)?;
+
+    let mut by_constraint: BTreeMap<(String, String), ForeignKey> = BTreeMap::new();
+    for r in rows {
+        let table: String = r.try_get("TABLE_NAME").map_err(intro_err)?;
+        let name: String = r.try_get("CONSTRAINT_NAME").map_err(intro_err)?;
+        let local: String = r.try_get("COLUMN_NAME").map_err(intro_err)?;
+        let ref_table: String = r.try_get("REFERENCED_TABLE_NAME").map_err(intro_err)?;
+        let ref_col: String = r.try_get("REFERENCED_COLUMN_NAME").map_err(intro_err)?;
+
+        let entry = by_constraint
+            .entry((table.clone(), name.clone()))
+            .or_insert_with(|| ForeignKey {
+                name,
+                columns: Vec::new(),
+                referenced_schema: db_name.to_string(),
+                referenced_table: ref_table,
+                referenced_columns: Vec::new(),
+            });
+        entry.columns.push(local);
+        entry.referenced_columns.push(ref_col);
+    }
+
+    let mut out: FkMap = BTreeMap::new();
+    for ((table, _), fk) in by_constraint {
+        out.entry((db_name.to_string(), table))
+            .or_default()
+            .push(fk);
+    }
+    Ok(out)
+}
+
+type IdxMap = BTreeMap<(String, String), Vec<Index>>;
+
+async fn list_indexes(pool: &MySqlPool, db_name: &str) -> CellarResult<IdxMap> {
+    let rows = sqlx::query(
+        "SELECT TABLE_NAME, INDEX_NAME, COLUMN_NAME, \
+                NON_UNIQUE, SEQ_IN_INDEX \
+         FROM information_schema.statistics \
+         WHERE TABLE_SCHEMA = ? \
+         ORDER BY TABLE_NAME, INDEX_NAME, SEQ_IN_INDEX",
+    )
+    .bind(db_name)
+    .fetch_all(pool)
+    .await
+    .map_err(intro_err)?;
+
+    let mut by_idx: BTreeMap<(String, String, bool), Index> = BTreeMap::new();
+    for r in rows {
+        let table: String = r.try_get("TABLE_NAME").map_err(intro_err)?;
+        let name: String = r.try_get("INDEX_NAME").map_err(intro_err)?;
+        let col: String = r.try_get("COLUMN_NAME").map_err(intro_err)?;
+        let non_unique: i64 = r.try_get("NON_UNIQUE").map_err(intro_err)?;
+        let unique = non_unique == 0;
+        let primary = name == "PRIMARY";
+        let entry = by_idx
+            .entry((table, name.clone(), primary))
+            .or_insert_with(|| Index {
+                name,
+                columns: Vec::new(),
+                unique,
+                primary,
+            });
+        entry.columns.push(col);
+    }
+
+    let mut out: IdxMap = BTreeMap::new();
+    for ((table, _, _), idx) in by_idx {
+        out.entry((db_name.to_string(), table))
+            .or_default()
+            .push(idx);
+    }
+    Ok(out)
+}
+
+async fn list_view_definitions(
+    pool: &MySqlPool,
+    db_name: &str,
+) -> CellarResult<BTreeMap<(String, String), String>> {
+    let rows = sqlx::query(
+        "SELECT TABLE_NAME, VIEW_DEFINITION \
+         FROM information_schema.views \
+         WHERE TABLE_SCHEMA = ?",
+    )
+    .bind(db_name)
+    .fetch_all(pool)
+    .await
+    .map_err(intro_err)?;
+
+    let mut out = BTreeMap::new();
+    for r in rows {
+        let table: String = r.try_get("TABLE_NAME").map_err(intro_err)?;
+        let def: Option<String> = r.try_get("VIEW_DEFINITION").map_err(intro_err)?;
+        if let Some(d) = def {
+            out.insert((db_name.to_string(), table), d);
+        }
+    }
+    Ok(out)
+}
+
+fn intro_err(e: sqlx::Error) -> CellarError {
+    crate::connect::map_sqlx_err_for_runtime(e, "schema introspection", CellarError::introspection)
+}

--- a/crates/cellar-drivers/mysql/src/lib.rs
+++ b/crates/cellar-drivers/mysql/src/lib.rs
@@ -1,0 +1,73 @@
+//! MySQL driver for Cellar, built on `sqlx`. Implements [`Driver`] for the
+//! MySQL engine: pooled connect, `information_schema` introspection, and
+//! materialized query execution with type-aware cell decoding.
+
+use async_trait::async_trait;
+use cellar_core::driver::{Connection, ConnectionConfig, Driver, Engine};
+use cellar_core::error::CellarResult;
+use cellar_core::query::{PlanMode, Query, QueryPlan, QueryResult, TableBrowseRequest};
+use cellar_core::schema::{Database, Table};
+
+mod connect;
+mod decode;
+mod introspect;
+mod query;
+mod table_browse;
+
+pub use connect::{open_pool, MySqlConnection};
+
+/// Zero-sized handle. Construct once per process and reuse.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct MySqlDriver;
+
+impl MySqlDriver {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+pub async fn browse_table(
+    conn: &dyn Connection,
+    request: &TableBrowseRequest,
+    table: &Table,
+) -> CellarResult<QueryResult> {
+    let mysql = connect::as_mysql(conn)?;
+    table_browse::browse_table(mysql, request, table).await
+}
+
+#[async_trait]
+impl Driver for MySqlDriver {
+    fn engine(&self) -> Engine {
+        Engine::MySql
+    }
+
+    async fn connect(
+        &self,
+        config: &ConnectionConfig,
+        password: Option<&str>,
+    ) -> CellarResult<Box<dyn Connection>> {
+        let mysql = open_pool(config, password).await?;
+        Ok(Box::new(mysql))
+    }
+
+    async fn introspect(&self, conn: &dyn Connection) -> CellarResult<Vec<Database>> {
+        let mysql = connect::as_mysql(conn)?;
+        introspect::introspect(mysql).await
+    }
+
+    async fn execute_query(&self, conn: &dyn Connection, q: &Query) -> CellarResult<QueryResult> {
+        let mysql = connect::as_mysql(conn)?;
+        query::execute_query(mysql, q).await
+    }
+
+    async fn explain_query(
+        &self,
+        _conn: &dyn Connection,
+        _q: &Query,
+        _mode: PlanMode,
+    ) -> CellarResult<QueryPlan> {
+        Err(cellar_core::error::CellarError::invalid_config(
+            "MySQL execution plans are not available yet",
+        ))
+    }
+}

--- a/crates/cellar-drivers/mysql/src/query.rs
+++ b/crates/cellar-drivers/mysql/src/query.rs
@@ -17,17 +17,26 @@ pub async fn execute_query(conn: &MySqlConnection, query: &Query) -> CellarResul
     let offset = query.offset.unwrap_or(0) as usize;
     let started = Instant::now();
 
-    let mut stream = sqlx::query(&query.sql).fetch(pool);
+    // fetch_many (vs fetch) also yields the command-complete arm, which carries
+    // the affected-row count for DML (INSERT/UPDATE/DELETE). fetch alone drops
+    // it, so those statements would never report a count.
+    #[allow(deprecated)]
+    let mut stream = sqlx::query(&query.sql).fetch_many(pool);
     let mut columns: Option<Vec<ColumnMeta>> = None;
     let mut rows: Vec<Row> = Vec::with_capacity(max_rows.min(10_000));
     let mut truncated = false;
     let mut rows_seen: usize = 0;
+    let mut rows_affected: Option<u64> = None;
 
-    while let Some(r) = stream
-        .try_next()
-        .await
-        .map_err(query_sqlx_err)?
-    {
+    while let Some(item) = stream.try_next().await.map_err(query_sqlx_err)? {
+        let r = match item {
+            sqlx::Either::Left(done) => {
+                rows_affected = Some(rows_affected.unwrap_or(0) + done.rows_affected());
+                continue;
+            }
+            sqlx::Either::Right(row) => row,
+        };
+
         if columns.is_none() {
             columns = Some(
                 r.columns()
@@ -59,6 +68,11 @@ pub async fn execute_query(conn: &MySqlConnection, query: &Query) -> CellarResul
         rows.push(cells);
     }
 
+    // Only surface an affected count for statements without a result set
+    // (INSERT/UPDATE/DELETE/DDL). For SELECTs the count is just the row count
+    // and the UI would mislabel it as "N rows affected".
+    let rows_affected = if columns.is_none() { rows_affected } else { None };
+
     Ok(QueryResult {
         columns: columns.unwrap_or_default(),
         rows,
@@ -66,7 +80,7 @@ pub async fn execute_query(conn: &MySqlConnection, query: &Query) -> CellarResul
         notice_capture: NoticeCapture::unsupported(
             "MySQL does not expose server notices through the sqlx query path.",
         ),
-        rows_affected: None,
+        rows_affected,
         duration_ms: started.elapsed().as_millis() as u64,
         truncated,
         total_rows: None,

--- a/crates/cellar-drivers/mysql/src/query.rs
+++ b/crates/cellar-drivers/mysql/src/query.rs
@@ -1,0 +1,78 @@
+use std::time::Instant;
+
+use cellar_core::error::CellarResult;
+use cellar_core::query::{NoticeCapture, Query, QueryResult};
+use cellar_core::value::{ColumnMeta, Row};
+use futures::TryStreamExt;
+use sqlx::{Column as _, Row as _, TypeInfo as _};
+
+use crate::connect::MySqlConnection;
+use crate::decode::decode_cell;
+
+const DEFAULT_MAX_ROWS: u32 = 500;
+
+pub async fn execute_query(conn: &MySqlConnection, query: &Query) -> CellarResult<QueryResult> {
+    let pool = conn.pool();
+    let max_rows = query.max_rows.unwrap_or(DEFAULT_MAX_ROWS) as usize;
+    let offset = query.offset.unwrap_or(0) as usize;
+    let started = Instant::now();
+
+    let mut stream = sqlx::query(&query.sql).fetch(pool);
+    let mut columns: Option<Vec<ColumnMeta>> = None;
+    let mut rows: Vec<Row> = Vec::with_capacity(max_rows.min(10_000));
+    let mut truncated = false;
+    let mut rows_seen: usize = 0;
+
+    while let Some(r) = stream
+        .try_next()
+        .await
+        .map_err(query_sqlx_err)?
+    {
+        if columns.is_none() {
+            columns = Some(
+                r.columns()
+                    .iter()
+                    .map(|c| ColumnMeta {
+                        name: c.name().to_string(),
+                        data_type: c.type_info().name().to_string().to_lowercase(),
+                        nullable: true,
+                    })
+                    .collect(),
+            );
+        }
+
+        if rows_seen < offset {
+            rows_seen += 1;
+            continue;
+        }
+        rows_seen += 1;
+
+        if rows.len() >= max_rows {
+            truncated = true;
+            break;
+        }
+
+        let mut cells: Row = Vec::with_capacity(r.columns().len());
+        for i in 0..r.columns().len() {
+            cells.push(decode_cell(&r, i)?);
+        }
+        rows.push(cells);
+    }
+
+    Ok(QueryResult {
+        columns: columns.unwrap_or_default(),
+        rows,
+        notices: Vec::new(),
+        notice_capture: NoticeCapture::unsupported(
+            "MySQL does not expose server notices through the sqlx query path.",
+        ),
+        rows_affected: None,
+        duration_ms: started.elapsed().as_millis() as u64,
+        truncated,
+        total_rows: None,
+    })
+}
+
+fn query_sqlx_err(err: sqlx::Error) -> cellar_core::error::CellarError {
+    crate::connect::map_sqlx_err_for_runtime(err, "query execution", cellar_core::error::CellarError::query)
+}

--- a/crates/cellar-drivers/mysql/src/table_browse.rs
+++ b/crates/cellar-drivers/mysql/src/table_browse.rs
@@ -289,7 +289,9 @@ fn push_filter<'args>(
         | TableFilterOperator::LessThan
         | TableFilterOperator::LessThanOrEqual => {
             let value = require_value(filter)?;
-            if !matches!(kind, ColumnKind::Numeric) {
+            // Range comparisons are valid for numeric and temporal columns;
+            // MySQL coerces the bound string for DATE/TIME/DATETIME.
+            if !matches!(kind, ColumnKind::Numeric | ColumnKind::Temporal) {
                 return Err(unsupported(column, filter.operator));
             }
             let operator = match filter.operator {
@@ -488,6 +490,21 @@ mod tests {
             "SELECT * FROM `app`.`users` WHERE `email` LIKE CONCAT('%', ?, '%') ORDER BY `id` LIMIT ?"
         );
         assert!(!sql.contains("o'reilly"));
+    }
+
+    #[test]
+    fn allows_range_comparison_on_temporal_column() {
+        let mut req = request();
+        req.filters.push(TableFilterClause {
+            column: "created_at".into(),
+            operator: TableFilterOperator::GreaterThan,
+            value: Some("2024-01-01".into()),
+        });
+        let sql = sql_for(&req).expect("sql");
+        assert_eq!(
+            sql,
+            "SELECT * FROM `app`.`users` WHERE `created_at` > ? ORDER BY `id` LIMIT ?"
+        );
     }
 
     #[test]

--- a/crates/cellar-drivers/mysql/src/table_browse.rs
+++ b/crates/cellar-drivers/mysql/src/table_browse.rs
@@ -317,17 +317,25 @@ enum ColumnKind {
 }
 
 impl ColumnKind {
+    /// Classify a column from its `information_schema.COLUMN_TYPE`, e.g.
+    /// `"varchar(255)"`, `"int(10) unsigned"`, `"decimal(10,2)"`,
+    /// `"enum('a','b')"`. We key off the leading base-type token, ignoring the
+    /// length/enum-value parenthetical and the trailing `unsigned`/`zerofill`
+    /// attributes.
     fn from_mysql_type(type_name: &str) -> Self {
-        let t = type_name.to_uppercase();
-        match t.as_str() {
-            "TINYINT" | "SMALLINT" | "MEDIUMINT" | "INT" | "INTEGER" | "BIGINT" | "FLOAT"
-            | "DOUBLE" | "DECIMAL" | "NUMERIC" | "NEWDECIMAL" | "UNSIGNED TINYINT"
-            | "UNSIGNED SMALLINT" | "UNSIGNED INT" | "UNSIGNED INTEGER" | "UNSIGNED BIGINT" => {
+        let lowered = type_name.to_ascii_lowercase();
+        let base = lowered
+            .split(['(', ' '])
+            .next()
+            .unwrap_or(lowered.as_str());
+        match base {
+            "tinyint" | "smallint" | "mediumint" | "int" | "integer" | "bigint" | "float"
+            | "double" | "real" | "decimal" | "numeric" | "dec" | "fixed" | "bit" | "year" => {
                 ColumnKind::Numeric
             }
-            "CHAR" | "VARCHAR" | "TEXT" | "TINYTEXT" | "MEDIUMTEXT" | "LONGTEXT" | "ENUM"
-            | "SET" => ColumnKind::Text,
-            "DATE" | "TIME" | "DATETIME" | "TIMESTAMP" => ColumnKind::Temporal,
+            "char" | "varchar" | "text" | "tinytext" | "mediumtext" | "longtext" | "enum"
+            | "set" => ColumnKind::Text,
+            "date" | "time" | "datetime" | "timestamp" => ColumnKind::Temporal,
             _ => ColumnKind::Other,
         }
     }
@@ -384,4 +392,196 @@ fn push_qualified_table<'args>(
 
 fn to_query_err(err: TableBrowseError) -> CellarError {
     CellarError::query(err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cellar_core::query::TableSortClause;
+
+    fn request() -> TableBrowseRequest {
+        TableBrowseRequest {
+            connection_id: "conn".into(),
+            database: Some("app".into()),
+            schema: "app".into(),
+            table: "users".into(),
+            limit: Some(500),
+            offset: None,
+            sorts: Vec::new(),
+            filters: Vec::new(),
+            primary_key_fallback_ordering: true,
+            include_total: false,
+        }
+    }
+
+    fn table() -> Table {
+        Table {
+            name: "users".into(),
+            schema: "app".into(),
+            row_count: None,
+            primary_key: vec!["id".into()],
+            foreign_keys: Vec::new(),
+            indexes: Vec::new(),
+            columns: vec![
+                column("id", "bigint(20)", true),
+                column("email", "varchar(255)", false),
+                column("age", "int(11)", false),
+                column("created_at", "datetime", false),
+            ],
+        }
+    }
+
+    fn column(name: &str, data_type: &str, primary: bool) -> Column {
+        Column {
+            name: name.into(),
+            data_type: data_type.into(),
+            nullable: true,
+            default: None,
+            is_primary_key: primary,
+            ordinal: 1,
+            comment: None,
+        }
+    }
+
+    fn sql_for(request: &TableBrowseRequest) -> Result<String, TableBrowseError> {
+        Ok(build_table_browse_query(request, &table())?
+            .sql()
+            .to_string())
+    }
+
+    #[test]
+    fn backtick_quotes_and_uses_primary_key_fallback_ordering() {
+        let sql = sql_for(&request()).expect("sql");
+        assert_eq!(sql, "SELECT * FROM `app`.`users` ORDER BY `id` LIMIT ?");
+    }
+
+    #[test]
+    fn doubles_embedded_backticks() {
+        let mut req = request();
+        req.schema = "odd`schema".into();
+        req.table = "user`data".into();
+        let mut meta = table();
+        meta.schema = req.schema.clone();
+        meta.name = req.table.clone();
+
+        let sql = build_table_browse_query(&req, &meta)
+            .expect("sql")
+            .sql()
+            .to_string();
+        assert_eq!(
+            sql,
+            "SELECT * FROM `odd``schema`.`user``data` ORDER BY `id` LIMIT ?"
+        );
+    }
+
+    #[test]
+    fn binds_contains_value_instead_of_inlining() {
+        let mut req = request();
+        req.filters.push(TableFilterClause {
+            column: "email".into(),
+            operator: TableFilterOperator::Contains,
+            value: Some("o'reilly".into()),
+        });
+        let sql = sql_for(&req).expect("sql");
+        assert_eq!(
+            sql,
+            "SELECT * FROM `app`.`users` WHERE `email` LIKE CONCAT('%', ?, '%') ORDER BY `id` LIMIT ?"
+        );
+        assert!(!sql.contains("o'reilly"));
+    }
+
+    #[test]
+    fn comparison_on_numeric_column_with_is_null_and_sort() {
+        let mut req = request();
+        req.filters.push(TableFilterClause {
+            column: "age".into(),
+            operator: TableFilterOperator::GreaterThanOrEqual,
+            value: Some("21".into()),
+        });
+        req.filters.push(TableFilterClause {
+            column: "created_at".into(),
+            operator: TableFilterOperator::IsNull,
+            value: None,
+        });
+        req.sorts.push(TableSortClause {
+            column: "email".into(),
+            direction: SortDirection::Desc,
+        });
+        let sql = sql_for(&req).expect("sql");
+        assert_eq!(
+            sql,
+            "SELECT * FROM `app`.`users` WHERE `age` >= ? AND `created_at` IS NULL ORDER BY `email` DESC LIMIT ?"
+        );
+    }
+
+    #[test]
+    fn rejects_comparison_on_text_column() {
+        let mut req = request();
+        req.filters.push(TableFilterClause {
+            column: "email".into(),
+            operator: TableFilterOperator::GreaterThan,
+            value: Some("a".into()),
+        });
+        let err = match build_table_browse_query(&req, &table()) {
+            Err(e) => e,
+            Ok(_) => panic!("expected the comparison to be rejected"),
+        };
+        assert!(matches!(
+            err,
+            TableBrowseError::UnsupportedOperator { .. }
+        ));
+    }
+
+    #[test]
+    fn rejects_unknown_column() {
+        let mut req = request();
+        req.filters.push(TableFilterClause {
+            column: "ghost".into(),
+            operator: TableFilterOperator::Equals,
+            value: Some("x".into()),
+        });
+        let err = match build_table_browse_query(&req, &table()) {
+            Err(e) => e,
+            Ok(_) => panic!("expected the unknown column to be rejected"),
+        };
+        assert!(matches!(err, TableBrowseError::UnknownColumn(c) if c == "ghost"));
+    }
+
+    #[test]
+    fn count_query_omits_limit_and_order() {
+        let mut req = request();
+        req.filters.push(TableFilterClause {
+            column: "age".into(),
+            operator: TableFilterOperator::Equals,
+            value: Some("21".into()),
+        });
+        let sql = build_table_count_query(&req, &table())
+            .expect("sql")
+            .sql()
+            .to_string();
+        assert_eq!(
+            sql,
+            "SELECT count(*) FROM `app`.`users` WHERE `age` = ?"
+        );
+        assert!(!sql.contains("LIMIT"));
+        assert!(!sql.contains("ORDER BY"));
+    }
+
+    #[test]
+    fn column_kind_parses_column_type_modifiers() {
+        assert_eq!(ColumnKind::from_mysql_type("varchar(255)"), ColumnKind::Text);
+        assert_eq!(
+            ColumnKind::from_mysql_type("int(10) unsigned"),
+            ColumnKind::Numeric
+        );
+        assert_eq!(
+            ColumnKind::from_mysql_type("decimal(10,2)"),
+            ColumnKind::Numeric
+        );
+        assert_eq!(
+            ColumnKind::from_mysql_type("enum('a','b')"),
+            ColumnKind::Text
+        );
+        assert_eq!(ColumnKind::from_mysql_type("datetime"), ColumnKind::Temporal);
+    }
 }

--- a/crates/cellar-drivers/mysql/src/table_browse.rs
+++ b/crates/cellar-drivers/mysql/src/table_browse.rs
@@ -1,0 +1,387 @@
+use std::time::Instant;
+
+use cellar_core::error::CellarError;
+use cellar_core::error::CellarResult;
+use cellar_core::query::{
+    NoticeCapture, QueryResult, SortDirection, TableBrowseRequest, TableFilterClause,
+    TableFilterOperator,
+};
+use cellar_core::schema::{Column, Table};
+use cellar_core::value::{ColumnMeta, Row};
+use futures::TryStreamExt;
+use sqlx::{Column as _, MySql, QueryBuilder, Row as _, TypeInfo as _};
+use thiserror::Error;
+
+use crate::connect::MySqlConnection;
+use crate::decode::decode_cell;
+
+const DEFAULT_TABLE_BROWSE_ROWS: u32 = 500;
+const MAX_TABLE_BROWSE_ROWS: u32 = 2000;
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum TableBrowseError {
+    #[error("schema name is empty")]
+    EmptySchema,
+    #[error("table name is empty")]
+    EmptyTable,
+    #[error("table metadata does not match requested table")]
+    TableMetadataMismatch,
+    #[error("table browse limit must be greater than zero")]
+    EmptyLimit,
+    #[error("table browse limit cannot exceed {MAX_TABLE_BROWSE_ROWS} rows per page")]
+    LimitTooLarge,
+    #[error("table browse offset is too large")]
+    OffsetTooLarge,
+    #[error("unknown column {0}")]
+    UnknownColumn(String),
+    #[error("operator {operator:?} requires a value for column {column}")]
+    MissingValue {
+        column: String,
+        operator: TableFilterOperator,
+    },
+    #[error("operator {operator:?} does not accept a value for column {column}")]
+    UnexpectedValue {
+        column: String,
+        operator: TableFilterOperator,
+    },
+    #[error("operator {operator:?} is not supported for column {column} ({data_type})")]
+    UnsupportedOperator {
+        column: String,
+        data_type: String,
+        operator: TableFilterOperator,
+    },
+}
+
+pub async fn browse_table(
+    conn: &MySqlConnection,
+    request: &TableBrowseRequest,
+    table: &Table,
+) -> CellarResult<QueryResult> {
+    let max_rows = normalized_limit(request).map_err(to_query_err)?;
+    let pool = conn.pool();
+
+    let total_rows: Option<u64> = if request.include_total {
+        let count: i64 = build_table_count_query(request, table)
+            .map_err(to_query_err)?
+            .build_query_scalar()
+            .fetch_one(pool)
+            .await
+            .map_err(|e| CellarError::query(e.to_string()))?;
+        Some(count.max(0) as u64)
+    } else {
+        None
+    };
+
+    let mut builder = build_table_browse_query(request, table).map_err(to_query_err)?;
+    let started = Instant::now();
+    let mut stream = builder.build().fetch(pool);
+    let mut columns: Option<Vec<ColumnMeta>> = None;
+    let mut materialized: Vec<Row> = Vec::with_capacity(max_rows as usize);
+    let mut truncated = false;
+
+    while let Some(r) = stream
+        .try_next()
+        .await
+        .map_err(|e| CellarError::query(e.to_string()))?
+    {
+        if columns.is_none() {
+            columns = Some(
+                r.columns()
+                    .iter()
+                    .map(|c| ColumnMeta {
+                        name: c.name().to_string(),
+                        data_type: c.type_info().name().to_string().to_lowercase(),
+                        nullable: true,
+                    })
+                    .collect(),
+            );
+        }
+
+        if materialized.len() >= max_rows as usize {
+            truncated = true;
+            break;
+        }
+
+        let mut cells: Row = Vec::with_capacity(r.columns().len());
+        for i in 0..r.columns().len() {
+            cells.push(decode_cell(&r, i)?);
+        }
+        materialized.push(cells);
+    }
+
+    Ok(QueryResult {
+        columns: columns.unwrap_or_default(),
+        rows: materialized,
+        notices: Vec::new(),
+        notice_capture: NoticeCapture::unsupported(
+            "MySQL does not expose server notices through the sqlx query path.",
+        ),
+        rows_affected: None,
+        duration_ms: started.elapsed().as_millis() as u64,
+        truncated,
+        total_rows,
+    })
+}
+
+fn build_table_count_query<'args>(
+    request: &'args TableBrowseRequest,
+    table: &Table,
+) -> Result<QueryBuilder<'args, MySql>, TableBrowseError> {
+    for filter in &request.filters {
+        column_for(table, &filter.column)?;
+    }
+
+    let mut builder = QueryBuilder::<MySql>::new("SELECT count(*) FROM ");
+    push_qualified_table(&mut builder, &request.schema, &request.table);
+
+    if !request.filters.is_empty() {
+        builder.push(" WHERE ");
+        for (i, filter) in request.filters.iter().enumerate() {
+            if i > 0 {
+                builder.push(" AND ");
+            }
+            push_filter(&mut builder, filter, table)?;
+        }
+    }
+
+    Ok(builder)
+}
+
+fn build_table_browse_query<'args>(
+    request: &'args TableBrowseRequest,
+    table: &Table,
+) -> Result<QueryBuilder<'args, MySql>, TableBrowseError> {
+    validate_table_request(request, table)?;
+
+    let mut builder = QueryBuilder::<MySql>::new("SELECT * FROM ");
+    push_qualified_table(&mut builder, &request.schema, &request.table);
+
+    if !request.filters.is_empty() {
+        builder.push(" WHERE ");
+        for (i, filter) in request.filters.iter().enumerate() {
+            if i > 0 {
+                builder.push(" AND ");
+            }
+            push_filter(&mut builder, filter, table)?;
+        }
+    }
+
+    if !request.sorts.is_empty() {
+        builder.push(" ORDER BY ");
+        for (i, sort) in request.sorts.iter().enumerate() {
+            if i > 0 {
+                builder.push(", ");
+            }
+            let column = column_for(table, &sort.column)?;
+            push_ident(&mut builder, &column.name);
+            match sort.direction {
+                SortDirection::Asc => builder.push(" ASC"),
+                SortDirection::Desc => builder.push(" DESC"),
+            };
+        }
+    } else if request.primary_key_fallback_ordering && !table.primary_key.is_empty() {
+        builder.push(" ORDER BY ");
+        for (i, column_name) in table.primary_key.iter().enumerate() {
+            if i > 0 {
+                builder.push(", ");
+            }
+            let column = column_for(table, column_name)?;
+            push_ident(&mut builder, &column.name);
+        }
+    }
+
+    let fetch_limit = normalized_limit(request)? + 1;
+    builder.push(" LIMIT ");
+    builder.push_bind(fetch_limit as i64);
+    if let Some(offset) = normalized_offset(request)? {
+        builder.push(" OFFSET ");
+        builder.push_bind(offset as i64);
+    }
+
+    Ok(builder)
+}
+
+fn validate_table_request(
+    request: &TableBrowseRequest,
+    table: &Table,
+) -> Result<(), TableBrowseError> {
+    if request.schema.trim().is_empty() {
+        return Err(TableBrowseError::EmptySchema);
+    }
+    if request.table.trim().is_empty() {
+        return Err(TableBrowseError::EmptyTable);
+    }
+    if table.schema != request.schema || table.name != request.table {
+        return Err(TableBrowseError::TableMetadataMismatch);
+    }
+    normalized_limit(request)?;
+    normalized_offset(request)?;
+    for sort in &request.sorts {
+        column_for(table, &sort.column)?;
+    }
+    for filter in &request.filters {
+        column_for(table, &filter.column)?;
+    }
+    Ok(())
+}
+
+fn normalized_limit(request: &TableBrowseRequest) -> Result<u32, TableBrowseError> {
+    let limit = request.limit.unwrap_or(DEFAULT_TABLE_BROWSE_ROWS);
+    if limit == 0 {
+        return Err(TableBrowseError::EmptyLimit);
+    }
+    if limit > MAX_TABLE_BROWSE_ROWS {
+        return Err(TableBrowseError::LimitTooLarge);
+    }
+    Ok(limit)
+}
+
+fn normalized_offset(request: &TableBrowseRequest) -> Result<Option<u32>, TableBrowseError> {
+    match request.offset {
+        Some(offset) if offset > i32::MAX as u32 => Err(TableBrowseError::OffsetTooLarge),
+        Some(0) | None => Ok(None),
+        Some(offset) => Ok(Some(offset)),
+    }
+}
+
+fn push_filter<'args>(
+    builder: &mut QueryBuilder<'args, MySql>,
+    filter: &'args TableFilterClause,
+    table: &Table,
+) -> Result<(), TableBrowseError> {
+    let column = column_for(table, &filter.column)?;
+    let kind = ColumnKind::from_mysql_type(&column.data_type);
+
+    match filter.operator {
+        TableFilterOperator::IsNull => {
+            reject_value(filter)?;
+            push_ident(builder, &column.name);
+            builder.push(" IS NULL");
+        }
+        TableFilterOperator::IsNotNull => {
+            reject_value(filter)?;
+            push_ident(builder, &column.name);
+            builder.push(" IS NOT NULL");
+        }
+        TableFilterOperator::Contains => {
+            let value = require_value(filter)?;
+            if !matches!(kind, ColumnKind::Text) {
+                return Err(unsupported(column, filter.operator));
+            }
+            push_ident(builder, &column.name);
+            builder.push(" LIKE CONCAT('%', ");
+            builder.push_bind(value);
+            builder.push(", '%')");
+        }
+        TableFilterOperator::Equals | TableFilterOperator::NotEquals => {
+            let value = require_value(filter)?;
+            let operator = if filter.operator == TableFilterOperator::Equals {
+                " = "
+            } else {
+                " <> "
+            };
+            push_ident(builder, &column.name);
+            builder.push(operator);
+            builder.push_bind(value);
+        }
+        TableFilterOperator::GreaterThan
+        | TableFilterOperator::GreaterThanOrEqual
+        | TableFilterOperator::LessThan
+        | TableFilterOperator::LessThanOrEqual => {
+            let value = require_value(filter)?;
+            if !matches!(kind, ColumnKind::Numeric) {
+                return Err(unsupported(column, filter.operator));
+            }
+            let operator = match filter.operator {
+                TableFilterOperator::GreaterThan => " > ",
+                TableFilterOperator::GreaterThanOrEqual => " >= ",
+                TableFilterOperator::LessThan => " < ",
+                TableFilterOperator::LessThanOrEqual => " <= ",
+                _ => unreachable!(),
+            };
+            push_ident(builder, &column.name);
+            builder.push(operator);
+            builder.push_bind(value);
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ColumnKind {
+    Numeric,
+    Text,
+    Temporal,
+    Other,
+}
+
+impl ColumnKind {
+    fn from_mysql_type(type_name: &str) -> Self {
+        let t = type_name.to_uppercase();
+        match t.as_str() {
+            "TINYINT" | "SMALLINT" | "MEDIUMINT" | "INT" | "INTEGER" | "BIGINT" | "FLOAT"
+            | "DOUBLE" | "DECIMAL" | "NUMERIC" | "NEWDECIMAL" | "UNSIGNED TINYINT"
+            | "UNSIGNED SMALLINT" | "UNSIGNED INT" | "UNSIGNED INTEGER" | "UNSIGNED BIGINT" => {
+                ColumnKind::Numeric
+            }
+            "CHAR" | "VARCHAR" | "TEXT" | "TINYTEXT" | "MEDIUMTEXT" | "LONGTEXT" | "ENUM"
+            | "SET" => ColumnKind::Text,
+            "DATE" | "TIME" | "DATETIME" | "TIMESTAMP" => ColumnKind::Temporal,
+            _ => ColumnKind::Other,
+        }
+    }
+}
+
+fn column_for<'a>(table: &'a Table, column_name: &str) -> Result<&'a Column, TableBrowseError> {
+    table
+        .columns
+        .iter()
+        .find(|c| c.name == column_name)
+        .ok_or_else(|| TableBrowseError::UnknownColumn(column_name.to_string()))
+}
+
+fn require_value(filter: &TableFilterClause) -> Result<&str, TableBrowseError> {
+    filter.value.as_deref().ok_or_else(|| TableBrowseError::MissingValue {
+        column: filter.column.clone(),
+        operator: filter.operator,
+    })
+}
+
+fn reject_value(filter: &TableFilterClause) -> Result<(), TableBrowseError> {
+    if filter.value.is_some() {
+        return Err(TableBrowseError::UnexpectedValue {
+            column: filter.column.clone(),
+            operator: filter.operator,
+        });
+    }
+    Ok(())
+}
+
+fn unsupported(column: &Column, operator: TableFilterOperator) -> TableBrowseError {
+    TableBrowseError::UnsupportedOperator {
+        column: column.name.clone(),
+        data_type: column.data_type.clone(),
+        operator,
+    }
+}
+
+fn push_ident<'args>(builder: &mut QueryBuilder<'args, MySql>, ident: &str) {
+    builder.push('`');
+    builder.push(ident.replace('`', "``"));
+    builder.push('`');
+}
+
+fn push_qualified_table<'args>(
+    builder: &mut QueryBuilder<'args, MySql>,
+    schema: &str,
+    table: &str,
+) {
+    push_ident(builder, schema);
+    builder.push('.');
+    push_ident(builder, table);
+}
+
+fn to_query_err(err: TableBrowseError) -> CellarError {
+    CellarError::query(err.to_string())
+}


### PR DESCRIPTION
## Summary
Adds a MySQL driver for Cellar (built on sqlx, mirroring the Postgres driver) and wires it end-to-end into the desktop app so MySQL connections are selectable, introspectable, queryable, and browsable.

## What changed
- **New `cellar-driver-mysql` crate**: pooled connect/ping/close with SSL, `information_schema` introspection (tables, views, columns, PKs, FKs, indexes), free-form query execution, and paginated table browse with filtering/sorting. Added to the workspace and the desktop app deps; registered in `state.rs` (`driver_for` + `browse_table`).
- **Type decoding correctness**: unsigned ints use the real `"INT UNSIGNED"` suffix names and decode via `u64` (BIGINT UNSIGNED above `i64::MAX` kept as exact text); all signed widths decode through `i64` (fixes MEDIUMINT overflow); DECIMAL/SET read via the unchecked path to preserve precision.
- **Frontend gating fixes**: the connection dialog and welcome screen hard-coded the enabled engine set, leaving MySQL unselectable and the already-supported Firestore greyed out — both now enable the engines that actually ship. The connection-name placeholder is now engine-aware (`local-mysql`, etc.) instead of always `local-postgres`. Marketing site updated to list MySQL as supported.

## User impact
Users can now create and use MySQL connections: connect, browse the schema tree, run SQL, and page through table data. Firestore is no longer incorrectly shown as unavailable.

## Validation
`cargo check` (workspace) and `cargo test -p cellar-driver-mysql` (8 unit tests) pass; desktop `tsc --noEmit` passes. Not yet smoke-tested against a live MySQL server — grid edits/commit, explain, and cancel are intentionally deferred and return clear "not supported yet" errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New database driver path handles credentials, TLS, and user-generated SQL/filter bindings; large surface area but follows existing Postgres patterns with unit tests on browse SQL generation.
> 
> **Overview**
> Adds **MySQL** as a first-class engine via a new **`cellar-driver-mysql`** crate (sqlx pool, SSL mapping, `information_schema` introspection, ad-hoc SQL execution, and parameterized table browse with filters/sort/PK ordering). The desktop Tauri layer registers **`MySqlDriver`** in **`driver_for`** and routes table browse through the MySQL path with the same connection-eviction behavior as Postgres.
> 
> **UI/marketing** enables MySQL in the connection dialog and welcome empty state (and fixes Firestore being incorrectly disabled on the welcome screen). New connections get per-engine default databases (e.g. **`mysql`** catalog) and engine-aware name placeholders. The marketing site FAQ/chips now list MySQL as supported.
> 
> **Deferred / explicit gaps:** MySQL **`explain_query`** returns “not available yet”; grid commits and query cancel remain Postgres-only at the registry level.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71b0a97afae129688fc6fb125d1c4ba0b02efc0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->