### PR TITLE
feat: switch database from the title-bar breadcrumb

### DIFF
--- a/apps/desktop/src/components/TitleBar.tsx
+++ b/apps/desktop/src/components/TitleBar.tsx
@@ -1,8 +1,10 @@
+import { useState } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { Icon } from "./icons";
 import { useTabs } from "../state/tabs";
 import { useConnections } from "../state/connections";
 import { ENGINE_META } from "./EngineBadge";
+import { ContextMenu, type ContextMenuState } from "./ContextMenu";
 import type { PanelId, Panels } from "../state/layout";
 
 // WKWebView ignores Electron's `-webkit-app-region`, so window dragging and
@@ -41,11 +43,42 @@ export function TitleBar({
 }) {
   const activeId = useTabs((s) => s.activeId);
   const tabs = useTabs((s) => s.tabs);
+  const setQueryDatabase = useTabs((s) => s.setQueryDatabase);
   const connections = useConnections((s) => s.connections);
+  const byId = useConnections((s) => s.byId);
   const activeTab = tabs.find((t) => t.id === activeId) ?? null;
   const activeConn = activeTab
     ? connections.find((c) => c.id === activeTab.connectionId) ?? null
     : null;
+
+  const [menu, setMenu] = useState<ContextMenuState | null>(null);
+
+  const engineColor = ENGINE_META[activeConn?.engine ?? "postgres"].color;
+  // The database list is loaded per-connection into `byId`, not onto the
+  // connection config itself.
+  const databases = activeTab ? byId[activeTab.connectionId]?.databases ?? [] : [];
+  // Only query tabs can be re-pointed — a table tab is bound to its database.
+  const canSwitchDatabase =
+    activeTab?.kind === "query" && databases.length > 0;
+
+  function openDatabaseMenu(e: React.MouseEvent<HTMLButtonElement>) {
+    if (!activeTab || activeTab.kind !== "query") return;
+    const tabId = activeTab.id;
+    const rect = e.currentTarget.getBoundingClientRect();
+    setMenu({
+      x: rect.left,
+      y: rect.bottom + 4,
+      items: databases.map((db) => ({
+        label: db.name,
+        icon: (
+          <span style={{ color: engineColor }}>
+            {db.name === activeTab.database ? "●" : "○"}
+          </span>
+        ),
+        onClick: () => setQueryDatabase(tabId, db.name),
+      })),
+    });
+  }
 
   return (
     <div
@@ -94,10 +127,23 @@ export function TitleBar({
                 <span>{activeConn?.name ?? activeTab.connectionId}</span>
               </span>
               <Icon.chevronRight size={11} style={{ opacity: 0.4 }} />
-              <span className="inline-flex items-center gap-[5px] whitespace-nowrap rounded-[4px] px-1.5 py-[3px] text-[11.5px] text-fg-1 max-[1080px]:hidden">
-                <span style={{ color: ENGINE_META[activeConn?.engine ?? "postgres"].color }}>●</span>
-                <span>{activeTab.database}</span>
-              </span>
+              {canSwitchDatabase ? (
+                <button
+                  type="button"
+                  onClick={openDatabaseMenu}
+                  title="Switch database"
+                  className="inline-flex items-center gap-[5px] whitespace-nowrap rounded-[4px] px-1.5 py-[3px] text-[11.5px] text-fg-1 transition-colors hover:bg-bg-2 max-[1080px]:hidden"
+                >
+                  <span style={{ color: engineColor }}>●</span>
+                  <span>{activeTab.database}</span>
+                  <Icon.chevronDown size={10} style={{ opacity: 0.5 }} />
+                </button>
+              ) : (
+                <span className="inline-flex items-center gap-[5px] whitespace-nowrap rounded-[4px] px-1.5 py-[3px] text-[11.5px] text-fg-1 max-[1080px]:hidden">
+                  <span style={{ color: engineColor }}>●</span>
+                  <span>{activeTab.database}</span>
+                </span>
+              )}
               <Icon.chevronRight size={11} style={{ opacity: 0.4 }} />
               <span className="inline-flex items-center gap-[5px] whitespace-nowrap rounded-[4px] px-1.5 py-[3px] text-[11.5px] text-fg-1 max-[1080px]:hidden">
                 {activeTab.kind === "query" ? (
@@ -168,6 +214,8 @@ export function TitleBar({
           </button>
         )}
       </div>
+
+      <ContextMenu state={menu} onClose={() => setMenu(null)} />
     </div>
   );
 }

--- a/apps/desktop/src/hooks/useQueryRunner.ts
+++ b/apps/desktop/src/hooks/useQueryRunner.ts
@@ -80,6 +80,27 @@ export function useQueryRunner(tab: QueryTab): QueryRunner {
     };
   }, []);
 
+  // When the tab is re-pointed at a different database (via the title-bar
+  // breadcrumb), invalidate any in-flight run. Its captured token, `source`,
+  // and target database all describe the *previous* database, so bumping
+  // `runToken` makes its completion fall through the staleness guard rather
+  // than writing rows, messages, or an error squiggle into the switched tab.
+  // The completion would otherwise repopulate the results `setQueryDatabase`
+  // just cleared. We also reset local runner state here, since the dropped
+  // completion never reaches the code that would clear it.
+  const prevDatabase = useRef(tab.database);
+  useEffect(() => {
+    if (prevDatabase.current === tab.database) return;
+    prevDatabase.current = tab.database;
+    runToken.current++;
+    activeRun.current = null;
+    loadMoreRef.current = null;
+    setRunning(false);
+    setCancelRequested(false);
+    setErrorLine(null);
+    setCanLoadMore(false);
+  }, [tab.database]);
+
   const clearError = useCallback(() => setErrorLine(null), []);
 
   const executeQuery = useCallback(

--- a/apps/desktop/src/state/tabs.test.ts
+++ b/apps/desktop/src/state/tabs.test.ts
@@ -216,6 +216,37 @@ describe("tab workspace state", () => {
     expect(queryTab().sql).toBe("select 1;");
   });
 
+  it("clears stale results when switching a query tab's database", () => {
+    const id = useTabs.getState().newQueryTab("conn-1", "app");
+    useTabResults.getState().setReady(id, {
+      source,
+      columns: [],
+      rows: [],
+      rowCount: 0,
+      truncated: false,
+      durationMs: 1,
+    });
+    expect(useTabResults.getState().byTabId[id]).toBeDefined();
+
+    useTabs.getState().setQueryDatabase(id, "analytics");
+    expect(useTabResults.getState().byTabId[id]).toBeUndefined();
+  });
+
+  it("leaves results intact when the database is unchanged", () => {
+    const id = useTabs.getState().newQueryTab("conn-1", "app");
+    useTabResults.getState().setReady(id, {
+      source,
+      columns: [],
+      rows: [],
+      rowCount: 0,
+      truncated: false,
+      durationMs: 1,
+    });
+
+    useTabs.getState().setQueryDatabase(id, "app");
+    expect(useTabResults.getState().byTabId[id]).toBeDefined();
+  });
+
   it("drops query messages and notices for a tab when it closes", () => {
     const id = useTabs.getState().newQueryTab("conn-1", "app");
     const keepId = useTabs.getState().newQueryTab("conn-1", "app");

--- a/apps/desktop/src/state/tabs.test.ts
+++ b/apps/desktop/src/state/tabs.test.ts
@@ -206,6 +206,16 @@ describe("tab workspace state", () => {
     expect(queryTab().dirty).toBe(false);
   });
 
+  it("re-points a query tab at a different database without touching the buffer", () => {
+    const id = useTabs.getState().newQueryTab("conn-1", "app");
+    const queryTab = () => useTabs.getState().tabs[0] as QueryTab;
+    useTabs.getState().setQuerySql(id, "select 1;");
+
+    useTabs.getState().setQueryDatabase(id, "analytics");
+    expect(queryTab().database).toBe("analytics");
+    expect(queryTab().sql).toBe("select 1;");
+  });
+
   it("drops query messages and notices for a tab when it closes", () => {
     const id = useTabs.getState().newQueryTab("conn-1", "app");
     const keepId = useTabs.getState().newQueryTab("conn-1", "app");

--- a/apps/desktop/src/state/tabs.ts
+++ b/apps/desktop/src/state/tabs.ts
@@ -57,6 +57,8 @@ interface TabsStore {
   ) => void;
   newQueryTab: (connectionId: string, database: string) => string;
   setQuerySql: (id: string, sql: string) => void;
+  /** Re-point a query tab at a different database on the same connection. */
+  setQueryDatabase: (id: string, database: string) => void;
   markQueryRun: (id: string) => void;
   closeTab: (id: string) => void;
   reopenClosedTab: () => void;
@@ -224,6 +226,14 @@ export const useTabs = create<TabsStore>((set, get) => ({
         t.id === id && t.kind === "query"
           ? { ...t, sql, dirty: sql !== t.savedSql }
           : t,
+      ),
+    }));
+  },
+
+  setQueryDatabase(id, database) {
+    set((s) => ({
+      tabs: s.tabs.map((t) =>
+        t.id === id && t.kind === "query" ? { ...t, database } : t,
       ),
     }));
   },

--- a/apps/desktop/src/state/tabs.ts
+++ b/apps/desktop/src/state/tabs.ts
@@ -231,11 +231,17 @@ export const useTabs = create<TabsStore>((set, get) => ({
   },
 
   setQueryDatabase(id, database) {
+    const tab = get().tabs.find((t) => t.id === id);
+    if (!tab || tab.kind !== "query" || tab.database === database) return;
     set((s) => ({
       tabs: s.tabs.map((t) =>
         t.id === id && t.kind === "query" ? { ...t, database } : t,
       ),
     }));
+    // The grid, its `result.source` header, the "Load more" callback, and any
+    // messages/notices still describe the previous database — drop them so the
+    // user isn't shown stale data until they re-run.
+    clearTabResults([id]);
   },
 
   markQueryRun(id) {


### PR DESCRIPTION
## Summary
Turns the database segment of the title-bar breadcrumb into a dropdown so you can re-point the active query at a different database without leaving the editor.

## What changed
- The database breadcrumb is now a button (with a chevron affordance and hover state) that opens a menu — reusing the existing `ContextMenu` — listing the connection's databases, with the current one marked.
- Added a `setQueryDatabase` action to the tabs store that swaps a query tab's database while leaving its SQL buffer intact; table tabs stay static since they're bound to a database.

## User impact
Faster to run the same query against another database (e.g. staging vs prod) straight from the breadcrumb.

## Validation
`pnpm typecheck` clean; `pnpm test` passes (105 tests, including a new one for `setQueryDatabase`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which database ad-hoc queries target and race handling for in-flight runs; mitigated by clearing tab results and staleness guards, but mis-switching could still run SQL against the wrong DB.
> 
> **Overview**
> Lets users **re-point the active query tab** at another database on the same connection from the title-bar breadcrumb, without changing the SQL buffer.
> 
> For **query tabs** with a loaded database list, the database segment becomes a **dropdown** (existing `ContextMenu`) with the current DB marked; **table tabs** stay read-only. Tabs store gains **`setQueryDatabase`**, which updates `database` and **clears results, messages, and notices** for that tab so the grid doesn’t show the old database.
> 
> **`useQueryRunner`** watches `tab.database` and **invalidates in-flight runs** (bumps `runToken`, resets running/load-more/error state) so a late completion can’t refill results after a switch. Tests cover buffer preservation, result clearing, and no-op when the database is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a71bf19cd8ecac26befadfd8ac82841aa61b2f2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->