### PR TITLE
Clarify prod DML confirmation message

### DIFF
--- a/apps/desktop/src/components/modals/ConnectionDialog.tsx
+++ b/apps/desktop/src/components/modals/ConnectionDialog.tsx
@@ -406,7 +406,7 @@ export function ConnectionDialog({
               {envTag === "prod" && (
                 <span className="ml-2 inline-flex items-center gap-1 text-[10.5px] text-warn">
                   <Icon.warn size={10} />
-                  <span>prod requires confirmation for DML</span>
+                  <span>prod will ask you to confirm before changing data (insert / update / delete)</span>
                 </span>
               )}
             </FormRow>


### PR DESCRIPTION
Replaces the jargon "prod requires confirmation for DML" in the connection dialog with plain language: "prod will ask you to confirm before changing data (insert / update / delete)". The term DML was unclear to users unfamiliar with SQL terminology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)