### PR TITLE
Quick filter + advanced filter coexistence, applied server-side

### DIFF
--- a/apps/desktop/src/components/Workspace.tsx
+++ b/apps/desktop/src/components/Workspace.tsx
@@ -6,6 +6,7 @@ import {
 } from "@cellar/data-grid";
 import {
   useCallback,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -182,6 +183,17 @@ function TableTabPane({
   const clearTableChanges = useTabs((s) => s.clearTableChanges);
   const [pageIndex, setPageIndex] = useState(0);
   const [pageSize, setPageSize] = useState(500);
+  const grid = useGridState();
+  // Quick filter is kept separate from the advanced chips (`grid.filters`) so
+  // clearing one never disturbs the other. `quickInput` is the immediate text
+  // box value; `quickFilter` is its debounced form that drives the server query.
+  const [quickInput, setQuickInput] = useState("");
+  const [quickFilter, setQuickFilter] = useState("");
+  const [quickColumn, setQuickColumn] = useState<string | null>(null);
+  useEffect(() => {
+    const handle = setTimeout(() => setQuickFilter(quickInput.trim()), 250);
+    return () => clearTimeout(handle);
+  }, [quickInput]);
   const data = useTableData(
     tab.connectionId,
     tab.database,
@@ -191,8 +203,18 @@ function TableTabPane({
     tab.id,
     pageIndex,
     pageSize,
+    grid.filters,
+    quickFilter,
+    quickColumn,
+    grid.sort,
   );
-  const grid = useGridState();
+  // Filters/sort apply to the whole table, so any change must jump back to the
+  // first page (page size already resets in its own handler below).
+  const filtersKey = JSON.stringify(grid.filters);
+  const sortKey = JSON.stringify(grid.sort);
+  useEffect(() => {
+    setPageIndex(0);
+  }, [filtersKey, sortKey, quickFilter, quickColumn]);
   const [rowMenu, setRowMenu] = useState<ContextMenuState | null>(null);
   const [headerMenu, setHeaderMenu] = useState<ContextMenuState | null>(null);
   const findUsages = useFindUsages((s) => s.findUsages);
@@ -298,6 +320,10 @@ function TableTabPane({
         onEdit={grid.setEditing}
         filters={grid.filters}
         onFiltersChange={grid.setFilters}
+        quickFilter={quickInput}
+        onQuickFilterChange={setQuickInput}
+        quickFilterColumn={quickColumn}
+        onQuickFilterColumnChange={setQuickColumn}
         sort={grid.sort}
         onSortChange={grid.setSort}
         columnLayout={columnLayout}

--- a/apps/desktop/src/hooks/useTableData.ts
+++ b/apps/desktop/src/hooks/useTableData.ts
@@ -2,11 +2,15 @@ import { commands, unwrap } from "@cellar/ipc";
 import type { QueryResult, TableBrowseRequest } from "@cellar/ipc";
 import type {
   CellAlign,
+  FilterClause,
   GridColumn,
   GridRow,
   GridValue,
+  SortState,
 } from "@cellar/data-grid";
 import { useEffect, useState } from "react";
+
+import { buildBrowseFilters, sortToClauses } from "../lib/browseFilters";
 
 import {
   cellValueToGrid,
@@ -61,8 +65,25 @@ export function useTableData(
   tabId?: string,
   pageIndex = 0,
   pageSize = DEFAULT_LIMIT,
+  advancedFilters: readonly FilterClause[] = [],
+  quickFilter = "",
+  quickFilterColumn: string | null = null,
+  sort: SortState = null,
 ): TableData {
   const offset = pageIndex * pageSize;
+  // Column metadata comes from the connection cache so the filter/sort mapping
+  // is stable across page loads (the query result columns get a fresh identity
+  // every fetch, which would otherwise re-trigger the effect below).
+  const columnMeta = tableColumnsMeta(connectionId, database, schema, table);
+  const filters = buildBrowseFilters(
+    columnMeta,
+    advancedFilters,
+    quickFilter,
+    quickFilterColumn,
+  );
+  const sorts = sortToClauses(sort);
+  const filtersKey = JSON.stringify(filters);
+  const sortsKey = JSON.stringify(sorts);
   const [state, setState] = useState<TableData>({
     columns: [],
     rows: [],
@@ -96,8 +117,8 @@ export function useTableData(
       table,
       limit: pageSize,
       offset,
-      sorts: [],
-      filters: [],
+      sorts,
+      filters,
       primary_key_fallback_ordering: true,
       // Request total count only on the first page so the pagination bar can
       // show "rows X-Y of TOTAL". Subsequent pages re-use the cached total.
@@ -188,7 +209,7 @@ export function useTableData(
     return () => {
       cancelled = true;
     };
-  }, [connectionId, database, schema, table, refreshKey, tabId, offset, pageSize]);
+  }, [connectionId, database, schema, table, refreshKey, tabId, offset, pageSize, filtersKey, sortsKey]);
 
   return state;
 }
@@ -257,6 +278,32 @@ function columnsFor(
       nullable: meta ? meta.nullable : c.nullable,
     };
   });
+}
+
+/**
+ * Minimal column metadata from the connection cache (available before the first
+ * query result), used to compile quick/advanced filters into the browse request.
+ */
+function tableColumnsMeta(
+  connectionId: string,
+  database: string,
+  schema: string,
+  table: string,
+): GridColumn[] {
+  const cache = useConnections.getState().byId[connectionId];
+  const tableMeta = cache?.databases
+    .filter((d) => d.name === database)
+    .flatMap((d) => d.schemas)
+    .find((s) => s.name === schema)
+    ?.tables.find((t) => t.name === table);
+  return (tableMeta?.columns ?? []).map((c) => ({
+    key: c.name,
+    name: c.name,
+    type: c.data_type,
+    width: 0,
+    pk: c.is_primary_key,
+    nullable: c.nullable,
+  }));
 }
 
 function tablePrimaryKey(

--- a/apps/desktop/src/lib/browseFilters.test.ts
+++ b/apps/desktop/src/lib/browseFilters.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import type { FilterClause, GridColumn } from "@cellar/data-grid";
+import {
+  advancedFiltersToClauses,
+  buildBrowseFilters,
+  quickFilterToClause,
+  sortToClauses,
+} from "./browseFilters";
+
+const columns: GridColumn[] = [
+  { key: "id", name: "id", type: "int4", width: 0, pk: true },
+  { key: "status", name: "status", type: "text", width: 0 },
+  { key: "name", name: "name", type: "varchar", width: 0 },
+];
+
+const chip = (over: Partial<FilterClause>): FilterClause => ({
+  id: over.id ?? "c1",
+  columnKey: over.columnKey ?? "status",
+  operator: over.operator ?? "equals",
+  logic: over.logic ?? "and",
+  value: over.value,
+});
+
+describe("advancedFiltersToClauses", () => {
+  it("maps a supported chip to a server clause", () => {
+    expect(advancedFiltersToClauses([chip({ value: "active" })])).toEqual([
+      { column: "status", operator: "equals", value: "active" },
+    ]);
+  });
+
+  it("emits null value for null-check operators", () => {
+    expect(
+      advancedFiltersToClauses([chip({ operator: "isNull" })]),
+    ).toEqual([{ column: "status", operator: "is_null", value: null }]);
+  });
+
+  it("drops value-needing chips with empty values", () => {
+    expect(advancedFiltersToClauses([chip({ value: "  " })])).toEqual([]);
+  });
+
+  it("skips operators without a server equivalent (startsWith)", () => {
+    expect(
+      advancedFiltersToClauses([chip({ operator: "startsWith", value: "a" })]),
+    ).toEqual([]);
+  });
+
+  it("pushes nothing when chips use OR (no server grouping)", () => {
+    expect(
+      advancedFiltersToClauses([
+        chip({ id: "a", value: "x" }),
+        chip({ id: "b", columnKey: "name", value: "y", logic: "or" }),
+      ]),
+    ).toEqual([]);
+  });
+});
+
+describe("quickFilterToClause", () => {
+  it("matches a numeric value against the id/PK column with equals", () => {
+    expect(quickFilterToClause("42", columns, null)).toEqual({
+      column: "id",
+      operator: "equals",
+      value: "42",
+    });
+  });
+
+  it("falls back to contains on the first text column for free text", () => {
+    expect(quickFilterToClause("acme", columns, null)).toEqual({
+      column: "status",
+      operator: "contains",
+      value: "acme",
+    });
+  });
+
+  it("uses the selected text column when provided", () => {
+    expect(quickFilterToClause("acme", columns, "name")).toEqual({
+      column: "name",
+      operator: "contains",
+      value: "acme",
+    });
+  });
+
+  it("returns null for an empty value", () => {
+    expect(quickFilterToClause("   ", columns, null)).toBeNull();
+  });
+});
+
+describe("buildBrowseFilters", () => {
+  it("combines advanced clauses with the quick filter (server ANDs them)", () => {
+    const result = buildBrowseFilters(
+      columns,
+      [chip({ value: "active" })],
+      "42",
+      null,
+    );
+    expect(result).toEqual([
+      { column: "status", operator: "equals", value: "active" },
+      { column: "id", operator: "equals", value: "42" },
+    ]);
+  });
+});
+
+describe("sortToClauses", () => {
+  it("maps a sort state to a single clause", () => {
+    expect(sortToClauses({ columnKey: "name", direction: "desc" })).toEqual([
+      { column: "name", direction: "desc" },
+    ]);
+  });
+
+  it("returns nothing when unsorted", () => {
+    expect(sortToClauses(null)).toEqual([]);
+  });
+});

--- a/apps/desktop/src/lib/browseFilters.ts
+++ b/apps/desktop/src/lib/browseFilters.ts
@@ -1,0 +1,115 @@
+import { operatorsForColumn } from "@cellar/data-grid";
+import type {
+  FilterClause,
+  FilterOperator,
+  GridColumn,
+  SortState,
+} from "@cellar/data-grid";
+import type {
+  TableFilterClause,
+  TableFilterOperator,
+  TableSortClause,
+} from "@cellar/ipc";
+
+/**
+ * Maps the grid's advanced filter chips and the toolbar quick filter into the
+ * server-side `TableBrowseRequest` filter/sort model so browse applies them to
+ * the whole table instead of just the loaded page.
+ */
+
+const ADVANCED_OPERATOR_MAP: Partial<Record<FilterOperator, TableFilterOperator>> = {
+  equals: "equals",
+  notEquals: "not_equals",
+  contains: "contains",
+  greaterThan: "greater_than",
+  lessThan: "less_than",
+  isNull: "is_null",
+  isNotNull: "is_not_null",
+  // `startsWith` has no server operator — it stays a local page filter.
+};
+
+function operatorNeedsValue(operator: TableFilterOperator): boolean {
+  return operator !== "is_null" && operator !== "is_not_null";
+}
+
+export function advancedFiltersToClauses(
+  filters: readonly FilterClause[],
+): TableFilterClause[] {
+  // The drivers AND every clause together with no grouping. If the chips use
+  // OR we can't express it server-side, so push nothing and let the grid keep
+  // filtering the loaded page locally (the pre-existing behavior).
+  // ponytail: OR-across-chips needs a backend grouping model — deferred (W3).
+  if (filters.some((clause, index) => index > 0 && clause.logic === "or")) {
+    return [];
+  }
+
+  const clauses: TableFilterClause[] = [];
+  for (const filter of filters) {
+    const operator = ADVANCED_OPERATOR_MAP[filter.operator];
+    if (!operator) continue;
+    const needsValue = operatorNeedsValue(operator);
+    const value = (filter.value ?? "").trim();
+    if (needsValue && value.length === 0) continue;
+    clauses.push({
+      column: filter.columnKey,
+      operator,
+      value: needsValue ? value : null,
+    });
+  }
+  return clauses;
+}
+
+const ID_VALUE = /^-?\d+$/;
+
+/** A text-ish column accepts `contains` (ILIKE) — reuse the grid's own rule. */
+export function isTextColumn(column: GridColumn): boolean {
+  return operatorsForColumn(column).includes("contains");
+}
+
+export function firstTextColumnKey(columns: readonly GridColumn[]): string | null {
+  return columns.find(isTextColumn)?.key ?? null;
+}
+
+function idLikeColumnKey(columns: readonly GridColumn[]): string | null {
+  return (
+    columns.find((column) => column.pk)?.key ??
+    columns.find((column) => column.key.toLowerCase() === "id")?.key ??
+    null
+  );
+}
+
+export function quickFilterToClause(
+  quickFilter: string,
+  columns: readonly GridColumn[],
+  targetColumnKey: string | null,
+): TableFilterClause | null {
+  const value = quickFilter.trim();
+  if (value.length === 0) return null;
+
+  // Numeric value + an id/PK column → exact match on the id.
+  if (ID_VALUE.test(value)) {
+    const idColumn = idLikeColumnKey(columns);
+    if (idColumn) return { column: idColumn, operator: "equals", value };
+  }
+
+  // Otherwise a contains search on the chosen (or first) text column.
+  const target = targetColumnKey ?? firstTextColumnKey(columns);
+  if (!target) return null;
+  return { column: target, operator: "contains", value };
+}
+
+export function buildBrowseFilters(
+  columns: readonly GridColumn[],
+  advancedFilters: readonly FilterClause[],
+  quickFilter: string,
+  quickFilterColumn: string | null,
+): TableFilterClause[] {
+  const clauses = advancedFiltersToClauses(advancedFilters);
+  const quick = quickFilterToClause(quickFilter, columns, quickFilterColumn);
+  return quick ? [...clauses, quick] : clauses;
+}
+
+export function sortToClauses(sort: SortState): TableSortClause[] {
+  if (!sort) return [];
+  return [{ column: sort.columnKey, direction: sort.direction }];
+}

--- a/apps/desktop/src/styles/grid.css
+++ b/apps/desktop/src/styles/grid.css
@@ -205,6 +205,40 @@
   font-size: 10.5px;
 }
 
+/* ── quick filter (pinned, alongside advanced chips) ──────── */
+.grid-quickfilter {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+  padding-right: 8px;
+  border-right: 1px solid var(--border-default);
+}
+.grid-quickfilter-input {
+  height: 18px;
+  width: 160px;
+  padding: 0 6px;
+  border: 1px solid var(--border-default);
+  border-radius: 3px;
+  background: var(--bg-inset);
+  color: var(--fg-0);
+  font-size: 10.5px;
+  outline: none;
+}
+.grid-quickfilter-input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent-line);
+}
+.grid-quickfilter-column { max-width: 120px; }
+.grid-filter-active-count {
+  padding: 0 5px;
+  border-radius: 8px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 9.5px;
+  font-weight: 600;
+}
+
 /* ── table scroll + rows ──────────────────────────────────── */
 .grid-scroll {
   flex: 1;

--- a/packages/data-grid/src/DataGrid.tsx
+++ b/packages/data-grid/src/DataGrid.tsx
@@ -110,6 +110,16 @@ export type DataGridProps = {
   filters: ColumnFilters;
   onFiltersChange: (next: ColumnFilters) => void;
 
+  /**
+   * Quick filter pinned in the toolbar. Independent of the advanced filter
+   * chips: clearing one never touches the other. When omitted, the quick filter
+   * input is hidden. The compiled clause is applied server-side by the host.
+   */
+  quickFilter?: string;
+  onQuickFilterChange?: (next: string) => void;
+  quickFilterColumn?: string | null;
+  onQuickFilterColumnChange?: (next: string | null) => void;
+
   sort?: SortState;
   onSortChange?: (next: SortState) => void;
 
@@ -204,6 +214,10 @@ export function DataGrid({
   onEdit,
   filters,
   onFiltersChange,
+  quickFilter,
+  onQuickFilterChange,
+  quickFilterColumn,
+  onQuickFilterColumnChange,
   sort,
   onSortChange,
   columnLayout,
@@ -662,6 +676,10 @@ export function DataGrid({
         columns={renderedColumns}
         filters={filters}
         setFilters={onFiltersChange}
+        quickFilter={quickFilter}
+        onQuickFilterChange={onQuickFilterChange}
+        quickFilterColumn={quickFilterColumn}
+        onQuickFilterColumnChange={onQuickFilterColumnChange}
         totalRows={rows.length}
         filteredRows={visibleRows.length}
         serverRows={totalRows}

--- a/packages/data-grid/src/FilterBar.tsx
+++ b/packages/data-grid/src/FilterBar.tsx
@@ -28,6 +28,15 @@ export type FilterBarProps = {
   columns: readonly GridColumn[];
   filters: ColumnFilters;
   setFilters: (next: ColumnFilters) => void;
+  /**
+   * Optional quick filter, pinned at the start of the toolbar. Lives alongside
+   * the advanced chips — clearing one never touches the other. Hidden when no
+   * `onQuickFilterChange` is supplied.
+   */
+  quickFilter?: string;
+  onQuickFilterChange?: (next: string) => void;
+  quickFilterColumn?: string | null;
+  onQuickFilterColumnChange?: (next: string | null) => void;
   totalRows: number;
   filteredRows: number;
   serverRows?: number;
@@ -37,6 +46,10 @@ export function FilterBar({
   columns,
   filters,
   setFilters,
+  quickFilter,
+  onQuickFilterChange,
+  quickFilterColumn,
+  onQuickFilterColumnChange,
   totalRows,
   filteredRows,
   serverRows,
@@ -138,11 +151,63 @@ export function FilterBar({
   const canApply =
     !!draft && !!draftColumn && (!needsValue || draft.value.trim().length > 0);
 
+  // Quick filter targets a single text-ish column (one that accepts `contains`).
+  const textColumns = useMemo(
+    () => columns.filter((column) => operatorsForColumn(column).includes("contains")),
+    [columns],
+  );
+  const showQuickFilter = !!onQuickFilterChange;
+  const quickValue = quickFilter ?? "";
+  const quickColumnValue = quickFilterColumn ?? textColumns[0]?.key ?? "";
+  const quickActive = quickValue.trim().length > 0;
+  const activeCount = filters.length + (quickActive ? 1 : 0);
+
   return (
     <div className="grid-filterbar">
+      {showQuickFilter && (
+        <div className="grid-quickfilter">
+          <GridIcon.search size={11} style={{ color: "var(--fg-3)" }} />
+          <input
+            className="grid-quickfilter-input mono"
+            value={quickValue}
+            onChange={(e) => onQuickFilterChange?.(e.target.value)}
+            placeholder="Quick filter (id or text)…"
+            aria-label="Quick filter"
+          />
+          {textColumns.length > 0 && (
+            <select
+              className="grid-filter-select grid-quickfilter-column"
+              value={quickColumnValue}
+              onChange={(e) => onQuickFilterColumnChange?.(e.target.value || null)}
+              aria-label="Quick filter column"
+              title="Text column searched by the quick filter (numeric values match the id/primary key)"
+            >
+              {textColumns.map((column) => (
+                <option key={column.key} value={column.key}>
+                  {column.name}
+                </option>
+              ))}
+            </select>
+          )}
+          {quickActive && (
+            <button
+              className="grid-filter-remove"
+              onClick={() => onQuickFilterChange?.("")}
+              aria-label="Clear quick filter"
+            >
+              <GridIcon.close size={9} />
+            </button>
+          )}
+        </div>
+      )}
       <div className="grid-filterbar-label">
         <GridIcon.filter size={11} style={{ color: "var(--accent)" }} />
         <span>where</span>
+        {activeCount > 0 && (
+          <span className="grid-filter-active-count" title="Active filters (quick + advanced)">
+            {activeCount} active
+          </span>
+        )}
       </div>
       <div className="grid-filterbar-chips">
         {filters.map((clause, index) => {

--- a/packages/data-grid/src/icons.tsx
+++ b/packages/data-grid/src/icons.tsx
@@ -55,6 +55,12 @@ export const GridIcon = {
     </I>
   ),
   filter: (p: IconProps) => <I {...p} d="M3 5h18l-7 9v6l-4-2v-4z" />,
+  search: (p: IconProps) => (
+    <I {...p}>
+      <circle cx="11" cy="11" r="7" />
+      <path d="M21 21l-4.3-4.3" />
+    </I>
+  ),
   sortAsc: (p: IconProps) => (
     <I {...p}>
       <path d="M7 4v16M3 16l4 4 4-4" />


### PR DESCRIPTION
Implements wishlist W3: a debounced quick filter pinned in the table toolbar that lives alongside the advanced filter chips, each independently clearable with a combined active-filter indicator. Table browse now compiles the active advanced chips, quick filter, and sort into `TableBrowseRequest` and sends them to `browse_table`, so filtering/sorting apply to the whole table and the total count instead of only the loaded page. The quick filter maps to one server clause — numeric values match the id/PK column with equals, otherwise a `contains` search on a chosen text column — while advanced chips map to the existing filter clauses. OR-across-chips stays a local page filter until the backend grows a grouping model. Page index resets to 0 whenever filters/quick filter/sort/page size change, and pagination/total-count behavior is preserved. Adds focused tests for the filter/sort mapping in `browseFilters.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how table data is fetched and paginated (query shape and refetch triggers); logic is covered by unit tests but OR filters and some operators still fall back to local-only behavior.
> 
> **Overview**
> **Table browse** now sends **advanced filter chips**, a **debounced quick filter**, and **column sort** to `browse_table` via `TableBrowseRequest`, so filtering and sorting apply to the **whole table** (and total row count) instead of only the loaded page.
> 
> A new **`browseFilters`** layer maps grid state to IPC clauses: advanced chips (AND-only; OR and unsupported ops like `startsWith` stay client-side on the page), quick filter (numeric → PK/`id` equals, otherwise `contains` on a chosen text column), and sort. **`useTableData`** includes filters/sorts in the request and refetches when they change; **`Workspace`** resets to page 0 on filter/sort/quick changes.
> 
> The data grid gains an optional **quick filter** toolbar (independent from advanced chips, combined **active** count) plus styling and a search icon. Tests cover the mapping in **`browseFilters.test.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f28aac0704cd8615d8b1e1266d1df0eba8ab7ac1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->