### PR TITLE
feat: add ER diagram tab for Postgres schemas

### DIFF
--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -28,6 +28,7 @@ pub fn builder() -> Builder<tauri::Wry> {
         connection::reconnect,
         connection::disconnect,
         schema::introspect,
+        schema::er_graph,
         query::run_query,
         query::cancel_query,
         query::explain_query,

--- a/apps/desktop/src-tauri/src/commands/schema.rs
+++ b/apps/desktop/src-tauri/src/commands/schema.rs
@@ -1,3 +1,4 @@
+use cellar_core::er::{build_er_graph, ErGraph};
 use cellar_core::error::CellarError;
 use cellar_core::schema::Database;
 use tauri::State;
@@ -14,4 +15,24 @@ pub async fn introspect(
     registry
         .introspect(&connection_id, refresh.unwrap_or(false))
         .await
+}
+
+/// Build the foreign-key graph for the ER diagram view. Reuses the cached
+/// introspection tree (so it never re-hits the server when the schema is warm)
+/// and derives the graph in [`cellar_core::er`]. `schemas` scopes the graph to
+/// a subset of schemas; `None` includes them all.
+#[tauri::command]
+#[specta::specta]
+pub async fn er_graph(
+    registry: State<'_, ConnectionRegistry>,
+    connection_id: String,
+    database: String,
+    schemas: Option<Vec<String>>,
+) -> Result<ErGraph, CellarError> {
+    let databases = registry.introspect(&connection_id, false).await?;
+    build_er_graph(&databases, &database, schemas.as_deref()).ok_or_else(|| {
+        CellarError::invalid_config(format!(
+            "database {database} was not found in schema metadata"
+        ))
+    })
 }

--- a/apps/desktop/src/components/BottomPanel.tsx
+++ b/apps/desktop/src/components/BottomPanel.tsx
@@ -51,7 +51,7 @@ import {
 } from "../state/notices";
 import { useBottomPanel, type BottomTabId } from "../state/bottomPanel";
 import { useStatus } from "../state/status";
-import { useTabs, type TableTab } from "../state/tabs";
+import { useTabs, tabLabel, type TableTab } from "../state/tabs";
 import {
   maxRowsLabel,
   resultContextLabel,
@@ -253,11 +253,7 @@ export function BottomPanel({ onClose }: { onClose: () => void }) {
             activeConnectionName={activeConnection?.name ?? null}
             activeEngine={activeConnection?.engine ?? null}
             activeTabLabel={
-                activeTab
-                  ? activeTab.kind === "query"
-                    ? `${activeTab.database}.${activeTab.title}`
-                    : `${activeTab.database}.${activeTab.schema}.${activeTab.table}`
-                  : null
+              activeTab ? `${activeTab.database}.${tabLabel(activeTab)}` : null
             }
             entry={noticeEntry}
             onClear={() => clearNotices(noticeScope)}
@@ -303,6 +299,7 @@ function headerItems(
 ): string[] {
   if (!activeTab) return ["no active tab"];
   if (activeTab.kind === "query") return [activeTab.title, "query tab"];
+  if (activeTab.kind === "er-diagram") return [activeTab.title, "ER diagram"];
   if (!result) return [tableLabel(activeTab), "table rows shown above"];
 
   const context = resultContextLabel(result.source);
@@ -354,6 +351,14 @@ function ResultsBody({
         <EmptyPanel
           title="Run a query to see results"
           detail={`${activeTab.title} has not produced a result set yet.`}
+        />
+      );
+    }
+    if (activeTab.kind === "er-diagram") {
+      return (
+        <EmptyPanel
+          title="ER diagram"
+          detail={`${activeTab.title} renders the foreign-key graph above. The Results grid is reserved for SQL query output.`}
         />
       );
     }
@@ -751,8 +756,7 @@ function HistoryPanel({
 
   const scopeLabel = useMemo(() => {
     if (!activeTab) return "No active tab";
-    if (activeTab.kind === "query") return `${activeTab.database}.${activeTab.title}`;
-    return `${activeTab.database}.${activeTab.schema}.${activeTab.table}`;
+    return `${activeTab.database}.${tabLabel(activeTab)}`;
   }, [activeTab]);
 
   return (

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -63,6 +63,7 @@ export function Sidebar({
   const deleteConnection = useConnections((s) => s.deleteConnection);
   const refreshSchema = useConnections((s) => s.refreshSchema);
   const openTable = useTabs((s) => s.openTable);
+  const openErDiagram = useTabs((s) => s.openErDiagram);
   const newQueryTab = useTabs((s) => s.newQueryTab);
   const setQuerySql = useTabs((s) => s.setQuerySql);
   const activeTabId = useTabs((s) => s.activeId);
@@ -121,6 +122,11 @@ export function Sidebar({
             onClick: () => queryFor(node.connectionId, node.database),
           },
           {
+            label: "Open ER diagram",
+            icon: <Icon.diagram size={12} />,
+            onClick: () => openErDiagram(node.connectionId, node.database, null),
+          },
+          {
             label: "Refresh schemas",
             icon: <Icon.history size={12} />,
             onClick: () => void refreshSchema(node.connectionId),
@@ -163,6 +169,12 @@ export function Sidebar({
             label: "New SQL query",
             icon: <Icon.terminal size={12} />,
             onClick: () => queryFor(node.connectionId, node.database),
+          },
+          {
+            label: "Open ER diagram",
+            icon: <Icon.diagram size={12} />,
+            onClick: () =>
+              openErDiagram(node.connectionId, node.database, [node.schema]),
           },
           {
             label: node.hidden ? "Show in sidebar" : "Hide from sidebar",

--- a/apps/desktop/src/components/TabBar.tsx
+++ b/apps/desktop/src/components/TabBar.tsx
@@ -8,7 +8,7 @@ import {
 import { Icon } from "./icons";
 import { qualifiedName, selectAllStatement } from "../lib/sqlIdent";
 import { useConnections } from "../state/connections";
-import { useTabs, type WorkspaceTab } from "../state/tabs";
+import { useTabs, tabLabel, type WorkspaceTab } from "../state/tabs";
 
 /**
  * Pick the connection + database a new query tab should bind to: the active
@@ -75,7 +75,7 @@ export function TabBar() {
     const index = tabs.findIndex((t) => t.id === tab.id);
     const hasRightTabs = index >= 0 && index < tabs.length - 1;
     const name =
-      tab.kind === "query" ? tab.title : qualifiedName(tab.schema, tab.table);
+      tab.kind === "table" ? qualifiedName(tab.schema, tab.table) : tab.title;
 
     return [
       {
@@ -99,7 +99,7 @@ export function TabBar() {
           ]
         : []),
       {
-        label: tab.kind === "query" ? "Copy title" : "Copy qualified name",
+        label: tab.kind === "table" ? "Copy qualified name" : "Copy title",
         icon: <Icon.copy size={12} />,
         onClick: () => copyText(name),
       },
@@ -192,12 +192,14 @@ export function TabBar() {
               <span className="inline-flex" style={{ color: "var(--fg-1)" }}>
                 {t.kind === "query" ? (
                   <Icon.terminal size={11} />
+                ) : t.kind === "er-diagram" ? (
+                  <Icon.diagram size={11} />
                 ) : (
                   <Icon.table size={11} />
                 )}
               </span>
               <span className="overflow-hidden text-ellipsis whitespace-nowrap font-mono">
-                {t.kind === "query" ? t.title : `${t.schema}.${t.table}`}
+                {tabLabel(t)}
               </span>
               {t.kind === "query" && t.dirty && (
                 <span

--- a/apps/desktop/src/components/TitleBar.tsx
+++ b/apps/desktop/src/components/TitleBar.tsx
@@ -81,10 +81,14 @@ export function TitleBar({
               <span className="inline-flex items-center gap-[5px] whitespace-nowrap rounded-[4px] px-1.5 py-[3px] text-[11.5px] text-fg-1 max-[1080px]:hidden">
                 {activeTab.kind === "query" ? (
                   <Icon.terminal size={11} />
+                ) : activeTab.kind === "er-diagram" ? (
+                  <Icon.diagram size={11} />
                 ) : (
                   <Icon.schema size={11} />
                 )}
-                <span>{activeTab.kind === "query" ? activeTab.title : activeTab.schema}</span>
+                <span>
+                  {activeTab.kind === "table" ? activeTab.schema : activeTab.title}
+                </span>
               </span>
             </div>
           </>

--- a/apps/desktop/src/components/Workspace.tsx
+++ b/apps/desktop/src/components/Workspace.tsx
@@ -13,9 +13,10 @@ import {
 } from "react";
 
 import { SqlEditor } from "./SqlEditor";
+import { ErDiagram } from "./er/ErDiagram";
 import { ContextMenu, type ContextMenuState } from "./ContextMenu";
 import { Icon } from "./icons";
-import { useTabs, type TableTab, type WorkspaceTab } from "../state/tabs";
+import { useTabs, tabLabel, type TableTab, type WorkspaceTab } from "../state/tabs";
 import { useTableData } from "../hooks/useTableData";
 import { useSettings } from "../lib/settings";
 import { toCsv, toJson, toSqlInserts, toTsv } from "../lib/export";
@@ -112,7 +113,7 @@ function SplitPane({
           title={tabTitle(tab)}
         >
           <span className="inline-flex shrink-0 text-fg-3">
-            {tab.kind === "query" ? <Icon.terminal size={11} /> : <Icon.table size={11} />}
+            <TabIcon tab={tab} />
           </span>
           <span className="truncate font-mono">{tabTitle(tab)}</span>
         </button>
@@ -140,13 +141,23 @@ function renderTab(tab: WorkspaceTab, onCommit?: () => void) {
     // `key` gives each query tab its own caret/wrap state.
     return <SqlEditor key={tab.id} tab={tab} />;
   }
+  if (tab.kind === "er-diagram") {
+    // `key` resets zoom/pan and node positions per diagram tab.
+    return <ErDiagram key={tab.id} tab={tab} />;
+  }
   // `key` resets the grid's local state (filters/selection) when the user
   // switches to a different table tab.
   return <TableTabPane key={tab.id} tab={tab} onCommit={onCommit} />;
 }
 
+function TabIcon({ tab }: { tab: WorkspaceTab }) {
+  if (tab.kind === "query") return <Icon.terminal size={11} />;
+  if (tab.kind === "er-diagram") return <Icon.diagram size={11} />;
+  return <Icon.table size={11} />;
+}
+
 function tabTitle(tab: WorkspaceTab): string {
-  return tab.kind === "query" ? tab.title : `${tab.schema}.${tab.table}`;
+  return tabLabel(tab);
 }
 
 function TableTabPane({

--- a/apps/desktop/src/components/er/ErDiagram.tsx
+++ b/apps/desktop/src/components/er/ErDiagram.tsx
@@ -1,0 +1,703 @@
+import { commands, unwrap, type ErGraph } from "@cellar/ipc";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
+
+import { Icon } from "../icons";
+import { useTabs, type ErDiagramTab } from "../../state/tabs";
+import { ErNodeCard } from "./ErNodeCard";
+import {
+  columnRowOffsets,
+  edgeGeometry,
+  graphBounds,
+  layoutGraph,
+  type EdgeGeometry,
+  type NodePositions,
+} from "./layout";
+
+type Status = "loading" | "ready" | "error";
+
+const MIN_ZOOM = 0.1;
+const MAX_ZOOM = 2.5;
+const CLICK_THRESHOLD = 4;
+/** Above this many tables, default to compact mode so the graph stays legible. */
+const COMPACT_THRESHOLD = 30;
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.min(hi, Math.max(lo, v));
+}
+
+interface Viewport {
+  tx: number;
+  ty: number;
+  k: number;
+}
+
+interface DragState {
+  mode: "pan" | "node";
+  id?: string;
+  pointerId: number;
+  startX: number;
+  startY: number;
+  origTx: number;
+  origTy: number;
+  origX: number;
+  origY: number;
+  moved: boolean;
+}
+
+/** Per-tab view state, kept across remounts. The diagram component unmounts
+ *  when you switch to another tab (e.g. clicking a node opens its grid), so
+ *  zoom/pan, dragged positions, expanded tables, and the column/schema filters
+ *  live here keyed by tab id instead of being lost on remount. */
+interface ErViewState {
+  compact: boolean;
+  hidden: Set<string>;
+  expanded: Set<string>;
+  overrides: Record<string, { x: number; y: number }>;
+  view: Viewport;
+  focusedId: string | null;
+}
+
+const erViewCache = new Map<string, ErViewState>();
+
+export function ErDiagram({ tab }: { tab: ErDiagramTab }) {
+  const openTable = useTabs((s) => s.openTable);
+
+  const cached = erViewCache.get(tab.id);
+  const [graph, setGraph] = useState<ErGraph | null>(null);
+  const [status, setStatus] = useState<Status>("loading");
+  const [error, setError] = useState<string | null>(null);
+  const [compact, setCompact] = useState(cached?.compact ?? false);
+  const [hidden, setHidden] = useState<Set<string>>(cached?.hidden ?? new Set());
+  const [expanded, setExpanded] = useState<Set<string>>(
+    cached?.expanded ?? new Set(),
+  );
+  const [overrides, setOverrides] = useState<Record<string, { x: number; y: number }>>(
+    cached?.overrides ?? {},
+  );
+  const [view, setView] = useState<Viewport>(cached?.view ?? { tx: 0, ty: 0, k: 1 });
+  const [focusedId, setFocusedId] = useState<string | null>(
+    cached?.focusedId ?? null,
+  );
+  const [schemaMenuOpen, setSchemaMenuOpen] = useState(false);
+  // Container size drives viewport culling — only on-screen nodes are rendered.
+  const [size, setSize] = useState({ w: 0, h: 0 });
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const dragRef = useRef<DragState | null>(null);
+  // When restoring a cached view, treat the diagram as already fitted so we
+  // don't auto-fit over the user's saved zoom/pan.
+  const restoredRef = useRef(Boolean(cached));
+  const fittedRef = useRef(Boolean(cached));
+  // Mirror live state into refs so pointer handlers can stay referentially
+  // stable (deps `[]`). That keeps `beginNodeDrag`/`focusNode` from changing
+  // every frame, which is what lets the memoized nodes/edges skip re-rendering
+  // during a pan or zoom.
+  const viewRef = useRef(view);
+  viewRef.current = view;
+  const graphRef = useRef(graph);
+  graphRef.current = graph;
+
+  const load = useCallback(() => {
+    let cancelled = false;
+    setStatus("loading");
+    setError(null);
+    unwrap(commands.erGraph(tab.connectionId, tab.database, tab.schemas))
+      .then((g) => {
+        if (cancelled) return;
+        setGraph(g);
+        // Only pick the default density / fit for a fresh diagram; a restored
+        // one keeps whatever the user last had.
+        if (!restoredRef.current) {
+          setCompact(g.nodes.length > COMPACT_THRESHOLD);
+          fittedRef.current = false;
+        }
+        setStatus("ready");
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+        setStatus("error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [tab.connectionId, tab.database, tab.schemas]);
+
+  useEffect(() => load(), [load]);
+
+  // Persist the live view state so switching tabs and back restores it.
+  useEffect(() => {
+    erViewCache.set(tab.id, {
+      compact,
+      hidden,
+      expanded,
+      overrides,
+      view,
+      focusedId,
+    });
+  }, [tab.id, compact, hidden, expanded, overrides, view, focusedId]);
+
+  const filtered = useMemo<ErGraph | null>(() => {
+    if (!graph) return null;
+    const nodes = graph.nodes.filter((n) => !hidden.has(n.schema));
+    const ids = new Set(nodes.map((n) => n.id));
+    const edges = graph.edges.filter(
+      (e) => ids.has(e.source) && ids.has(e.target),
+    );
+    return { ...graph, nodes, edges };
+  }, [graph, hidden]);
+
+  const basePositions = useMemo<NodePositions>(
+    () => (filtered ? layoutGraph(filtered, { compact, expanded }) : {}),
+    [filtered, compact, expanded],
+  );
+
+  const positions = useMemo<NodePositions>(() => {
+    const out: NodePositions = {};
+    for (const [id, box] of Object.entries(basePositions)) {
+      const o = overrides[id];
+      out[id] = o ? { ...box, x: o.x, y: o.y } : box;
+    }
+    return out;
+  }, [basePositions, overrides]);
+  const positionsRef = useRef(positions);
+  positionsRef.current = positions;
+
+  // Row-centre offset of every visible column, so edges anchor at the actual
+  // FK/PK field instead of the box edge.
+  const rowOffsets = useMemo(() => {
+    const m = new Map<string, Map<string, number>>();
+    if (filtered) {
+      for (const n of filtered.nodes) {
+        m.set(n.id, columnRowOffsets(n, compact, expanded.has(n.id)));
+      }
+    }
+    return m;
+  }, [filtered, compact, expanded]);
+
+  const edgeGeometries = useMemo<EdgeGeometry[]>(() => {
+    if (!filtered) return [];
+    const lookup = (id: string, col: string) => rowOffsets.get(id)?.get(col);
+    const out: EdgeGeometry[] = [];
+    for (const e of filtered.edges) {
+      const geo = edgeGeometry(e, positions, lookup);
+      if (geo) out.push(geo);
+    }
+    return out;
+  }, [filtered, positions, rowOffsets]);
+
+  // Graph-space rectangle currently in view (plus a margin so panning doesn't
+  // pop nodes in at the edge). Used to cull off-screen content from the DOM —
+  // the big win when zoomed in on a large/expanded table.
+  const viewRect = useMemo(() => {
+    const margin = 400;
+    return {
+      x0: -view.tx / view.k - margin,
+      y0: -view.ty / view.k - margin,
+      x1: (size.w - view.tx) / view.k + margin,
+      y1: (size.h - view.ty) / view.k + margin,
+    };
+  }, [view, size]);
+
+  const visibleNodes = useMemo(() => {
+    if (!filtered) return [];
+    if (size.w === 0) return filtered.nodes;
+    return filtered.nodes.filter((n) => {
+      const b = positions[n.id];
+      return (
+        b &&
+        b.x <= viewRect.x1 &&
+        b.x + b.width >= viewRect.x0 &&
+        b.y <= viewRect.y1 &&
+        b.y + b.height >= viewRect.y0
+      );
+    });
+  }, [filtered, positions, viewRect, size.w]);
+
+  const visibleEdges = useMemo(() => {
+    if (size.w === 0) return edgeGeometries;
+    const visIds = new Set(visibleNodes.map((n) => n.id));
+    return edgeGeometries.filter((g) => {
+      if (visIds.has(g.edge.source) || visIds.has(g.edge.target)) return true;
+      // Keep long edges that cross the viewport even when both ends are off-screen.
+      return (
+        Math.min(g.sx, g.tx) <= viewRect.x1 &&
+        Math.max(g.sx, g.tx) >= viewRect.x0 &&
+        Math.min(g.sy, g.ty) <= viewRect.y1 &&
+        Math.max(g.sy, g.ty) >= viewRect.y0
+      );
+    });
+  }, [edgeGeometries, visibleNodes, viewRect, size.w]);
+
+  const fit = useCallback(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const b = graphBounds(positions);
+    const w = el.clientWidth;
+    const h = el.clientHeight;
+    if (b.width === 0 || b.height === 0) {
+      setView({ tx: w / 2, ty: h / 2, k: 1 });
+      return;
+    }
+    const pad = 48;
+    const k = clamp(
+      Math.min((w - pad * 2) / b.width, (h - pad * 2) / b.height),
+      MIN_ZOOM,
+      1.2,
+    );
+    setView({
+      tx: (w - b.width * k) / 2 - b.minX * k,
+      ty: (h - b.height * k) / 2 - b.minY * k,
+      k,
+    });
+  }, [positions]);
+
+  // Fit once when the graph first becomes ready.
+  useEffect(() => {
+    if (status === "ready" && !fittedRef.current) {
+      fittedRef.current = true;
+      fit();
+    }
+  }, [status, fit]);
+
+  // Track the viewport size for culling.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const update = () => setSize({ w: el.clientWidth, h: el.clientHeight });
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  // Native non-passive wheel listener so we can preventDefault on zoom.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      const rect = el.getBoundingClientRect();
+      const px = e.clientX - rect.left;
+      const py = e.clientY - rect.top;
+      setView((v) => {
+        const k = clamp(v.k * Math.exp(-e.deltaY * 0.0015), MIN_ZOOM, MAX_ZOOM);
+        const ratio = k / v.k;
+        return {
+          k,
+          tx: px - (px - v.tx) * ratio,
+          ty: py - (py - v.ty) * ratio,
+        };
+      });
+    };
+    el.addEventListener("wheel", onWheel, { passive: false });
+    return () => el.removeEventListener("wheel", onWheel);
+  }, []);
+
+  const onPointerMove = useCallback((e: PointerEvent) => {
+    const drag = dragRef.current;
+    if (!drag) return;
+    const dx = e.clientX - drag.startX;
+    const dy = e.clientY - drag.startY;
+    if (!drag.moved && Math.hypot(dx, dy) > CLICK_THRESHOLD) {
+      drag.moved = true;
+    }
+    if (!drag.moved) return;
+    if (drag.mode === "pan") {
+      setView((v) => ({ ...v, tx: drag.origTx + dx, ty: drag.origTy + dy }));
+    } else if (drag.id) {
+      const k = viewRef.current.k;
+      const id = drag.id;
+      setOverrides((o) => ({
+        ...o,
+        [id]: { x: drag.origX + dx / k, y: drag.origY + dy / k },
+      }));
+    }
+  }, []);
+
+  const endDrag = useCallback(() => {
+    const drag = dragRef.current;
+    if (!drag) return;
+    dragRef.current = null;
+    window.removeEventListener("pointermove", onPointerMove);
+    window.removeEventListener("pointerup", endDrag);
+    // A node press that never moved is a click → open the table grid.
+    if (drag.mode === "node" && drag.id && !drag.moved) {
+      const node = graphRef.current?.nodes.find((n) => n.id === drag.id);
+      if (node) {
+        setFocusedId(node.id);
+        openTable(tab.connectionId, tab.database, node.schema, node.name);
+      }
+    }
+  }, [openTable, tab.connectionId, tab.database, onPointerMove]);
+
+  const beginPan = useCallback(
+    (e: ReactPointerEvent) => {
+      if (e.button !== 0) return;
+      // Stop the browser from starting a text/range selection on the SVG.
+      e.preventDefault();
+      const v = viewRef.current;
+      dragRef.current = {
+        mode: "pan",
+        pointerId: e.pointerId,
+        startX: e.clientX,
+        startY: e.clientY,
+        origTx: v.tx,
+        origTy: v.ty,
+        origX: 0,
+        origY: 0,
+        moved: false,
+      };
+      window.addEventListener("pointermove", onPointerMove);
+      window.addEventListener("pointerup", endDrag);
+    },
+    [onPointerMove, endDrag],
+  );
+
+  const beginNodeDrag = useCallback(
+    (e: ReactPointerEvent, id: string) => {
+      if (e.button !== 0) return;
+      e.stopPropagation();
+      e.preventDefault();
+      const box = positionsRef.current[id];
+      if (!box) return;
+      const v = viewRef.current;
+      dragRef.current = {
+        mode: "node",
+        id,
+        pointerId: e.pointerId,
+        startX: e.clientX,
+        startY: e.clientY,
+        origTx: v.tx,
+        origTy: v.ty,
+        origX: box.x,
+        origY: box.y,
+        moved: false,
+      };
+      window.addEventListener("pointermove", onPointerMove);
+      window.addEventListener("pointerup", endDrag);
+    },
+    [onPointerMove, endDrag],
+  );
+
+  const focusNode = useCallback((id: string) => {
+    const box = positionsRef.current[id];
+    const el = containerRef.current;
+    if (!box || !el) return;
+    setFocusedId(id);
+    setView((v) => ({
+      ...v,
+      tx: el.clientWidth / 2 - (box.x + box.width / 2) * v.k,
+      ty: el.clientHeight / 2 - (box.y + box.height / 2) * v.k,
+    }));
+  }, []);
+
+  const autoArrange = useCallback(() => {
+    setOverrides({});
+    fittedRef.current = false;
+    // Re-fit on the next frame once positions recompute.
+    requestAnimationFrame(() => {
+      fittedRef.current = true;
+      fit();
+    });
+  }, [fit]);
+
+  const zoomBy = useCallback((factor: number) => {
+    const el = containerRef.current;
+    const cx = (el?.clientWidth ?? 0) / 2;
+    const cy = (el?.clientHeight ?? 0) / 2;
+    setView((v) => {
+      const k = clamp(v.k * factor, MIN_ZOOM, MAX_ZOOM);
+      const ratio = k / v.k;
+      return { k, tx: cx - (cx - v.tx) * ratio, ty: cy - (cy - v.ty) * ratio };
+    });
+  }, []);
+
+  const toggleExpand = useCallback((id: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const toggleSchema = useCallback((schema: string) => {
+    setHidden((prev) => {
+      const next = new Set(prev);
+      if (next.has(schema)) next.delete(schema);
+      else next.add(schema);
+      return next;
+    });
+  }, []);
+
+  const allSchemas = graph?.schemas ?? [];
+  const visibleCount = filtered?.nodes.length ?? 0;
+  const edgeCount = filtered?.edges.length ?? 0;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col bg-bg-inset">
+      <Toolbar
+        zoom={view.k}
+        compact={compact}
+        schemas={allSchemas}
+        hidden={hidden}
+        schemaMenuOpen={schemaMenuOpen}
+        nodeCount={visibleCount}
+        edgeCount={edgeCount}
+        onZoomIn={() => zoomBy(1.2)}
+        onZoomOut={() => zoomBy(1 / 1.2)}
+        onFit={fit}
+        onAutoArrange={autoArrange}
+        onToggleCompact={() => setCompact((c) => !c)}
+        onToggleSchemaMenu={() => setSchemaMenuOpen((o) => !o)}
+        onToggleSchema={toggleSchema}
+        onRefresh={load}
+      />
+
+      <div
+        ref={containerRef}
+        className="relative min-h-0 flex-1 overflow-hidden"
+        style={{ cursor: "grab", userSelect: "none", WebkitUserSelect: "none" }}
+        onPointerDown={beginPan}
+      >
+        {status === "loading" && (
+          <Centered>
+            <span className="animate-sb-pulse">building diagram…</span>
+          </Centered>
+        )}
+        {status === "error" && (
+          <Centered>
+            <span className="text-warn">
+              Could not build diagram. {error}
+            </span>
+          </Centered>
+        )}
+        {status === "ready" && visibleCount === 0 && (
+          <Centered>
+            <span>
+              No tables to show
+              {hidden.size > 0 ? " (every schema is hidden)" : ""}.
+            </span>
+          </Centered>
+        )}
+        {status === "ready" && visibleCount > 0 && (
+          <svg className="h-full w-full" style={{ display: "block" }}>
+            <defs>
+              <marker
+                id="er-arrow"
+                viewBox="0 0 10 10"
+                refX={9}
+                refY={5}
+                markerWidth={7}
+                markerHeight={7}
+                orient="auto-start-reverse"
+              >
+                <path d="M0 0L10 5L0 10z" fill="var(--fg-3)" />
+              </marker>
+            </defs>
+            <g transform={`translate(${view.tx},${view.ty}) scale(${view.k})`}>
+              {visibleEdges.map((geo) => (
+                <EdgeLine key={geo.id} geo={geo} onFocus={focusNode} />
+              ))}
+              {visibleNodes.map((node) => {
+                const box = positions[node.id];
+                if (!box) return null;
+                return (
+                  <ErNodeCard
+                    key={node.id}
+                    node={node}
+                    box={box}
+                    compact={compact}
+                    expanded={expanded.has(node.id)}
+                    focused={focusedId === node.id}
+                    onPointerDown={beginNodeDrag}
+                    onToggleExpand={toggleExpand}
+                  />
+                );
+              })}
+            </g>
+          </svg>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const EdgeLine = memo(function EdgeLine({
+  geo,
+  onFocus,
+}: {
+  geo: EdgeGeometry;
+  onFocus: (target: string) => void;
+}) {
+  const label = geo.edge.source_columns.join(", ");
+  // Control points sit at the horizontal midpoint so the line leaves and meets
+  // each field row horizontally — making the connection point unambiguous.
+  const midX = (geo.sx + geo.tx) / 2;
+  const path = geo.selfLoop
+    ? `M ${geo.sx} ${geo.sy} C ${geo.sx + 44} ${geo.sy} ${geo.tx + 44} ${geo.ty} ${geo.tx} ${geo.ty}`
+    : `M ${geo.sx} ${geo.sy} C ${midX} ${geo.sy} ${midX} ${geo.ty} ${geo.tx} ${geo.ty}`;
+  return (
+    <g
+      style={{ cursor: "pointer" }}
+      onClick={(e) => {
+        e.stopPropagation();
+        onFocus(geo.edge.target);
+      }}
+    >
+      <title>
+        {geo.edge.constraint_name}: {label} → {geo.edge.target_columns.join(", ")}
+      </title>
+      {/* Fat transparent hit area so thin edges are easy to click. */}
+      <path d={path} fill="none" stroke="transparent" strokeWidth={10} />
+      <path
+        d={path}
+        fill="none"
+        stroke="var(--fg-3)"
+        strokeWidth={1}
+        markerEnd="url(#er-arrow)"
+      />
+      {label && (
+        <text
+          className="font-mono"
+          x={geo.labelX}
+          y={geo.labelY}
+          textAnchor="middle"
+          dominantBaseline="central"
+          fontSize={9}
+          fill="var(--fg-2)"
+          style={{ paintOrder: "stroke" }}
+          stroke="var(--bg-inset)"
+          strokeWidth={3}
+        >
+          {label}
+        </text>
+      )}
+    </g>
+  );
+});
+
+function Toolbar(props: {
+  zoom: number;
+  compact: boolean;
+  schemas: string[];
+  hidden: Set<string>;
+  schemaMenuOpen: boolean;
+  nodeCount: number;
+  edgeCount: number;
+  onZoomIn: () => void;
+  onZoomOut: () => void;
+  onFit: () => void;
+  onAutoArrange: () => void;
+  onToggleCompact: () => void;
+  onToggleSchemaMenu: () => void;
+  onToggleSchema: (schema: string) => void;
+  onRefresh: () => void;
+}) {
+  return (
+    <div className="relative flex h-7 shrink-0 items-center gap-1 border-b border-border-default bg-bg-1 px-2 text-[11px] text-fg-2">
+      <button type="button" className="icon-btn" title="Zoom out" onClick={props.onZoomOut}>
+        <Icon.minus size={12} />
+      </button>
+      <span className="w-9 text-center font-mono text-[10px] text-fg-3">
+        {Math.round(props.zoom * 100)}%
+      </span>
+      <button type="button" className="icon-btn" title="Zoom in" onClick={props.onZoomIn}>
+        <Icon.plus size={12} />
+      </button>
+      <button type="button" className="icon-btn" title="Fit to view" onClick={props.onFit}>
+        <Icon.expand size={12} />
+      </button>
+      <button
+        type="button"
+        className="icon-btn"
+        title="Auto-arrange"
+        onClick={props.onAutoArrange}
+      >
+        <Icon.layout size={12} />
+      </button>
+
+      <span className="mx-1 h-3.5 w-px bg-border-default" />
+
+      <button
+        type="button"
+        className={
+          "inline-flex h-[20px] items-center gap-1 rounded-[4px] border px-1.5 text-[10.5px] " +
+          (props.compact
+            ? "border-border-default bg-bg-2 text-fg-2 hover:text-fg-0"
+            : "border-accent-line bg-accent-soft text-accent")
+        }
+        aria-pressed={!props.compact}
+        title={
+          props.compact
+            ? "Showing key columns only — click to show all fields"
+            : "Showing all fields — click to show key columns only"
+        }
+        onClick={props.onToggleCompact}
+      >
+        <Icon.format size={11} />
+        {props.compact ? "Keys only" : "All fields"}
+      </button>
+
+      {props.schemas.length > 0 && (
+        <button
+          type="button"
+          className={"icon-btn" + (props.hidden.size > 0 ? " active" : "")}
+          title="Show/hide schemas"
+          onClick={props.onToggleSchemaMenu}
+        >
+          <Icon.eye size={12} />
+        </button>
+      )}
+
+      <button type="button" className="icon-btn" title="Refresh" onClick={props.onRefresh}>
+        <Icon.history size={12} />
+      </button>
+
+      <span className="ml-auto font-mono text-[10px] text-fg-3">
+        {props.nodeCount} tables · {props.edgeCount} refs
+      </span>
+
+      {props.schemaMenuOpen && props.schemas.length > 0 && (
+        <div className="absolute left-2 top-[30px] z-20 max-h-[260px] w-52 overflow-y-auto rounded-[6px] border border-border-default bg-bg-1 py-1 shadow-xl">
+          {props.schemas.map((schema) => {
+            const checked = !props.hidden.has(schema);
+            return (
+              <label
+                key={schema}
+                className="flex h-6 cursor-pointer items-center gap-2 px-2 text-[11px] text-fg-1 hover:bg-bg-2"
+              >
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  onChange={() => props.onToggleSchema(schema)}
+                  className="h-3 w-3 accent-[var(--accent)]"
+                />
+                <span className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap font-mono">
+                  {schema}
+                </span>
+              </label>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Centered({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex h-full items-center justify-center text-[11.5px] text-fg-3">
+      {children}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/er/ErNodeCard.tsx
+++ b/apps/desktop/src/components/er/ErNodeCard.tsx
@@ -1,0 +1,187 @@
+import { memo, type PointerEvent as ReactPointerEvent } from "react";
+import type { ErNode } from "@cellar/ipc";
+
+import {
+  NODE_FOOTER_H,
+  NODE_HEADER_H,
+  NODE_ROW_H,
+  visibleColumns,
+  type NodeBox,
+} from "./layout";
+
+const CHAR_PX = 6.6;
+
+function truncate(text: string, widthPx: number): string {
+  const max = Math.max(2, Math.floor(widthPx / CHAR_PX));
+  return text.length > max ? `${text.slice(0, max - 1)}…` : text;
+}
+
+function rowCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}
+
+export interface ErNodeCardProps {
+  node: ErNode;
+  box: NodeBox;
+  compact: boolean;
+  expanded: boolean;
+  focused: boolean;
+  onPointerDown: (event: ReactPointerEvent, id: string) => void;
+  onToggleExpand: (id: string) => void;
+}
+
+/**
+ * One table rendered as pure SVG — keeps 100+ nodes cheap and lets the whole
+ * card theme from the same CSS tokens as the rest of the app. Columns are
+ * monospace per the spec's "monospace for identifiers and data" rule.
+ */
+function ErNodeCardImpl({
+  node,
+  box,
+  compact,
+  expanded,
+  focused,
+  onPointerDown,
+  onToggleExpand,
+}: ErNodeCardProps) {
+  const { columns, hidden, overflow } = visibleColumns(node, compact, expanded);
+  const nameWidth = box.width - 16;
+
+  return (
+    <g
+      transform={`translate(${box.x},${box.y})`}
+      style={{ cursor: "pointer" }}
+      onPointerDown={(e) => onPointerDown(e, node.id)}
+    >
+      <title>
+        {node.schema}.{node.name}
+        {node.row_count != null ? ` · ${node.row_count} rows` : ""}
+      </title>
+      <rect
+        width={box.width}
+        height={box.height}
+        rx={4}
+        fill="var(--bg-1)"
+        stroke={focused ? "var(--accent)" : "var(--border-default)"}
+        strokeWidth={focused ? 1.5 : 1}
+      />
+      <rect width={box.width} height={NODE_HEADER_H} rx={4} fill="var(--bg-2)" />
+      <rect y={NODE_HEADER_H - 6} width={box.width} height={6} fill="var(--bg-2)" />
+      <line
+        x1={0}
+        y1={NODE_HEADER_H}
+        x2={box.width}
+        y2={NODE_HEADER_H}
+        stroke="var(--border-default)"
+      />
+      <text
+        className="font-mono"
+        x={8}
+        y={NODE_HEADER_H / 2}
+        dominantBaseline="central"
+        fontSize={11}
+        fontWeight={600}
+        fill="var(--fg-0)"
+      >
+        {truncate(node.name, nameWidth - 36)}
+      </text>
+      {node.row_count != null && (
+        <text
+          className="font-mono"
+          x={box.width - 8}
+          y={NODE_HEADER_H / 2}
+          textAnchor="end"
+          dominantBaseline="central"
+          fontSize={9}
+          fill="var(--fg-3)"
+        >
+          {rowCount(node.row_count)}
+        </text>
+      )}
+
+      {columns.map((col, i) => {
+        const cy = NODE_HEADER_H + i * NODE_ROW_H + NODE_ROW_H / 2;
+        const badge = col.is_primary_key ? "PK" : col.is_foreign_key ? "FK" : "";
+        const badgeColor = col.is_primary_key
+          ? "var(--accent)"
+          : "var(--warn)";
+        const typeText = truncate(col.data_type, 60);
+        const nameMax = nameWidth - typeText.length * CHAR_PX - 22;
+        return (
+          <g key={col.name}>
+            {badge && (
+              <text
+                className="font-mono"
+                x={8}
+                y={cy}
+                dominantBaseline="central"
+                fontSize={8}
+                fontWeight={700}
+                fill={badgeColor}
+              >
+                {badge}
+              </text>
+            )}
+            <text
+              className="font-mono"
+              x={badge ? 26 : 10}
+              y={cy}
+              dominantBaseline="central"
+              fontSize={10.5}
+              fill={col.is_primary_key ? "var(--fg-0)" : "var(--fg-1)"}
+            >
+              {truncate(col.name, nameMax)}
+            </text>
+            <text
+              className="font-mono"
+              x={box.width - 8}
+              y={cy}
+              textAnchor="end"
+              dominantBaseline="central"
+              fontSize={9.5}
+              fill="var(--fg-3)"
+            >
+              {typeText}
+            </text>
+          </g>
+        );
+      })}
+
+      {overflow && (
+        <g
+          style={{ cursor: "pointer" }}
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleExpand(node.id);
+          }}
+        >
+          {/* Full-width hit area so the whole footer toggles expansion. */}
+          <rect
+            y={box.height - NODE_FOOTER_H}
+            width={box.width}
+            height={NODE_FOOTER_H}
+            fill="transparent"
+          />
+          <text
+            className="font-mono"
+            x={10}
+            y={box.height - NODE_FOOTER_H / 2}
+            dominantBaseline="central"
+            fontSize={9}
+            fontWeight={600}
+            fill="var(--accent)"
+          >
+            {expanded ? "▾ show less" : `▸ +${hidden} more`}
+          </text>
+        </g>
+      )}
+    </g>
+  );
+}
+
+// Memoized so panning/zooming (which only changes the root transform) doesn't
+// re-render every table's full SVG subtree — props are stable between frames.
+export const ErNodeCard = memo(ErNodeCardImpl);

--- a/apps/desktop/src/components/er/layout.test.ts
+++ b/apps/desktop/src/components/er/layout.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import type { ErGraph, ErNode } from "@cellar/ipc";
+
+import {
+  edgeGeometry,
+  graphBounds,
+  layoutGraph,
+  visibleColumns,
+} from "./layout";
+
+function node(id: string, extra: Partial<ErNode> = {}): ErNode {
+  const [schema, name] = id.split(".");
+  return {
+    id,
+    schema: schema ?? "public",
+    name: name ?? id,
+    columns: [
+      {
+        name: "id",
+        data_type: "int8",
+        nullable: false,
+        is_primary_key: true,
+        is_foreign_key: false,
+      },
+    ],
+    primary_key: ["id"],
+    row_count: null,
+    ...extra,
+  };
+}
+
+const graph: ErGraph = {
+  database: "shop",
+  schemas: ["public"],
+  nodes: [
+    node("public.orders", {
+      columns: [
+        {
+          name: "id",
+          data_type: "int8",
+          nullable: false,
+          is_primary_key: true,
+          is_foreign_key: false,
+        },
+        {
+          name: "customer_id",
+          data_type: "int8",
+          nullable: false,
+          is_primary_key: false,
+          is_foreign_key: true,
+        },
+        {
+          name: "note",
+          data_type: "text",
+          nullable: true,
+          is_primary_key: false,
+          is_foreign_key: false,
+        },
+      ],
+    }),
+    node("public.customers"),
+    node("public.lonely"),
+  ],
+  edges: [
+    {
+      id: "public.orders->public.customers:fk",
+      constraint_name: "fk",
+      source: "public.orders",
+      target: "public.customers",
+      source_columns: ["customer_id"],
+      target_columns: ["id"],
+    },
+  ],
+};
+
+describe("er layout", () => {
+  it("places every node without overlap on the grid", () => {
+    const positions = layoutGraph(graph, { compact: false });
+    expect(Object.keys(positions).sort()).toEqual([
+      "public.customers",
+      "public.lonely",
+      "public.orders",
+    ]);
+    const boxes = Object.values(positions);
+    for (const b of boxes) {
+      expect(b.width).toBeGreaterThan(0);
+      expect(b.height).toBeGreaterThan(0);
+    }
+  });
+
+  it("compact mode keeps only key columns", () => {
+    const orders = graph.nodes[0]!;
+    const full = visibleColumns(orders, false);
+    const compact = visibleColumns(orders, true);
+    expect(full.columns).toHaveLength(3);
+    expect(compact.columns.map((c) => c.name)).toEqual(["id", "customer_id"]);
+  });
+
+  it("derives edge endpoints from node boxes", () => {
+    const positions = layoutGraph(graph, { compact: true });
+    const geo = edgeGeometry(graph.edges[0]!, positions);
+    expect(geo).not.toBeNull();
+    expect(geo?.selfLoop).toBe(false);
+    expect(Number.isFinite(geo?.sx)).toBe(true);
+    expect(Number.isFinite(geo?.ty)).toBe(true);
+  });
+
+  it("anchors edge endpoints at the resolved column rows", () => {
+    const positions = layoutGraph(graph, { compact: true });
+    const lookup = (id: string, col: string) =>
+      id === "public.orders" && col === "customer_id" ? 50 : undefined;
+    const geo = edgeGeometry(graph.edges[0]!, positions, lookup);
+    const source = positions["public.orders"]!;
+    // Source anchors at its row centre; target falls back to its box centre.
+    expect(geo?.sy).toBe(source.y + 50);
+    const target = positions["public.customers"]!;
+    expect(geo?.ty).toBe(target.y + target.height / 2);
+  });
+
+  it("returns null geometry when an endpoint is filtered out", () => {
+    const positions = layoutGraph(
+      { ...graph, nodes: [graph.nodes[0]!] },
+      { compact: true },
+    );
+    expect(edgeGeometry(graph.edges[0]!, positions)).toBeNull();
+  });
+
+  it("bounds cover the laid-out nodes", () => {
+    const positions = layoutGraph(graph, { compact: false });
+    const bounds = graphBounds(positions);
+    expect(bounds.width).toBeGreaterThan(0);
+    expect(bounds.height).toBeGreaterThan(0);
+  });
+
+  it("is deterministic across runs", () => {
+    const a = layoutGraph(graph, { compact: false });
+    const b = layoutGraph(graph, { compact: false });
+    expect(a).toEqual(b);
+  });
+});

--- a/apps/desktop/src/components/er/layout.ts
+++ b/apps/desktop/src/components/er/layout.ts
@@ -1,0 +1,291 @@
+// Deterministic, dependency-free layout for the ER diagram. The spec's
+// philosophy is to own the rendering surface (the data grid is custom for the
+// same reason), so rather than pull in reactflow/dagre/elkjs — which bring
+// their own styling and, in elkjs' case, a non-MIT (EPL) license — we lay the
+// graph out ourselves. A degree-ordered BFS clusters related tables, then they
+// pack into a grid. Nodes are plain SVG, so 100+ tables stay cheap and the
+// whole surface themes from the same CSS tokens as the rest of the app.
+
+import type { ErColumn, ErEdge, ErGraph, ErNode } from "@cellar/ipc";
+
+export const NODE_HEADER_H = 26;
+export const NODE_ROW_H = 18;
+export const NODE_FOOTER_H = 16;
+export const NODE_MIN_WIDTH = 184;
+export const NODE_MAX_WIDTH = 300;
+
+/** Cap rows so a wide table can't produce an unusably tall node. */
+const MAX_ROWS = 14;
+/** Approximate monospace advance at the node font size, in px. */
+const CHAR_PX = 6.6;
+
+export interface NodeBox {
+  id: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export type NodePositions = Record<string, NodeBox>;
+
+export interface VisibleColumns {
+  columns: ErColumn[];
+  /** How many columns are hidden behind the row cap (0 when fully shown). */
+  hidden: number;
+  /** `true` when this node has more columns than the cap — i.e. it is
+   *  expandable, regardless of whether it is currently expanded. */
+  overflow: boolean;
+}
+
+/**
+ * Which columns to render for a node. Compact mode keeps only key columns
+ * (primary or foreign), which is what matters for reading relationships in a
+ * dense graph; full mode shows everything. Either way the visible rows are
+ * capped at [`MAX_ROWS`] so a wide table stays readable — unless `expanded`,
+ * in which case every column in the set is shown.
+ */
+export function visibleColumns(
+  node: ErNode,
+  compact: boolean,
+  expanded = false,
+): VisibleColumns {
+  const cols = compact
+    ? node.columns.filter((c) => c.is_primary_key || c.is_foreign_key)
+    : node.columns;
+  const overflow = cols.length > MAX_ROWS;
+  if (expanded || !overflow) return { columns: cols, hidden: 0, overflow };
+  return {
+    columns: cols.slice(0, MAX_ROWS),
+    hidden: cols.length - MAX_ROWS,
+    overflow,
+  };
+}
+
+function measure(
+  node: ErNode,
+  compact: boolean,
+  expanded: boolean,
+): { width: number; height: number } {
+  const { columns, overflow } = visibleColumns(node, compact, expanded);
+  const longest = Math.max(
+    node.name.length + 6,
+    ...columns.map((c) => c.name.length + c.data_type.length + 4),
+    10,
+  );
+  const width = Math.min(
+    NODE_MAX_WIDTH,
+    Math.max(NODE_MIN_WIDTH, Math.round(longest * CHAR_PX) + 24),
+  );
+  const height =
+    NODE_HEADER_H +
+    columns.length * NODE_ROW_H +
+    (overflow ? NODE_FOOTER_H : 0);
+  return { width, height };
+}
+
+/**
+ * Order nodes so connected tables land near each other: degree-ordered BFS
+ * across components. Deterministic — ties break on id — so re-running
+ * auto-arrange always produces the same layout.
+ */
+function orderNodes(graph: ErGraph): ErNode[] {
+  const byId = new Map(graph.nodes.map((n) => [n.id, n] as const));
+  const adj = new Map<string, Set<string>>();
+  for (const n of graph.nodes) adj.set(n.id, new Set());
+  for (const e of graph.edges) {
+    if (e.source === e.target) continue;
+    adj.get(e.source)?.add(e.target);
+    adj.get(e.target)?.add(e.source);
+  }
+  const degree = (id: string) => adj.get(id)?.size ?? 0;
+  const cmp = (a: string, b: string) =>
+    degree(b) - degree(a) || a.localeCompare(b);
+
+  const seeds = [...graph.nodes].sort((a, b) => cmp(a.id, b.id));
+  const visited = new Set<string>();
+  const order: ErNode[] = [];
+  for (const seed of seeds) {
+    if (visited.has(seed.id)) continue;
+    const queue = [seed.id];
+    visited.add(seed.id);
+    while (queue.length > 0) {
+      const id = queue.shift() as string;
+      const node = byId.get(id);
+      if (node) order.push(node);
+      const neighbors = [...(adj.get(id) ?? [])].sort(cmp);
+      for (const nb of neighbors) {
+        if (!visited.has(nb)) {
+          visited.add(nb);
+          queue.push(nb);
+        }
+      }
+    }
+  }
+  return order;
+}
+
+export interface LayoutOptions {
+  compact: boolean;
+  /** Ids of nodes that are expanded to show all columns. */
+  expanded?: Set<string>;
+  gapX?: number;
+  gapY?: number;
+}
+
+/** Pack the ordered nodes into a grid sized to roughly square the diagram. */
+export function layoutGraph(graph: ErGraph, options: LayoutOptions): NodePositions {
+  const gapX = options.gapX ?? 48;
+  const gapY = options.gapY ?? 36;
+  const expanded = options.expanded ?? new Set<string>();
+  const dims = new Map(
+    graph.nodes.map(
+      (n) => [n.id, measure(n, options.compact, expanded.has(n.id))] as const,
+    ),
+  );
+  const order = orderNodes(graph);
+  const count = order.length;
+  if (count === 0) return {};
+
+  const cols = Math.max(1, Math.ceil(Math.sqrt(count)));
+  const cellWidth = Math.max(
+    NODE_MIN_WIDTH,
+    ...[...dims.values()].map((d) => d.width),
+  );
+
+  const positions: NodePositions = {};
+  let y = 0;
+  let rowHeight = 0;
+  order.forEach((node, i) => {
+    const col = i % cols;
+    if (col === 0 && i > 0) {
+      y += rowHeight + gapY;
+      rowHeight = 0;
+    }
+    const d = dims.get(node.id) ?? { width: NODE_MIN_WIDTH, height: NODE_HEADER_H };
+    positions[node.id] = {
+      id: node.id,
+      x: col * (cellWidth + gapX),
+      y,
+      width: d.width,
+      height: d.height,
+    };
+    rowHeight = Math.max(rowHeight, d.height);
+  });
+  return positions;
+}
+
+export interface Bounds {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+  width: number;
+  height: number;
+}
+
+export function graphBounds(positions: NodePositions): Bounds {
+  const boxes = Object.values(positions);
+  if (boxes.length === 0) {
+    return { minX: 0, minY: 0, maxX: 0, maxY: 0, width: 0, height: 0 };
+  }
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const b of boxes) {
+    minX = Math.min(minX, b.x);
+    minY = Math.min(minY, b.y);
+    maxX = Math.max(maxX, b.x + b.width);
+    maxY = Math.max(maxY, b.y + b.height);
+  }
+  return { minX, minY, maxX, maxY, width: maxX - minX, height: maxY - minY };
+}
+
+export interface EdgeGeometry {
+  id: string;
+  edge: ErEdge;
+  sx: number;
+  sy: number;
+  tx: number;
+  ty: number;
+  labelX: number;
+  labelY: number;
+  selfLoop: boolean;
+}
+
+/**
+ * Vertical offset (relative to a node's top-left) of each visible column row's
+ * centre. Lets edges anchor at the exact FK/PK field rather than the box edge.
+ */
+export function columnRowOffsets(
+  node: ErNode,
+  compact: boolean,
+  expanded: boolean,
+): Map<string, number> {
+  const { columns } = visibleColumns(node, compact, expanded);
+  const map = new Map<string, number>();
+  columns.forEach((c, i) => {
+    map.set(c.name, NODE_HEADER_H + i * NODE_ROW_H + NODE_ROW_H / 2);
+  });
+  return map;
+}
+
+/** Resolve a column's row-centre offset within a node, if it is visible. */
+export type RowOffsetLookup = (
+  nodeId: string,
+  column: string,
+) => number | undefined;
+
+export function edgeGeometry(
+  edge: ErEdge,
+  positions: NodePositions,
+  rowOffset?: RowOffsetLookup,
+): EdgeGeometry | null {
+  const s = positions[edge.source];
+  const t = positions[edge.target];
+  if (!s || !t) return null;
+
+  // Anchor at the first FK column on the source and its referenced column on
+  // the target; fall back to the box centre if the column is hidden.
+  const sCol = edge.source_columns[0];
+  const tCol = edge.target_columns[0];
+  const sRowY = (sCol ? rowOffset?.(edge.source, sCol) : undefined) ?? s.height / 2;
+  const tRowY = (tCol ? rowOffset?.(edge.target, tCol) : undefined) ?? t.height / 2;
+
+  if (edge.source === edge.target) {
+    const x = s.x + s.width;
+    const sy = s.y + sRowY;
+    const ty = s.y + (tRowY === sRowY ? tRowY + NODE_ROW_H : tRowY);
+    return {
+      id: edge.id,
+      edge,
+      sx: x,
+      sy,
+      tx: x,
+      ty,
+      labelX: x + 30,
+      labelY: (sy + ty) / 2,
+      selfLoop: true,
+    };
+  }
+
+  // Leave/enter on whichever side faces the other node so the line connects to
+  // the row horizontally.
+  const targetIsRight = t.x + t.width / 2 >= s.x + s.width / 2;
+  const sx = targetIsRight ? s.x + s.width : s.x;
+  const tx = targetIsRight ? t.x : t.x + t.width;
+  const sy = s.y + sRowY;
+  const ty = t.y + tRowY;
+  return {
+    id: edge.id,
+    edge,
+    sx,
+    sy,
+    tx,
+    ty,
+    labelX: (sx + tx) / 2,
+    labelY: (sy + ty) / 2,
+    selfLoop: false,
+  };
+}

--- a/apps/desktop/src/components/icons.tsx
+++ b/apps/desktop/src/components/icons.tsx
@@ -97,6 +97,7 @@ export const Icon = {
   ),
 
   plus: (p: IconProps) => <I {...p} d="M12 5v14M5 12h14" />,
+  minus: (p: IconProps) => <I {...p} d="M5 12h14" />,
   close: (p: IconProps) => <I {...p} d="M6 6l12 12M18 6L6 18" />,
   check: (p: IconProps) => <I {...p} d="M5 12l5 5L20 7" />,
   search: (p: IconProps) => (
@@ -313,6 +314,13 @@ export const Icon = {
     </I>
   ),
   bracket: (p: IconProps) => <I {...p} d="M8 4H4v16h4M16 4h4v16h-4" />,
+  diagram: (p: IconProps) => (
+    <I {...p}>
+      <rect x="2.5" y="4" width="8" height="6" rx="1" />
+      <rect x="13.5" y="14" width="8" height="6" rx="1" />
+      <path d="M6.5 10v3a1 1 0 001 1h6" />
+    </I>
+  ),
   trash: (p: IconProps) => (
     <I {...p}>
       <path d="M3 6h18" />

--- a/apps/desktop/src/components/modals/CommandPalette.tsx
+++ b/apps/desktop/src/components/modals/CommandPalette.tsx
@@ -468,7 +468,7 @@ function pickQueryTarget(
 }
 
 function tabLabel(tab: WorkspaceTab): string {
-  return tab.kind === "query" ? tab.title : `${tab.schema}.${tab.table}`;
+  return tab.kind === "table" ? `${tab.schema}.${tab.table}` : tab.title;
 }
 
 function titleCase(value: string): string {

--- a/apps/desktop/src/state/tabs.ts
+++ b/apps/desktop/src/state/tabs.ts
@@ -28,8 +28,23 @@ export interface QueryTab {
   dirty: boolean;
 }
 
-export type WorkspaceTab = TableTab | QueryTab;
+export interface ErDiagramTab {
+  id: string;
+  kind: "er-diagram";
+  connectionId: string;
+  database: string;
+  title: string;
+  /** Schema scope the graph was opened for; `null` means every schema. */
+  schemas: string[] | null;
+}
+
+export type WorkspaceTab = TableTab | QueryTab | ErDiagramTab;
 export type SplitOrientation = "horizontal" | "vertical";
+
+/** Short label for a tab — title for query/ER tabs, `schema.table` for tables. */
+export function tabLabel(tab: WorkspaceTab): string {
+  return tab.kind === "table" ? `${tab.schema}.${tab.table}` : tab.title;
+}
 
 export interface WorkspaceSplit {
   orientation: SplitOrientation;
@@ -56,6 +71,11 @@ interface TabsStore {
     table: string,
   ) => void;
   newQueryTab: (connectionId: string, database: string) => string;
+  openErDiagram: (
+    connectionId: string,
+    database: string,
+    schemas: string[] | null,
+  ) => void;
   setQuerySql: (id: string, sql: string) => void;
   markQueryRun: (id: string) => void;
   closeTab: (id: string) => void;
@@ -191,6 +211,28 @@ export const useTabs = create<TabsStore>((set, get) => ({
       tabs: [
         ...s.tabs,
         { id, kind: "table", connectionId, database, schema, table },
+      ],
+      activeId: id,
+    }));
+  },
+
+  openErDiagram(connectionId, database, schemas) {
+    const scope =
+      schemas && schemas.length > 0 ? [...schemas].sort() : null;
+    const id = `er:${connectionId}::${database}::${scope?.join(",") ?? "all"}`;
+    const existing = get().tabs.find((t) => t.id === id);
+    if (existing) {
+      set({ activeId: id });
+      return;
+    }
+    const title =
+      scope && scope.length === 1
+        ? `ER: ${scope[0]}`
+        : `ER: ${database}`;
+    set((s) => ({
+      tabs: [
+        ...s.tabs,
+        { id, kind: "er-diagram", connectionId, database, title, schemas: scope },
       ],
       activeId: id,
     }));

--- a/crates/cellar-core/src/er.rs
+++ b/crates/cellar-core/src/er.rs
@@ -1,0 +1,278 @@
+//! Entity-relationship graph derivation.
+//!
+//! ER diagrams are built from the engine-neutral [`crate::schema`] types that
+//! every driver already populates during `introspect`. Foreign-key metadata is
+//! part of the shared `Schema` contract (see [`crate::schema::ForeignKey`]), so
+//! any engine whose driver fills in [`crate::schema::Table::foreign_keys`] gets
+//! ER diagrams for free — there is no per-engine ER code to write. Postgres is
+//! the only driver wired today, but the contract is deliberately engine-neutral.
+
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+use specta::Type;
+
+use crate::schema::Database;
+
+/// A column rendered inside an ER node. Carries just enough for the diagram:
+/// name, type, and key-role badges.
+#[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
+pub struct ErColumn {
+    pub name: String,
+    pub data_type: String,
+    pub nullable: bool,
+    pub is_primary_key: bool,
+    /// `true` when the column participates in at least one outgoing foreign key.
+    pub is_foreign_key: bool,
+}
+
+/// One table in the diagram. `id` is `"schema.table"`; edges reference nodes by
+/// this id.
+#[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
+pub struct ErNode {
+    pub id: String,
+    pub schema: String,
+    pub name: String,
+    pub columns: Vec<ErColumn>,
+    pub primary_key: Vec<String>,
+    pub row_count: Option<u64>,
+}
+
+/// A foreign-key relationship, drawn as an edge from the referencing table to
+/// the referenced table.
+#[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
+pub struct ErEdge {
+    /// Stable id derived from the endpoints and constraint name.
+    pub id: String,
+    pub constraint_name: String,
+    /// `"schema.table"` of the table that holds the FK columns.
+    pub source: String,
+    /// `"schema.table"` of the referenced table.
+    pub target: String,
+    pub source_columns: Vec<String>,
+    pub target_columns: Vec<String>,
+}
+
+/// The full graph for one database, scoped to a selection of schemas.
+#[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
+pub struct ErGraph {
+    pub database: String,
+    /// Schema names present in this graph, sorted — drives the show/hide UI.
+    pub schemas: Vec<String>,
+    pub nodes: Vec<ErNode>,
+    pub edges: Vec<ErEdge>,
+}
+
+fn node_id(schema: &str, table: &str) -> String {
+    format!("{schema}.{table}")
+}
+
+/// Build an ER graph for `database` out of an introspected database tree.
+///
+/// When `schemas` is `Some`, only tables in those schemas are included; `None`
+/// includes every schema. Edges are kept only when both endpoints are present
+/// in the resulting node set, so hiding a schema also drops the relationships
+/// that would dangle out of the view. Returns `None` when `database` is absent
+/// from `databases`.
+pub fn build_er_graph(
+    databases: &[Database],
+    database: &str,
+    schemas: Option<&[String]>,
+) -> Option<ErGraph> {
+    let db = databases.iter().find(|d| d.name == database)?;
+    let allow: Option<BTreeSet<&str>> = schemas.map(|s| s.iter().map(String::as_str).collect());
+    let included = |schema: &str| allow.as_ref().is_none_or(|a| a.contains(schema));
+
+    let mut nodes = Vec::new();
+    let mut node_ids = BTreeSet::new();
+    let mut schema_names = BTreeSet::new();
+
+    for schema in &db.schemas {
+        if !included(&schema.name) {
+            continue;
+        }
+        schema_names.insert(schema.name.clone());
+        for table in &schema.tables {
+            let fk_cols: BTreeSet<&str> = table
+                .foreign_keys
+                .iter()
+                .flat_map(|fk| fk.columns.iter().map(String::as_str))
+                .collect();
+            let columns = table
+                .columns
+                .iter()
+                .map(|c| ErColumn {
+                    name: c.name.clone(),
+                    data_type: c.data_type.clone(),
+                    nullable: c.nullable,
+                    is_primary_key: c.is_primary_key,
+                    is_foreign_key: fk_cols.contains(c.name.as_str()),
+                })
+                .collect();
+            let id = node_id(&schema.name, &table.name);
+            node_ids.insert(id.clone());
+            nodes.push(ErNode {
+                id,
+                schema: schema.name.clone(),
+                name: table.name.clone(),
+                columns,
+                primary_key: table.primary_key.clone(),
+                row_count: table.row_count,
+            });
+        }
+    }
+
+    let mut edges = Vec::new();
+    for schema in &db.schemas {
+        if !included(&schema.name) {
+            continue;
+        }
+        for table in &schema.tables {
+            let source = node_id(&schema.name, &table.name);
+            for fk in &table.foreign_keys {
+                let target = node_id(&fk.referenced_schema, &fk.referenced_table);
+                // Skip relationships whose referenced table was filtered out so
+                // every rendered edge connects two real nodes.
+                if !node_ids.contains(&target) {
+                    continue;
+                }
+                edges.push(ErEdge {
+                    id: format!("{source}->{target}:{}", fk.name),
+                    constraint_name: fk.name.clone(),
+                    source: source.clone(),
+                    target,
+                    source_columns: fk.columns.clone(),
+                    target_columns: fk.referenced_columns.clone(),
+                });
+            }
+        }
+    }
+
+    Some(ErGraph {
+        database: db.name.clone(),
+        schemas: schema_names.into_iter().collect(),
+        nodes,
+        edges,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::{Column, ForeignKey, Schema, Table};
+
+    fn col(name: &str, pk: bool) -> Column {
+        Column {
+            name: name.into(),
+            data_type: "int8".into(),
+            nullable: !pk,
+            default: None,
+            is_primary_key: pk,
+            ordinal: 1,
+            comment: None,
+        }
+    }
+
+    fn table_with_fk(name: &str, fks: Vec<ForeignKey>) -> Table {
+        Table {
+            name: name.into(),
+            schema: "public".into(),
+            row_count: Some(10),
+            columns: vec![col("id", true), col("customer_id", false)],
+            primary_key: vec!["id".into()],
+            foreign_keys: fks,
+            indexes: vec![],
+        }
+    }
+
+    fn sample() -> Vec<Database> {
+        let orders = table_with_fk(
+            "orders",
+            vec![ForeignKey {
+                name: "orders_customer_fk".into(),
+                columns: vec!["customer_id".into()],
+                referenced_schema: "public".into(),
+                referenced_table: "customers".into(),
+                referenced_columns: vec!["id".into()],
+            }],
+        );
+        let customers = table_with_fk("customers", vec![]);
+        let audit = Table {
+            name: "audit".into(),
+            schema: "internal".into(),
+            row_count: None,
+            columns: vec![col("id", true)],
+            primary_key: vec!["id".into()],
+            foreign_keys: vec![],
+            indexes: vec![],
+        };
+        vec![Database {
+            name: "shop".into(),
+            is_default: true,
+            schemas: vec![
+                Schema {
+                    name: "public".into(),
+                    tables: vec![orders, customers],
+                    views: vec![],
+                },
+                Schema {
+                    name: "internal".into(),
+                    tables: vec![audit],
+                    views: vec![],
+                },
+            ],
+        }]
+    }
+
+    #[test]
+    fn builds_nodes_and_edges_for_all_schemas() {
+        let graph = build_er_graph(&sample(), "shop", None).expect("graph");
+        assert_eq!(graph.schemas, vec!["internal", "public"]);
+        assert_eq!(graph.nodes.len(), 3);
+        assert_eq!(graph.edges.len(), 1);
+        let edge = &graph.edges[0];
+        assert_eq!(edge.source, "public.orders");
+        assert_eq!(edge.target, "public.customers");
+        assert_eq!(edge.source_columns, vec!["customer_id"]);
+    }
+
+    #[test]
+    fn marks_foreign_key_columns() {
+        let graph = build_er_graph(&sample(), "shop", None).expect("graph");
+        let orders = graph
+            .nodes
+            .iter()
+            .find(|n| n.id == "public.orders")
+            .unwrap();
+        let fk_col = orders
+            .columns
+            .iter()
+            .find(|c| c.name == "customer_id")
+            .unwrap();
+        assert!(fk_col.is_foreign_key);
+        let pk_col = orders.columns.iter().find(|c| c.name == "id").unwrap();
+        assert!(pk_col.is_primary_key);
+        assert!(!pk_col.is_foreign_key);
+    }
+
+    #[test]
+    fn schema_filter_drops_nodes_and_dangling_edges() {
+        let only_public = vec!["public".to_string()];
+        let graph = build_er_graph(&sample(), "shop", Some(&only_public)).expect("graph");
+        assert_eq!(graph.schemas, vec!["public"]);
+        assert_eq!(graph.nodes.len(), 2);
+        assert_eq!(graph.edges.len(), 1);
+
+        // Filtering to only `internal` keeps the audit node but drops the
+        // public→public edge entirely.
+        let only_internal = vec!["internal".to_string()];
+        let graph = build_er_graph(&sample(), "shop", Some(&only_internal)).expect("graph");
+        assert_eq!(graph.nodes.len(), 1);
+        assert!(graph.edges.is_empty());
+    }
+
+    #[test]
+    fn unknown_database_is_none() {
+        assert!(build_er_graph(&sample(), "nope", None).is_none());
+    }
+}

--- a/crates/cellar-core/src/lib.rs
+++ b/crates/cellar-core/src/lib.rs
@@ -3,12 +3,14 @@
 //! and exported via specta in `apps/desktop/src-tauri`.
 
 pub mod driver;
+pub mod er;
 pub mod error;
 pub mod query;
 pub mod schema;
 pub mod value;
 
 pub use driver::{Connection, ConnectionConfig, Driver, DriverInfo, Engine, EnvTag, SslMode};
+pub use er::{ErColumn, ErEdge, ErGraph, ErNode};
 pub use error::{CellarError, CellarResult};
 pub use query::{
     DatabaseNotice, NoticeCapture, NoticeSeverity, PlanDetail, PlanMode, PlanNode, Query,

--- a/packages/ipc/src/generated.ts
+++ b/packages/ipc/src/generated.ts
@@ -69,6 +69,20 @@ async introspect(connectionId: string, refresh: boolean | null) : Promise<Result
     else return { status: "error", error: e  as any };
 }
 },
+/**
+ * Build the foreign-key graph for the ER diagram view. Reuses the cached
+ * introspection tree (so it never re-hits the server when the schema is warm)
+ * and derives the graph in [`cellar_core::er`]. `schemas` scopes the graph to
+ * a subset of schemas; `None` includes them all.
+ */
+async erGraph(connectionId: string, database: string, schemas: string[] | null) : Promise<Result<ErGraph, CellarError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("er_graph", { connectionId, database, schemas }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async runQuery(connectionId: string, sql: string, maxRows: number | null, offset: number | null, database: string | null, tabId: string | null, queryId: string | null) : Promise<Result<QueryResult, CellarError>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("run_query", { connectionId, sql, maxRows, offset, database, tabId, queryId }) };
@@ -291,6 +305,45 @@ export type Engine = "postgres" | "mysql" | "sqlite" | "mssql" | "azure" | "fire
  * styling and confirmation guardrails — this PR wires the data, not the UX.
  */
 export type EnvTag = "local" | "dev" | "staging" | "prod"
+/**
+ * A column rendered inside an ER node. Carries just enough for the diagram:
+ * name, type, and key-role badges.
+ */
+export type ErColumn = { name: string; data_type: string; nullable: boolean; is_primary_key: boolean; 
+/**
+ * `true` when the column participates in at least one outgoing foreign key.
+ */
+is_foreign_key: boolean }
+/**
+ * A foreign-key relationship, drawn as an edge from the referencing table to
+ * the referenced table.
+ */
+export type ErEdge = { 
+/**
+ * Stable id derived from the endpoints and constraint name.
+ */
+id: string; constraint_name: string; 
+/**
+ * `"schema.table"` of the table that holds the FK columns.
+ */
+source: string; 
+/**
+ * `"schema.table"` of the referenced table.
+ */
+target: string; source_columns: string[]; target_columns: string[] }
+/**
+ * The full graph for one database, scoped to a selection of schemas.
+ */
+export type ErGraph = { database: string; 
+/**
+ * Schema names present in this graph, sorted — drives the show/hide UI.
+ */
+schemas: string[]; nodes: ErNode[]; edges: ErEdge[] }
+/**
+ * One table in the diagram. `id` is `"schema.table"`; edges reference nodes by
+ * this id.
+ */
+export type ErNode = { id: string; schema: string; name: string; columns: ErColumn[]; primary_key: string[]; row_count: number | null }
 export type ForeignKey = { name: string; columns: string[]; referenced_schema: string; referenced_table: string; referenced_columns: string[] }
 export type Index = { name: string; columns: string[]; unique: boolean; primary: boolean }
 export type JsonValue = null | boolean | number | string | JsonValue[] | Partial<{ [key in string]: JsonValue }>

--- a/packages/ipc/src/index.test.ts
+++ b/packages/ipc/src/index.test.ts
@@ -25,6 +25,7 @@ describe("@cellar/ipc", () => {
         "connect",
         "deleteConnection",
         "disconnect",
+        "erGraph",
         "explainQuery",
         "introspect",
         "listQueryHistory",

--- a/packages/ipc/src/mock.ts
+++ b/packages/ipc/src/mock.ts
@@ -9,6 +9,7 @@ import type {
   ConnectionConfig,
   Database,
   DriverInfo,
+  ErGraph,
   QueryPlan,
   QueryHistoryRecord,
   QueryResult,
@@ -53,6 +54,13 @@ export const mockCommands = {
     _connectionId: string,
     _refresh: boolean | null,
   ): Promise<Result<Database[], CellarError>> => ok([]),
+
+  erGraph: async (
+    _connectionId: string,
+    database: string,
+    _schemas: string[] | null,
+  ): Promise<Result<ErGraph, CellarError>> =>
+    ok({ database, schemas: [], nodes: [], edges: [] }),
 
   runQuery: async (
     _connectionId: string,


### PR DESCRIPTION
## Summary
Adds an "ER Diagram" workspace tab that visualizes a Postgres database's tables as nodes and foreign-key relationships as labelled edges, with interactive zoom/pan, auto-arrange, and filtering.

## What changed
- **Backend:** new engine-neutral `cellar-core::er` graph builder (derived from the shared `Schema`/FK contract, so other engines get it for free) and an `er_graph` Tauri command, with regenerated IPC bindings and a web-mode mock.
- **Frontend:** a dependency-free custom SVG renderer (`components/er/`) with zoom/pan, grid auto-arrange, draggable nodes, per-schema show/hide, key-only vs all-fields density, and per-table expand; wired in as a new `er-diagram` tab kind (opened from the sidebar database/schema context menus).

## User impact
Click a table node to open its grid tab, click an edge to jump to the referenced table, and edges anchor at the actual FK/PK column rows; view state (zoom, positions, filters) persists across tab switches.

## Validation
`pnpm typecheck`, `cargo check --workspace`, and `cargo test --workspace` pass; 111 frontend tests pass (incl. new `cellar-core::er` and layout tests). Rendering uses `React.memo` plus viewport culling to stay smooth on 100+ tables.

## Known warnings
`pnpm lint`'s `cargo fmt --check` step reports diffs in pre-existing files I did not touch (`crates/cellar-drivers/mysql/*`, `src-tauri/src/state.rs`) — a rustfmt version skew already present on the branch; new code is formatted clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new UI surface and tab type across the shell, but read-only schema-derived data with tests; no query or mutation paths touched.
> 
> **Overview**
> Adds an **ER diagram** workspace tab that visualizes tables and foreign-key relationships for a connection/database (optionally scoped to one or more schemas).
> 
> **Backend:** New `cellar-core::er` builds `ErGraph` from cached introspection metadata; Tauri exposes `er_graph`, with regenerated IPC types and a web mock.
> 
> **Frontend:** Sidebar **Open ER diagram** on database/schema nodes opens a deduped `er-diagram` tab. Custom SVG UI (`ErDiagram`, layout, node cards) supports zoom/pan, fit/auto-arrange, draggable nodes, schema show/hide, keys-only vs all fields, column expand, viewport culling, and per-tab view state. Clicking a table opens its grid; clicking an edge focuses the referenced table. Tab bar, title bar, bottom panel, and shared `tabLabel` handle the new tab kind.
> 
> **Tests:** Rust unit tests for graph building; Vitest for layout/edge geometry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0b57a05235e0b58b404bcc3b72e714d9c3559c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->