### PR TITLE
fix(grid): stop freezing first two columns by default

### DIFF
--- a/packages/data-grid/src/DataGrid.tsx
+++ b/packages/data-grid/src/DataGrid.tsx
@@ -222,7 +222,7 @@ export function DataGrid({
   onSortChange,
   columnLayout,
   onColumnLayoutChange,
-  frozenCount = 2,
+  frozenCount = 0,
   totalRows,
   pagination,
   onCommit,


### PR DESCRIPTION
The data grid hardcoded `frozenCount = 2`, pinning the first two columns of every result with a thick divider after them — even though no caller set it and no setting backed it. This surfaced as an unexplained "freeze panes" effect that confused users. This changes the default to `0` so columns only freeze when a caller explicitly opts in; the frozen-column capability (prop + CSS) stays intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)