### PR TITLE
feat: remove logo and app name from title bar

### DIFF
--- a/apps/desktop/src/components/TitleBar.tsx
+++ b/apps/desktop/src/components/TitleBar.tsx
@@ -64,27 +64,6 @@ export function TitleBar({
           aria-hidden="true"
           className="pointer-events-none h-full w-[68px] shrink-0"
         />
-        <div className="flex items-center gap-1.5 px-1">
-          <span
-            className="relative h-[14px] w-[14px] rounded-[3px]"
-            style={{
-              background:
-                "linear-gradient(135deg, #c4b5fd 0%, var(--accent) 55%, #6d4ed1 100%)",
-              boxShadow: "0 0 0 1px rgba(0, 0, 0, 0.2) inset",
-            }}
-          >
-            <span
-              className="absolute inset-[2px] rounded-[1px] bg-bg-1"
-              style={{
-                clipPath:
-                  "polygon(0 0, 100% 0, 100% 35%, 35% 35%, 35% 65%, 100% 65%, 100% 100%, 0 100%)",
-              }}
-            />
-          </span>
-          <span className="text-[12px] font-semibold tracking-[0.02em] text-fg-0">
-            Cellar
-          </span>
-        </div>
         {!empty && activeTab && (
           <>
             <div className="mx-0.5 h-4 w-px bg-border-default" />


### PR DESCRIPTION
## Summary
Removes the Cellar logo mark and "Cellar" app-name text from the left side of the title bar to reduce visual clutter.

## What changed
Deleted the logo span (the CSS-drawn purple "C" gradient mark) and the "Cellar" text label from `TitleBar.tsx`. The title bar still reserves space for the macOS traffic lights, followed by the connection/tab info.

## User impact
The top bar no longer shows the logo or app name.

## Validation
Visual change only; no logic affected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change in `TitleBar.tsx`; no logic, state, or behavior affected.
> 
> **Overview**
> **Removes** the left-side branding block from the desktop title bar: the CSS gradient “C” logo mark and the **Cellar** label.
> 
> The **68px** spacer for macOS traffic lights is unchanged. When a tab is active, the bar still shows the connection → database → tab breadcrumb after the divider—only the logo/name cluster is gone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbf7acedd67cde6e326386e970bb8c8f685cdea1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->