### PR TITLE
fix(sqlserver): decode date/time columns; strengthen grid column separators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,6 +508,7 @@ version = "0.2.0"
 dependencies = [
  "async-trait",
  "cellar-core",
+ "chrono",
  "futures-util",
  "thiserror 1.0.69",
  "tiberius",

--- a/apps/desktop/src/styles/grid.css
+++ b/apps/desktop/src/styles/grid.css
@@ -285,7 +285,7 @@
   text-overflow: ellipsis;
   position: relative;
   flex-shrink: 0;
-  border-right: 1px solid var(--border-divider);
+  border-right: 1px solid var(--grid-column-line);
 }
 .grid-row:hover { background: var(--bg-2); }
 /* Stripe rows: the .is-stripe class is applied in JS (GridRowView) using the
@@ -321,7 +321,7 @@
   justify-content: center;
   color: var(--fg-3);
   background: var(--bg-1);
-  border-right: 1px solid var(--border-divider);
+  border-right: 1px solid var(--grid-column-line);
   font-size: 10px;
   position: sticky;
   left: 0;
@@ -375,7 +375,7 @@
   text-transform: none;
   background: var(--bg-1);
   cursor: pointer;
-  border-right: 1px solid var(--border-default);
+  border-right: 1px solid var(--grid-column-line);
 }
 .grid-header-cell:hover { background: var(--bg-2); }
 .grid-header-cell:focus-visible {

--- a/apps/desktop/src/styles/tokens.css
+++ b/apps/desktop/src/styles/tokens.css
@@ -16,6 +16,9 @@
   --border-default: rgba(255, 255, 255, 0.075);
   --border-strong: rgba(255, 255, 255, 0.12);
   --border-divider: rgba(255, 255, 255, 0.06);
+  /* Vertical separator between grid columns: stronger than the row divider so
+     columns read as distinct. */
+  --grid-column-line: rgba(255, 255, 255, 0.11);
 
   /* Text */
   --fg-0: #ecedef;
@@ -105,6 +108,7 @@
   --border-default: rgba(0, 0, 0, 0.09);
   --border-strong: rgba(0, 0, 0, 0.16);
   --border-divider: rgba(0, 0, 0, 0.07);
+  --grid-column-line: rgba(0, 0, 0, 0.13);
 
   --fg-0: #15171b;
   --fg-1: #43464d;

--- a/crates/cellar-drivers/sqlserver/Cargo.toml
+++ b/crates/cellar-drivers/sqlserver/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [dependencies]
 cellar-core = { path = "../../cellar-core" }
+chrono = { version = "0.4", default-features = false }
 async-trait = "0.1"
 futures-util = "0.3"
 tokio = { workspace = true }

--- a/crates/cellar-drivers/sqlserver/src/decode.rs
+++ b/crates/cellar-drivers/sqlserver/src/decode.rs
@@ -1,7 +1,42 @@
 use cellar_core::value::CellValue;
-use tiberius::ColumnData;
+use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+use tiberius::{ColumnData, FromSql};
 
 pub fn decode_cell(value: ColumnData<'static>) -> CellValue {
+    // Temporal types: decode via tiberius's chrono FromSql impls into the typed
+    // CellValue variants. The inner ColumnData::DateTime2 etc. only implement
+    // Debug, so formatting them directly yields "DateTime2 { date: Date(0) }".
+    match &value {
+        ColumnData::DateTime(_) | ColumnData::SmallDateTime(_) | ColumnData::DateTime2(_) => {
+            return NaiveDateTime::from_sql(&value)
+                .ok()
+                .flatten()
+                .map(CellValue::Timestamp)
+                .unwrap_or(CellValue::Null);
+        }
+        ColumnData::DateTimeOffset(_) => {
+            return DateTime::<Utc>::from_sql(&value)
+                .ok()
+                .flatten()
+                .map(CellValue::TimestampTz)
+                .unwrap_or(CellValue::Null);
+        }
+        ColumnData::Date(_) => {
+            return NaiveDate::from_sql(&value)
+                .ok()
+                .flatten()
+                .map(CellValue::Date)
+                .unwrap_or(CellValue::Null);
+        }
+        ColumnData::Time(_) => {
+            return NaiveTime::from_sql(&value)
+                .ok()
+                .flatten()
+                .map(CellValue::Time)
+                .unwrap_or(CellValue::Null);
+        }
+        _ => {}
+    }
     match value {
         ColumnData::U8(v) => v
             .map(|v| CellValue::Int(v as i64))
@@ -31,23 +66,12 @@ pub fn decode_cell(value: ColumnData<'static>) -> CellValue {
         ColumnData::Xml(v) => v
             .map(|v| CellValue::Text(format!("{v:?}")))
             .unwrap_or(CellValue::Null),
-        ColumnData::DateTime(v) => v
-            .map(|v| CellValue::Text(format!("{v:?}")))
-            .unwrap_or(CellValue::Null),
-        ColumnData::SmallDateTime(v) => v
-            .map(|v| CellValue::Text(format!("{v:?}")))
-            .unwrap_or(CellValue::Null),
-        ColumnData::Time(v) => v
-            .map(|v| CellValue::Text(format!("{v:?}")))
-            .unwrap_or(CellValue::Null),
-        ColumnData::Date(v) => v
-            .map(|v| CellValue::Text(format!("{v:?}")))
-            .unwrap_or(CellValue::Null),
-        ColumnData::DateTime2(v) => v
-            .map(|v| CellValue::Text(format!("{v:?}")))
-            .unwrap_or(CellValue::Null),
-        ColumnData::DateTimeOffset(v) => v
-            .map(|v| CellValue::Text(format!("{v:?}")))
-            .unwrap_or(CellValue::Null),
+        // Temporal variants handled above via FromSql.
+        ColumnData::DateTime(_)
+        | ColumnData::SmallDateTime(_)
+        | ColumnData::Time(_)
+        | ColumnData::Date(_)
+        | ColumnData::DateTime2(_)
+        | ColumnData::DateTimeOffset(_) => unreachable!("handled above"),
     }
 }


### PR DESCRIPTION
SQL Server date/time columns were rendering as Rust Debug output (e.g. `DateTime2 { date: Date(0) }`) because every temporal `ColumnData` variant was formatted with `{:?}`. They're now decoded through tiberius's chrono `FromSql` impls into the typed `CellValue` temporal variants, matching the Postgres driver so the existing IPC → grid path renders them as ISO strings. Separately, grid columns were hard to distinguish because the vertical separator used the near-invisible `--border-divider` token; a new grid-scoped `--grid-column-line` token (stronger, theme-aware) now drives the body cell, header cell, and row-number gutter separators without affecting other dividers in the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)