### PR TITLE
Validate grid cell edits by type; replace native datetime picker with a calendar

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -22,6 +22,7 @@
     "@tauri-apps/plugin-process": "^2.0.0",
     "@tauri-apps/plugin-updater": "^2.0.0",
     "react": "^18.3.1",
+    "react-day-picker": "^10.0.1",
     "react-dom": "^18.3.1",
     "zustand": "^4.5.0"
   },

--- a/apps/desktop/src/components/Workspace.tsx
+++ b/apps/desktop/src/components/Workspace.tsx
@@ -14,6 +14,7 @@ import {
 } from "react";
 
 import { SqlEditor } from "./SqlEditor";
+import { renderGridEditor } from "./grid/GridDateEditor";
 import { SchemaComparePane } from "./SchemaComparePane";
 import { ErDiagram } from "./er/ErDiagram";
 import { ContextMenu, type ContextMenuState } from "./ContextMenu";
@@ -318,6 +319,7 @@ function TableTabPane({
         onSelect={grid.setSelection}
         editing={grid.editing}
         onEdit={grid.setEditing}
+        renderEditor={renderGridEditor}
         filters={grid.filters}
         onFiltersChange={grid.setFilters}
         quickFilter={quickInput}

--- a/apps/desktop/src/components/grid/GridDateEditor.test.ts
+++ b/apps/desktop/src/components/grid/GridDateEditor.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { parseTime, ymd } from "./GridDateEditor";
+
+describe("ymd", () => {
+  it("formats from local components (no UTC day-shift)", () => {
+    // Construct via local Y/M/D so the test is timezone-independent.
+    expect(ymd(new Date(2023, 3, 3))).toBe("2023-04-03");
+    expect(ymd(new Date(2023, 10, 8))).toBe("2023-11-08");
+  });
+});
+
+describe("parseTime", () => {
+  it("extracts HH:MM:SS from a stored timestamp, padding seconds", () => {
+    expect(parseTime("2023-04-03T05:00:31.15863")).toBe("05:00:31");
+    expect(parseTime("2023-04-03T05:00")).toBe("05:00:00");
+  });
+
+  it("defaults to midnight when no time is present", () => {
+    expect(parseTime("2023-04-03")).toBe("00:00:00");
+  });
+});

--- a/apps/desktop/src/components/grid/GridDateEditor.tsx
+++ b/apps/desktop/src/components/grid/GridDateEditor.tsx
@@ -76,7 +76,7 @@ function GridDateEditor({
 
   return (
     <>
-      <div ref={anchorRef} className="grid-date-anchor mono">
+      <div ref={anchorRef} className="cell-edit-input grid-date-anchor mono">
         {initial || "—"}
       </div>
       <CalendarPopover anchorRef={anchorRef} onOutside={commit} onEscape={onCancel}>

--- a/apps/desktop/src/components/grid/GridDateEditor.tsx
+++ b/apps/desktop/src/components/grid/GridDateEditor.tsx
@@ -1,0 +1,206 @@
+/**
+ * A calendar-based inline editor for date / datetime grid cells, injected into
+ * the data-grid via its `renderEditor` prop. The grid package is deliberately
+ * dependency-free, so the heavier UI (react-day-picker — the library shadcn/ui
+ * wraps) lives here in the desktop app where Tailwind and the design tokens are.
+ *
+ * It only claims date and timestamp columns; time/number/text fall back to the
+ * grid's built-in editor (`renderGridEditor` returns null for those).
+ */
+import { nativeControl, type CellEditorProps } from "@cellar/data-grid";
+import { useLayoutEffect, useRef, useState } from "react";
+import { DayPicker } from "react-day-picker";
+
+const pad = (n: number) => String(n).padStart(2, "0");
+// Format from local components, NOT toISOString(), so a date picked in the
+// user's timezone doesn't shift a day when serialised.
+export const ymd = (d: Date) =>
+  `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+
+/** Best-effort parse of a stored cell value into a Date for the calendar. */
+export function parseDate(raw: string): Date | undefined {
+  const ms = Date.parse(raw);
+  return Number.isNaN(ms) ? undefined : new Date(ms);
+}
+
+/** Pull an HH:MM:SS time out of a stored timestamp string, defaulting to 00s. */
+export function parseTime(raw: string): string {
+  // No \b before the hour: in "...T05:00:31" there's no word boundary between
+  // the separator letter and the digits, which would otherwise skip to "00:31".
+  const m = /(\d{2}:\d{2}(?::\d{2})?)/.exec(raw);
+  const hms = m?.[1];
+  if (!hms) return "00:00:00";
+  return hms.length === 5 ? `${hms}:00` : hms;
+}
+
+type Kind = "date" | "datetime";
+
+/**
+ * Returns the editor element when this column is a date/datetime, else null so
+ * the grid uses its built-in editor. Wire as `<DataGrid renderEditor={renderGridEditor} />`.
+ */
+export function renderGridEditor(props: CellEditorProps) {
+  const initial = props.value == null ? "" : String(props.value);
+  const control = nativeControl(props.col, initial);
+  if (control?.type === "date") return <GridDateEditor {...props} kind="date" />;
+  if (control?.type === "datetime-local")
+    return <GridDateEditor {...props} kind="datetime" />;
+  return null;
+}
+
+function GridDateEditor({
+  value,
+  onCommit,
+  onCancel,
+  kind,
+}: CellEditorProps & { kind: Kind }) {
+  const initial = value == null ? "" : String(value);
+  const [date, setDate] = useState<Date | undefined>(() => parseDate(initial));
+  const [time, setTime] = useState(() => parseTime(initial));
+  const anchorRef = useRef<HTMLDivElement | null>(null);
+
+  const commit = () => {
+    if (!date) {
+      // Nothing chosen — leave the cell unchanged.
+      onCancel();
+      return;
+    }
+    onCommit(kind === "datetime" ? `${ymd(date)}T${time}` : ymd(date));
+  };
+
+  return (
+    <>
+      <div ref={anchorRef} className="grid-date-anchor mono">
+        {initial || "—"}
+      </div>
+      <CalendarPopover anchorRef={anchorRef} onOutside={commit} onEscape={onCancel}>
+        <DayPicker
+          mode="single"
+          selected={date}
+          onSelect={setDate}
+          defaultMonth={date}
+          showOutsideDays
+          autoFocus
+        />
+        {kind === "datetime" && (
+          <label className="grid-date-popover-time">
+            Time
+            <input
+              type="time"
+              step={1}
+              value={time}
+              onChange={(e) => setTime(e.target.value || "00:00:00")}
+            />
+          </label>
+        )}
+        <div className="grid-date-popover-actions">
+          <button type="button" className="gdp-cancel" onClick={onCancel}>
+            Cancel
+          </button>
+          <button type="button" className="gdp-apply" onClick={commit}>
+            Apply
+          </button>
+        </div>
+      </CalendarPopover>
+    </>
+  );
+}
+
+/**
+ * A fixed-position popover anchored under the editing cell. Escape cancels;
+ * clicking away or scrolling commits (the usual "click-off applies" behaviour
+ * of a picker). Uses `position: fixed` with a one-pass correction so it escapes
+ * the grid cell's `overflow: hidden` and any transformed layout ancestor.
+ */
+function CalendarPopover({
+  anchorRef,
+  onOutside,
+  onEscape,
+  children,
+}: {
+  anchorRef: React.RefObject<HTMLElement | null>;
+  onOutside: () => void;
+  onEscape: () => void;
+  children: React.ReactNode;
+}) {
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const targetRef = useRef<{ top: number; left: number } | null>(null);
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+  const [settled, setSettled] = useState(false);
+
+  // Pass 1 — intended viewport position from the cell box.
+  useLayoutEffect(() => {
+    const cell =
+      (anchorRef.current?.closest(".grid-cell") as HTMLElement | null) ??
+      anchorRef.current;
+    if (!cell) return;
+    const r = cell.getBoundingClientRect();
+    const h = panelRef.current?.offsetHeight ?? 0;
+    const w = panelRef.current?.offsetWidth ?? 300;
+    const left = Math.max(8, Math.min(r.left, window.innerWidth - w - 8));
+    const below = r.bottom;
+    const top =
+      below + h <= window.innerHeight - 8 ? below : Math.max(8, r.top - h);
+    targetRef.current = { top, left };
+    setSettled(false);
+    setPos({ top, left });
+  }, [anchorRef]);
+
+  // Pass 2 — fixed is resolved against the nearest transformed ancestor (not
+  // the viewport here), so nudge by the delta between intended and actual.
+  useLayoutEffect(() => {
+    const panel = panelRef.current;
+    const target = targetRef.current;
+    if (!panel || !target || !pos) return;
+    const actual = panel.getBoundingClientRect();
+    const dx = target.left - actual.left;
+    const dy = target.top - actual.top;
+    if (Math.abs(dx) < 0.5 && Math.abs(dy) < 0.5) {
+      if (!settled) setSettled(true);
+      return;
+    }
+    setPos({ top: pos.top + dy, left: pos.left + dx });
+  }, [pos, settled]);
+
+  useLayoutEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onEscape();
+      } else if (e.key === "Enter") {
+        e.stopPropagation();
+        onOutside();
+      }
+    };
+    const onPointerDown = (e: MouseEvent) => {
+      if (!panelRef.current?.contains(e.target as Node | null)) onOutside();
+    };
+    const onScroll = (e: Event) => {
+      if (panelRef.current?.contains(e.target as Node | null)) return;
+      onOutside();
+    };
+    window.addEventListener("keydown", onKey, true);
+    window.addEventListener("mousedown", onPointerDown, true);
+    window.addEventListener("scroll", onScroll, true);
+    return () => {
+      window.removeEventListener("keydown", onKey, true);
+      window.removeEventListener("mousedown", onPointerDown, true);
+      window.removeEventListener("scroll", onScroll, true);
+    };
+  }, [onOutside, onEscape]);
+
+  return (
+    <div
+      ref={panelRef}
+      className="grid-date-popover"
+      role="dialog"
+      style={
+        pos
+          ? { top: pos.top, left: pos.left, visibility: settled ? "visible" : "hidden" }
+          : { visibility: "hidden" }
+      }
+    >
+      {children}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/grid/GridDateEditor.tsx
+++ b/apps/desktop/src/components/grid/GridDateEditor.tsx
@@ -33,11 +33,12 @@ export function parseTime(raw: string): string {
   return hms.length === 5 ? `${hms}:00` : hms;
 }
 
-type Kind = "date" | "datetime";
+type Kind = "date" | "datetime" | "time";
 
 /**
- * Returns the editor element when this column is a date/datetime, else null so
- * the grid uses its built-in editor. Wire as `<DataGrid renderEditor={renderGridEditor} />`.
+ * Returns the editor element when this column is a date/datetime/time, else
+ * null so the grid uses its built-in editor. Wire as
+ * `<DataGrid renderEditor={renderGridEditor} />`.
  */
 export function renderGridEditor(props: CellEditorProps) {
   const initial = props.value == null ? "" : String(props.value);
@@ -45,6 +46,7 @@ export function renderGridEditor(props: CellEditorProps) {
   if (control?.type === "date") return <GridDateEditor {...props} kind="date" />;
   if (control?.type === "datetime-local")
     return <GridDateEditor {...props} kind="datetime" />;
+  if (control?.type === "time") return <GridDateEditor {...props} kind="time" />;
   return null;
 }
 
@@ -60,6 +62,10 @@ function GridDateEditor({
   const anchorRef = useRef<HTMLDivElement | null>(null);
 
   const commit = () => {
+    if (kind === "time") {
+      onCommit(time);
+      return;
+    }
     if (!date) {
       // Nothing chosen — leave the cell unchanged.
       onCancel();
@@ -74,21 +80,24 @@ function GridDateEditor({
         {initial || "—"}
       </div>
       <CalendarPopover anchorRef={anchorRef} onOutside={commit} onEscape={onCancel}>
-        <DayPicker
-          mode="single"
-          selected={date}
-          onSelect={setDate}
-          defaultMonth={date}
-          showOutsideDays
-          autoFocus
-        />
-        {kind === "datetime" && (
+        {kind !== "time" && (
+          <DayPicker
+            mode="single"
+            selected={date}
+            onSelect={setDate}
+            defaultMonth={date}
+            showOutsideDays
+            autoFocus
+          />
+        )}
+        {kind !== "date" && (
           <label className="grid-date-popover-time">
             Time
             <input
               type="time"
               step={1}
               value={time}
+              autoFocus={kind === "time"}
               onChange={(e) => setTime(e.target.value || "00:00:00")}
             />
           </label>

--- a/apps/desktop/src/styles/date-picker.css
+++ b/apps/desktop/src/styles/date-picker.css
@@ -1,0 +1,113 @@
+/* react-day-picker base layout, themed to the app's design tokens. We import
+   the library's stylesheet (the same one shadcn/ui builds on) for the month
+   grid layout, then override its CSS variables so it adopts the dark/light
+   theme instead of its 2002-looking native cousin. */
+@import "react-day-picker/style.css";
+
+.grid-date-popover {
+  position: fixed;
+  z-index: 200;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+  background: var(--bg-2);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.45);
+  color: var(--fg-0);
+}
+
+.grid-date-popover .rdp-root {
+  --rdp-accent-color: var(--accent);
+  --rdp-accent-background-color: var(--accent-soft);
+  --rdp-today-color: var(--accent);
+  --rdp-day-width: 32px;
+  --rdp-day-height: 32px;
+  --rdp-day_button-width: 30px;
+  --rdp-day_button-height: 30px;
+  --rdp-day_button-border-radius: var(--radius-sm);
+  --rdp-font-family: inherit;
+  margin: 0;
+  font-size: var(--fs-sm, 12px);
+}
+
+.grid-date-popover .rdp-caption_label,
+.grid-date-popover .rdp-weekday {
+  color: var(--fg-2);
+}
+.grid-date-popover .rdp-day_button {
+  color: var(--fg-0);
+}
+.grid-date-popover .rdp-day_button:hover {
+  background: var(--bg-3);
+}
+.grid-date-popover .rdp-selected .rdp-day_button {
+  background: var(--accent);
+  color: var(--accent-fg);
+  border: none;
+}
+.grid-date-popover .rdp-outside .rdp-day_button {
+  color: var(--fg-3);
+}
+.grid-date-popover .rdp-chevron {
+  fill: var(--fg-1);
+}
+.grid-date-popover .rdp-button_previous:hover,
+.grid-date-popover .rdp-button_next:hover {
+  background: var(--bg-3);
+}
+
+/* Time field shown for datetime columns. */
+.grid-date-popover-time {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--fs-sm, 12px);
+  color: var(--fg-2);
+}
+.grid-date-popover-time input {
+  flex: 1;
+  padding: 4px 8px;
+  background: var(--bg-3);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  color: var(--fg-0);
+  font-family: inherit;
+}
+.grid-date-popover-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+}
+.grid-date-popover-actions button {
+  padding: 4px 10px;
+  border-radius: var(--radius-sm);
+  font-size: var(--fs-sm, 12px);
+  cursor: pointer;
+}
+.grid-date-popover-actions .gdp-cancel {
+  background: transparent;
+  border: 1px solid var(--border-default);
+  color: var(--fg-1);
+}
+.grid-date-popover-actions .gdp-apply {
+  background: var(--accent);
+  border: 1px solid var(--accent);
+  color: var(--accent-fg);
+}
+
+/* The in-cell anchor shown while the picker is open — mirrors .cell-edit-input
+   so the cell reads as "being edited" with the current value visible. */
+.grid-date-anchor {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  padding: 0 8px;
+  background: var(--bg-2);
+  color: var(--fg-0);
+  font-size: 11.5px;
+  white-space: nowrap;
+  overflow: hidden;
+}

--- a/apps/desktop/src/styles/date-picker.css
+++ b/apps/desktop/src/styles/date-picker.css
@@ -31,41 +31,35 @@
   --rdp-nav_button-height: 24px;
   --rdp-nav-height: 28px;
   --rdp-weekday-padding: 4px 0;
-  --rdp-font-family: inherit;
   margin: 0;
   /* The library's stylesheet sizes text with CSS keywords (large/small/smaller)
      relative to the 16px browser default, which dwarfs this dense ~12px UI and
      reads as inconsistent. Pin every text element to the app scale instead. */
-  font-size: var(--fs-sm, 12px);
+  font-size: var(--fs-sm);
 }
 
 .grid-date-popover .rdp-month_caption,
 .grid-date-popover .rdp-caption_label {
-  font-size: var(--fs-md, 13px);
+  font-size: var(--fs-md);
   font-weight: 600;
   color: var(--fg-0);
 }
 .grid-date-popover .rdp-weekday {
-  font-size: var(--fs-xs, 11px);
+  font-size: var(--fs-xs);
   font-weight: 500;
+  color: var(--fg-2);
 }
 .grid-date-popover .rdp-day_button {
-  font-size: var(--fs-sm, 12px);
+  font-size: var(--fs-sm);
+  color: var(--fg-0);
 }
 .grid-date-popover .rdp-selected {
-  font-size: var(--fs-sm, 12px);
+  font-size: var(--fs-sm);
 }
 .grid-date-popover .rdp-chevron {
   width: 14px;
   height: 14px;
-}
-
-.grid-date-popover .rdp-caption_label,
-.grid-date-popover .rdp-weekday {
-  color: var(--fg-2);
-}
-.grid-date-popover .rdp-day_button {
-  color: var(--fg-0);
+  fill: var(--fg-1);
 }
 .grid-date-popover .rdp-day_button:hover {
   background: var(--bg-3);
@@ -78,9 +72,6 @@
 .grid-date-popover .rdp-outside .rdp-day_button {
   color: var(--fg-3);
 }
-.grid-date-popover .rdp-chevron {
-  fill: var(--fg-1);
-}
 .grid-date-popover .rdp-button_previous:hover,
 .grid-date-popover .rdp-button_next:hover {
   background: var(--bg-3);
@@ -91,7 +82,7 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: var(--fs-sm, 12px);
+  font-size: var(--fs-sm);
   color: var(--fg-2);
 }
 .grid-date-popover-time input {
@@ -111,7 +102,7 @@
 .grid-date-popover-actions button {
   padding: 4px 10px;
   border-radius: var(--radius-sm);
-  font-size: var(--fs-sm, 12px);
+  font-size: var(--fs-sm);
   cursor: pointer;
 }
 .grid-date-popover-actions .gdp-cancel {
@@ -125,17 +116,11 @@
   color: var(--accent-fg);
 }
 
-/* The in-cell anchor shown while the picker is open — mirrors .cell-edit-input
-   so the cell reads as "being edited" with the current value visible. */
+/* In-cell anchor shown while the picker is open. Reuses .cell-edit-input for
+   the shared field look; only the flex/clip deltas live here. */
 .grid-date-anchor {
   display: flex;
   align-items: center;
-  width: 100%;
-  height: 100%;
-  padding: 0 8px;
-  background: var(--bg-2);
-  color: var(--fg-0);
-  font-size: 11.5px;
   white-space: nowrap;
   overflow: hidden;
 }

--- a/apps/desktop/src/styles/date-picker.css
+++ b/apps/desktop/src/styles/date-picker.css
@@ -22,14 +22,42 @@
   --rdp-accent-color: var(--accent);
   --rdp-accent-background-color: var(--accent-soft);
   --rdp-today-color: var(--accent);
-  --rdp-day-width: 32px;
-  --rdp-day-height: 32px;
-  --rdp-day_button-width: 30px;
-  --rdp-day_button-height: 30px;
+  --rdp-day-width: 30px;
+  --rdp-day-height: 30px;
+  --rdp-day_button-width: 28px;
+  --rdp-day_button-height: 28px;
   --rdp-day_button-border-radius: var(--radius-sm);
+  --rdp-nav_button-width: 24px;
+  --rdp-nav_button-height: 24px;
+  --rdp-nav-height: 28px;
+  --rdp-weekday-padding: 4px 0;
   --rdp-font-family: inherit;
   margin: 0;
+  /* The library's stylesheet sizes text with CSS keywords (large/small/smaller)
+     relative to the 16px browser default, which dwarfs this dense ~12px UI and
+     reads as inconsistent. Pin every text element to the app scale instead. */
   font-size: var(--fs-sm, 12px);
+}
+
+.grid-date-popover .rdp-month_caption,
+.grid-date-popover .rdp-caption_label {
+  font-size: var(--fs-md, 13px);
+  font-weight: 600;
+  color: var(--fg-0);
+}
+.grid-date-popover .rdp-weekday {
+  font-size: var(--fs-xs, 11px);
+  font-weight: 500;
+}
+.grid-date-popover .rdp-day_button {
+  font-size: var(--fs-sm, 12px);
+}
+.grid-date-popover .rdp-selected {
+  font-size: var(--fs-sm, 12px);
+}
+.grid-date-popover .rdp-chevron {
+  width: 14px;
+  height: 14px;
 }
 
 .grid-date-popover .rdp-caption_label,

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -4,6 +4,7 @@
 @import "./grid.css";
 @import "./grid-renderers.css";
 @import "./editor.css";
+@import "./date-picker.css";
 
 /* Bridge: expose every design token from tokens.css as a Tailwind v4 theme key
    so utilities like `bg-bg-0`, `text-fg-1`, `border-border-default`, `font-mono`,

--- a/apps/desktop/src/styles/tokens.css
+++ b/apps/desktop/src/styles/tokens.css
@@ -2,6 +2,9 @@
 
 :root,
 [data-theme="dark"] {
+  /* Render native controls (date/time pickers, spinners) in dark mode so they
+     stay legible against the dark surfaces instead of defaulting to light. */
+  color-scheme: dark;
   /* Surfaces — warm dark neutrals */
   --bg-0: #0c0d10;
   --bg-1: #111317;
@@ -96,6 +99,7 @@
 }
 
 [data-theme="light"] {
+  color-scheme: light;
   --bg-0: #f8f7f4;
   --bg-1: #ffffff;
   --bg-2: #f3f1ec;

--- a/packages/data-grid/src/Cell.test.ts
+++ b/packages/data-grid/src/Cell.test.ts
@@ -8,7 +8,12 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { parseCellInput, resolveBlurAction, resolveEnterAction } from "./Cell";
+import {
+  nativeControl,
+  parseCellInput,
+  resolveBlurAction,
+  resolveEnterAction,
+} from "./Cell";
 
 // ---------------------------------------------------------------------------
 // resolveEnterAction — used by the Enter key handler (text editor)
@@ -249,6 +254,29 @@ describe("parseCellInput", () => {
     });
   });
 
+  it("validates MSSQL/MySQL type aliases instead of accepting any text", () => {
+    // The bug: `datetime2` fell through to "unknown" and accepted "aaa".
+    expect(parseCellInput(column("CreationTime", "datetime2(7)"), "aaa")).toEqual({
+      ok: false,
+      message: "Enter a valid timestamp",
+    });
+    expect(
+      parseCellInput(column("CreationTime", "datetime2(7)"), "2023-04-03T05:00:31"),
+    ).toEqual({ ok: true, value: "2023-04-03T05:00:31" });
+    expect(parseCellInput(column("count", "int"), "abc")).toEqual({
+      ok: false,
+      message: "Enter a whole number",
+    });
+    expect(parseCellInput(column("flag", "tinyint"), "3")).toEqual({
+      ok: true,
+      value: 3,
+    });
+    expect(parseCellInput(column("note", "nvarchar(100)"), "hello")).toEqual({
+      ok: true,
+      value: "hello",
+    });
+  });
+
   it("requires enum values to match the column options", () => {
     expect(
       parseCellInput(
@@ -265,6 +293,48 @@ describe("parseCellInput", () => {
       ok: false,
       message: "Choose one of: new, done",
     });
+  });
+});
+
+describe("nativeControl", () => {
+  it("offers a datetime-local picker for timestamp columns, dropping sub-second precision", () => {
+    expect(
+      nativeControl(column("CreationTime", "datetime2(7)"), "2023-04-03T05:00:31.15863"),
+    ).toEqual({ type: "datetime-local", step: "1", value: "2023-04-03T05:00:31" });
+  });
+
+  it("offers a date picker for date columns", () => {
+    expect(nativeControl(column("d", "date"), "2023-04-03")).toEqual({
+      type: "date",
+      value: "2023-04-03",
+    });
+  });
+
+  it("offers a number input for integer and float columns", () => {
+    expect(nativeControl(column("n", "int"), "42")).toEqual({
+      type: "number",
+      step: "1",
+      value: "42",
+    });
+    expect(nativeControl(column("f", "float8"), "4.2")).toEqual({
+      type: "number",
+      step: "any",
+      value: "4.2",
+    });
+  });
+
+  it("still offers a picker for an empty/NULL date cell", () => {
+    expect(nativeControl(column("d", "datetime2"), "")).toEqual({
+      type: "datetime-local",
+      step: "1",
+      value: "",
+    });
+  });
+
+  it("falls back to text for non-native and unparseable values", () => {
+    expect(nativeControl(column("note", "nvarchar(100)"), "hi")).toBeNull();
+    // A legacy/garbage timestamp that can't be coerced stays editable as text.
+    expect(nativeControl(column("CreationTime", "datetime2"), "aaa")).toBeNull();
   });
 });
 

--- a/packages/data-grid/src/Cell.tsx
+++ b/packages/data-grid/src/Cell.tsx
@@ -159,20 +159,23 @@ function normalizeType(type: string):
   // every type shown as a hex blob is also validated as hex when edited.
   if (isByteaType(t)) return "bytea";
   if (t === "date") return "date";
-  if (["float4", "float8", "real", "double precision"].includes(t)) {
+  if (["float4", "float8", "real", "double precision", "float", "double"].includes(t)) {
     return "float";
   }
   if (
-    ["int2", "int4", "int8", "smallint", "integer", "bigint", "serial", "bigserial", "oid"].includes(
+    // Postgres int2/int4/int8/serial; MSSQL int/tinyint; MySQL mediumint
+    ["int2", "int4", "int8", "smallint", "integer", "int", "tinyint", "mediumint", "bigint", "serial", "bigserial", "oid"].includes(
       t,
     )
   ) {
     return "integer";
   }
   if (["json", "jsonb"].includes(t)) return "json";
-  if (["numeric", "decimal", "money"].includes(t)) return "numeric";
+  if (["numeric", "decimal", "money", "smallmoney"].includes(t)) return "numeric";
   if (
-    ["text", "varchar", "char", "bpchar", "citext", "name", "character varying", "character"].includes(
+    // Postgres text/varchar/...; MSSQL nvarchar/nchar/ntext/sysname/xml; MySQL *text
+    ["text", "varchar", "char", "bpchar", "citext", "name", "character varying", "character",
+     "nvarchar", "nchar", "ntext", "sysname", "xml", "tinytext", "mediumtext", "longtext"].includes(
       t,
     )
   ) {
@@ -182,7 +185,9 @@ function normalizeType(type: string):
     return "time";
   }
   if (
-    ["timestamp", "timestamptz", "timestamp without time zone", "timestamp with time zone"].includes(
+    // Postgres timestamp/timestamptz; MSSQL datetime/datetime2/smalldatetime/datetimeoffset
+    ["timestamp", "timestamptz", "timestamp without time zone", "timestamp with time zone",
+     "datetime", "datetime2", "smalldatetime", "datetimeoffset"].includes(
       t,
     )
   ) {
@@ -190,6 +195,51 @@ function normalizeType(type: string):
   }
   if (["uuid", "guid", "uniqueidentifier"].includes(t)) return "guid";
   return "unknown";
+}
+
+/**
+ * Picks a native HTML input control for the editor so date/time/number columns
+ * get the browser's built-in picker and keypad-level rejection of bad keys.
+ * Returns null to keep the plain text editor — for unknown types, or values the
+ * native control can't represent (those stay freely editable as raw text).
+ *
+ * `numeric`/`decimal` deliberately stay text: their value is a lossless string
+ * and a number input would lose precision on large decimals. The existing
+ * parseCellInput validation already rejects letters in those on commit.
+ */
+export function nativeControl(
+  col: GridColumn,
+  initial: string,
+): { type: string; step?: string; value: string } | null {
+  if (col.enum) return null;
+  const t = normalizeType(col.type);
+  if (t === "integer") return { type: "number", step: "1", value: initial };
+  if (t === "float") return { type: "number", step: "any", value: initial };
+
+  // For date/time/timestamp, an empty cell still gets a picker; a populated one
+  // only does if its stored value parses into the control's required format.
+  if (t === "date") {
+    if (initial === "") return { type: "date", value: "" };
+    return /^\d{4}-\d{2}-\d{2}/.test(initial)
+      ? { type: "date", value: initial.slice(0, 10) }
+      : null;
+  }
+  if (t === "time") {
+    if (initial === "") return { type: "time", step: "1", value: "" };
+    const m = /^(\d{2}:\d{2}(?::\d{2})?)/.exec(initial.trim());
+    return m?.[1] ? { type: "time", step: "1", value: m[1] } : null;
+  }
+  if (t === "timestamp") {
+    if (initial === "") return { type: "datetime-local", step: "1", value: "" };
+    // "2023-04-03T05:00:31.15863" or "2023-04-03 05:00:31" → "...T05:00:31".
+    // Sub-second precision is dropped — a picker can't express it — but only a
+    // user who actually changes the value commits, so stored values are intact.
+    const m = /^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2}(?::\d{2})?)/.exec(initial.trim());
+    return m?.[1] && m[2]
+      ? { type: "datetime-local", step: "1", value: `${m[1]}T${m[2]}` }
+      : null;
+  }
+  return null;
 }
 
 export function CellValue({
@@ -264,7 +314,8 @@ export type CellEditorProps = {
 
 export function CellEditor({ col, value, onCommit, onCancel }: CellEditorProps) {
   const initialValue = value == null ? "" : String(value);
-  const [v, setV] = useState<string>(initialValue);
+  const control = nativeControl(col, initialValue);
+  const [v, setV] = useState<string>(control ? control.value : initialValue);
   const [error, setError] = useState<string | null>(null);
   const ref = useRef<HTMLInputElement | null>(null);
   // Tracks whether Enter or Escape has already been handled so that the
@@ -278,7 +329,13 @@ export function CellEditor({ col, value, onCommit, onCancel }: CellEditorProps) 
 
   useEffect(() => {
     ref.current?.focus();
-    ref.current?.select();
+    // select() throws InvalidStateError on date/time/number inputs; only text
+    // (and the like) supports it, so guard rather than branch on type.
+    try {
+      ref.current?.select();
+    } catch {
+      /* non-text native control — nothing to select */
+    }
   }, []);
 
   const commitRawValue = () => {
@@ -345,6 +402,8 @@ export function CellEditor({ col, value, onCommit, onCancel }: CellEditorProps) 
     <input
       ref={ref}
       className={"cell-edit-input" + (col.mono ? " mono" : "")}
+      type={control?.type ?? "text"}
+      step={control?.step}
       value={v}
       onChange={(e) => {
         dirtyRef.current = true;

--- a/packages/data-grid/src/DataGrid.tsx
+++ b/packages/data-grid/src/DataGrid.tsx
@@ -8,9 +8,16 @@ import {
   useState,
   type MouseEvent as ReactMouseEvent,
   type PointerEvent as ReactPointerEvent,
+  type ReactNode,
   type UIEvent,
 } from "react";
-import { CellEditor, CellValue } from "./Cell";
+import { CellEditor, CellValue, type CellEditorProps } from "./Cell";
+
+/**
+ * Renders a custom inline editor for a cell, or returns `null` to defer to the
+ * built-in editor. See {@link DataGridProps.renderEditor}.
+ */
+export type CellEditorRenderer = (props: CellEditorProps) => ReactNode | null;
 import {
   emptyColumnLayout,
   layoutForColumns,
@@ -152,6 +159,15 @@ export type DataGridProps = {
    */
   renderers?: RendererRegistry | null;
 
+  /**
+   * Optional override for the inline cell editor. Receives the same props as the
+   * built-in editor; return an element to take over editing for a cell, or
+   * `null` to fall back to the built-in text/number/native-picker editor. Lets a
+   * host supply a richer editor — e.g. a calendar date picker — without pulling
+   * its UI dependencies into this dependency-free package.
+   */
+  renderEditor?: CellEditorRenderer;
+
   /** Override how a renderer persists binary payloads (e.g. a native dialog). */
   saveBlob?: SaveBlob;
 
@@ -230,6 +246,7 @@ export function DataGrid({
   readOnly = false,
   nullDisplay = "NULL",
   renderers = defaultRendererRegistry,
+  renderEditor,
   saveBlob,
   stripeRows = false,
   onCellContextMenu,
@@ -834,6 +851,7 @@ export function DataGrid({
                   readOnly={readOnly}
                   nullDisplay={nullDisplay}
                   renderers={renderers}
+                  renderEditor={renderEditor}
                   saveBlob={saveBlob}
                   stripeRows={stripeRows}
                   top={
@@ -900,6 +918,7 @@ type GridRowViewProps = {
   readOnly: boolean;
   nullDisplay: string;
   renderers: RendererRegistry | null;
+  renderEditor: CellEditorRenderer | undefined;
   saveBlob: SaveBlob | undefined;
   stripeRows: boolean;
   top: number | undefined;
@@ -929,6 +948,7 @@ const GridRowView = memo(function GridRowView({
   readOnly,
   nullDisplay,
   renderers,
+  renderEditor,
   saveBlob,
   stripeRows,
   top,
@@ -1068,20 +1088,25 @@ const GridRowView = memo(function GridRowView({
             }
           >
             {isEdit ? (
-              <CellEditor
-                col={c}
-                value={displayed}
-                onCommit={(v) => {
-                  onCellEdit(
-                    row.id,
-                    c.key,
-                    (original ?? null) as CellChange["from"],
-                    (v ?? null) as CellChange["to"],
-                  );
-                  onEdit(null);
-                }}
-                onCancel={() => onEdit(null)}
-              />
+              (() => {
+                const editorProps: CellEditorProps = {
+                  col: c,
+                  value: displayed,
+                  onCommit: (v) => {
+                    onCellEdit(
+                      row.id,
+                      c.key,
+                      (original ?? null) as CellChange["from"],
+                      (v ?? null) as CellChange["to"],
+                    );
+                    onEdit(null);
+                  },
+                  onCancel: () => onEdit(null),
+                };
+                // Host-supplied editor wins when it claims the cell; otherwise
+                // fall back to the built-in text/number/native-picker editor.
+                return renderEditor?.(editorProps) ?? <CellEditor {...editorProps} />;
+              })()
             ) : (
               <CellValue
                 col={c}

--- a/packages/data-grid/src/index.ts
+++ b/packages/data-grid/src/index.ts
@@ -34,8 +34,19 @@ export {
   rowMatchesFilters,
 } from "./filters";
 export { compareGridValues, cycleSortState, sortGridRows } from "./sort";
-export { DataGrid, useGridState, type DataGridProps } from "./DataGrid";
-export { CellEditor, CellValue, type CellEditorProps } from "./Cell";
+export {
+  DataGrid,
+  useGridState,
+  type DataGridProps,
+  type CellEditorRenderer,
+} from "./DataGrid";
+export {
+  CellEditor,
+  CellValue,
+  nativeControl,
+  parseCellInput,
+  type CellEditorProps,
+} from "./Cell";
 export { FilterBar, type FilterBarProps } from "./FilterBar";
 export { PendingBar, type PendingBarProps } from "./PendingBar";
 export { TypeIcon } from "./TypeIcon";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       react:
         specifier: ^18.3.1
         version: 18.3.1
+      react-day-picker:
+        specifier: ^10.0.1
+        version: 10.0.1(@types/react@18.3.29)(react@18.3.1)
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
@@ -247,6 +250,9 @@ packages:
 
   '@codemirror/view@6.43.0':
     resolution: {integrity: sha512-V7ZCLQO3Jus9hzh2jVCCPW3mO4IBMr43O37PqSUYautJSnnJF41YlgLw21x0fLJTYvJ+Vkm6Gp+qKGH9pltgXA==}
+
+  '@date-fns/tz@1.5.0':
+    resolution: {integrity: sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -844,6 +850,9 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  date-fns@4.4.0:
+    resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -1024,6 +1033,16 @@ packages:
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
+
+  react-day-picker@10.0.1:
+    resolution: {integrity: sha512-eNh6BlwcYInWaJtRv18mXQ06Ys/H6rdTZAnTaSdOYJuTpwP1JMCHNd1FDRadA+gbeinq+psdULN5Xnowy9mV8w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/react': '>=16.8.0'
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
@@ -1363,6 +1382,8 @@ snapshots:
       crelt: 1.0.6
       style-mod: 4.1.3
       w3c-keyname: 2.2.8
+
+  '@date-fns/tz@1.5.0': {}
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -1806,6 +1827,8 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  date-fns@4.4.0: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -1952,6 +1975,14 @@ snapshots:
       nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  react-day-picker@10.0.1(@types/react@18.3.29)(react@18.3.1):
+    dependencies:
+      '@date-fns/tz': 1.5.0
+      date-fns: 4.4.0
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.29
 
   react-dom@18.3.1(react@18.3.1):
     dependencies:


### PR DESCRIPTION
Cell edits are now validated against the column's data type, so a value like `aaa` can no longer be committed into a `datetime2` column — `normalizeType` learned MSSQL/MySQL type names (int, datetime2, nvarchar, etc.) that previously fell through to free-form text. Date/time/number columns get appropriate native input controls, and date/datetime/time columns open a themed react-day-picker calendar (with a time field) instead of the OS-native datetime picker. The grid package stays dependency-free via a new `renderEditor` prop that lets the desktop app inject the calendar editor, and `color-scheme` is now set per theme so native controls render legibly in dark mode. The calendar's text sizes are pinned to the app's `--fs-*` tokens so they match the dense UI rather than the library's 16px-relative defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)