### PR TITLE
fix: align title-bar search size with adjacent UI

### DIFF
--- a/apps/desktop/src/components/TitleBar.tsx
+++ b/apps/desktop/src/components/TitleBar.tsx
@@ -115,9 +115,9 @@ export function TitleBar({
       <button
         type="button"
         onClick={onOpenPalette}
-        className="absolute left-1/2 top-1/2 flex h-[22px] min-w-0 w-[320px] max-w-[320px] -translate-x-1/2 -translate-y-1/2 items-center gap-2 rounded-[5px] border border-border-default bg-bg-inset px-2 text-[11px] text-fg-3 transition-[border-color] duration-150 hover:border-border-strong"
+        className="absolute left-1/2 top-1/2 flex h-[24px] min-w-0 w-[320px] max-w-[320px] -translate-x-1/2 -translate-y-1/2 items-center gap-2 rounded-[5px] border border-border-default bg-bg-inset px-2 text-[11.5px] text-fg-3 transition-[border-color] duration-150 hover:border-border-strong"
       >
-        <Icon.search size={11} />
+        <Icon.search size={12} />
         <span className="flex-1 text-left">
           Search tables, columns, queries…
         </span>


### PR DESCRIPTION
## Summary
The command-palette search button in the title bar rendered at `11px` — a step smaller than its neighbors — so it read as undersized against the rest of the app.

## What changed
- `apps/desktop/src/components/TitleBar.tsx`: search button text `11px` → `11.5px` (matches adjacent breadcrumbs and tab labels), search icon `11` → `12`, and height `22px` → `24px` so the larger text isn't cramped.

## User impact
The title-bar search now visually matches the surrounding UI instead of appearing smaller.

## Validation
Change is a CSS/Tailwind-class tweak only; recommend a quick visual check in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only Tailwind class tweaks with no logic, auth, or data changes.
> 
> **Overview**
> The centered **command-palette search** control in the title bar was visually smaller than neighboring breadcrumb labels (`11.5px` text, `12` icons).
> 
> **What changed:** button height `22px` → `24px`, label `11px` → `11.5px`, and search icon `11` → `12` so the search field matches the connection/database/schema chips beside it.
> 
> Pure styling in `TitleBar.tsx`; behavior and `onOpenPalette` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3160cc795794e605b67922f98cdba628851c9e3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->