### PR TITLE
Per-pane tab strips with resizable, drag-to-split workspace

### DIFF
--- a/apps/desktop/src/components/TabBar.tsx
+++ b/apps/desktop/src/components/TabBar.tsx
@@ -8,7 +8,12 @@ import {
 import { Icon } from "./icons";
 import { qualifiedName, selectAllStatement } from "../lib/sqlIdent";
 import { useConnections } from "../state/connections";
-import { useTabs, tabLabel, type WorkspaceTab } from "../state/tabs";
+import {
+  useTabs,
+  tabLabel,
+  type PaneIndex,
+  type WorkspaceTab,
+} from "../state/tabs";
 
 /**
  * Pick the connection + database a new query tab should bind to: the active
@@ -34,15 +39,27 @@ function pickQueryTarget(): { connectionId: string; database: string } | null {
   return { connectionId: targetId, database };
 }
 
-export function TabBar() {
+/**
+ * The workspace tab strip. With no `pane`, it shows every open tab and is used
+ * as the single bar above an unsplit workspace (it renders nothing while a
+ * split is active — each pane draws its own strip then). With a `pane`, it
+ * shows only that pane's tabs and lands new tabs in it.
+ */
+export function TabBar({ pane }: { pane?: PaneIndex } = {}) {
   const [menu, setMenu] = useState<ContextMenuState | null>(null);
   const [draggedTabId, setDraggedTabId] = useState<string | null>(null);
   const [tabDropTargetId, setTabDropTargetId] = useState<string | null>(null);
-  const tabs = useTabs((s) => s.tabs);
+  const allTabs = useTabs((s) => s.tabs);
+  const tabPane = useTabs((s) => s.tabPane);
+  const paneActive = useTabs((s) => s.paneActive);
   const activeId = useTabs((s) => s.activeId);
+  const focusedPane = useTabs((s) => s.focusedPane);
   const split = useTabs((s) => s.split);
   const closedCount = useTabs((s) => s.closedTabs.length);
   const setActive = useTabs((s) => s.setActive);
+  const focusPane = useTabs((s) => s.focusPane);
+  const setDraggingTab = useTabs((s) => s.setDraggingTab);
+  const moveTabToPane = useTabs((s) => s.moveTabToPane);
   const closeTab = useTabs((s) => s.closeTab);
   const splitActiveTab = useTabs((s) => s.splitActiveTab);
   const reopenClosedTab = useTabs((s) => s.reopenClosedTab);
@@ -53,9 +70,21 @@ export function TabBar() {
   const setQuerySql = useTabs((s) => s.setQuerySql);
   const refreshTable = useTabs((s) => s.refreshTable);
   const hasConnections = useConnections((s) => s.connections.length > 0);
-  const canSplit = tabs.length > 1 && activeId != null;
+
+  // The single top bar disappears once split — the panes own their strips then.
+  if (pane == null && split) return null;
+
+  const tabs =
+    pane == null
+      ? allTabs
+      : allTabs.filter((t) => (tabPane[t.id] ?? 0) === pane);
+  // Highlight this strip's active tab; the unsplit bar tracks the global one.
+  const stripActiveId = pane == null ? activeId : paneActive[pane];
+  const isStripFocused = pane == null || pane === focusedPane;
+  const canSplit = split != null || (tabs.length > 1 && activeId != null);
 
   const onNewQuery = () => {
+    if (pane != null) focusPane(pane);
     const target = pickQueryTarget();
     if (target) newQueryTab(target.connectionId, target.database);
   };
@@ -136,14 +165,32 @@ export function TabBar() {
 
   return (
     <div className="flex h-[30px] items-stretch shrink-0 border-b border-border-default bg-bg-1">
-      <div className="flex flex-1 min-w-0 overflow-x-auto">
+      <div
+        className="flex flex-1 min-w-0 overflow-x-auto"
+        // Dropping a tab onto blank strip space moves it into this pane.
+        onDragOver={(e) => {
+          if (pane == null || !useTabs.getState().draggingTabId) return;
+          e.preventDefault();
+          e.dataTransfer.dropEffect = "move";
+        }}
+        onDrop={(e) => {
+          if (pane == null) return;
+          const sourceId =
+            e.dataTransfer.getData("text/plain") ||
+            useTabs.getState().draggingTabId;
+          if (sourceId) moveTabToPane(sourceId, pane);
+          setDraggingTab(null);
+          setDraggedTabId(null);
+          setTabDropTargetId(null);
+        }}
+      >
         {tabs.length === 0 && (
           <div className="inline-flex items-center px-3 text-[11px] text-fg-3">
             no tabs — double-click a table in the sidebar
           </div>
         )}
         {tabs.map((t) => {
-          const isActive = t.id === activeId;
+          const isActive = t.id === stripActiveId;
           return (
             <div
               key={t.id}
@@ -151,10 +198,12 @@ export function TabBar() {
               onDragStart={(e) => {
                 e.dataTransfer.effectAllowed = "move";
                 e.dataTransfer.setData("text/plain", t.id);
+                setDraggingTab(t.id);
                 setDraggedTabId(t.id);
               }}
               onDragOver={(e) => {
-                if (!draggedTabId || draggedTabId === t.id) return;
+                const dragging = useTabs.getState().draggingTabId;
+                if (!dragging || dragging === t.id) return;
                 e.preventDefault();
                 e.dataTransfer.dropEffect = "move";
                 setTabDropTargetId(t.id);
@@ -164,14 +213,18 @@ export function TabBar() {
               }}
               onDrop={(e) => {
                 e.preventDefault();
+                e.stopPropagation();
                 const sourceId =
-                  e.dataTransfer.getData("text/plain") || draggedTabId;
+                  e.dataTransfer.getData("text/plain") ||
+                  useTabs.getState().draggingTabId;
                 if (sourceId) reorderTab(sourceId, t.id);
                 if (sourceId) setActive(sourceId);
+                setDraggingTab(null);
                 setDraggedTabId(null);
                 setTabDropTargetId(null);
               }}
               onDragEnd={() => {
+                setDraggingTab(null);
                 setDraggedTabId(null);
                 setTabDropTargetId(null);
               }}
@@ -189,7 +242,7 @@ export function TabBar() {
               <span
                 className={
                   "absolute left-0 top-0 h-full w-0.5 transition-opacity duration-150 " +
-                  (isActive ? "opacity-100" : "opacity-0")
+                  (isActive && isStripFocused ? "opacity-100" : "opacity-0")
                 }
                 style={{ background: "var(--eng-postgres)" }}
               />
@@ -248,13 +301,13 @@ export function TabBar() {
       <div className="flex items-center gap-px border-l border-border-default px-1.5">
         <button
           type="button"
-          className={"icon-btn" + (split?.orientation === "horizontal" ? " active" : "")}
+          className={"icon-btn" + (split === "horizontal" ? " active" : "")}
           onClick={() => splitActiveTab("horizontal")}
           disabled={!canSplit}
-          aria-pressed={split?.orientation === "horizontal"}
+          aria-pressed={split === "horizontal"}
           title={
             canSplit
-              ? split?.orientation === "horizontal"
+              ? split === "horizontal"
                 ? "Close horizontal split"
                 : "Split active tab horizontally"
               : "Open another tab to split the workspace"
@@ -264,13 +317,13 @@ export function TabBar() {
         </button>
         <button
           type="button"
-          className={"icon-btn" + (split?.orientation === "vertical" ? " active" : "")}
+          className={"icon-btn" + (split === "vertical" ? " active" : "")}
           onClick={() => splitActiveTab("vertical")}
           disabled={!canSplit}
-          aria-pressed={split?.orientation === "vertical"}
+          aria-pressed={split === "vertical"}
           title={
             canSplit
-              ? split?.orientation === "vertical"
+              ? split === "vertical"
                 ? "Close vertical split"
                 : "Split active tab vertically"
               : "Open another tab to split the workspace"

--- a/apps/desktop/src/components/Workspace.tsx
+++ b/apps/desktop/src/components/Workspace.tsx
@@ -17,8 +17,15 @@ import { SqlEditor } from "./SqlEditor";
 import { SchemaComparePane } from "./SchemaComparePane";
 import { ErDiagram } from "./er/ErDiagram";
 import { ContextMenu, type ContextMenuState } from "./ContextMenu";
+import { TabBar } from "./TabBar";
 import { Icon } from "./icons";
-import { useTabs, tabLabel, type TableTab, type WorkspaceTab } from "../state/tabs";
+import {
+  useTabs,
+  type PaneIndex,
+  type SplitEdge,
+  type TableTab,
+  type WorkspaceTab,
+} from "../state/tabs";
 import { useFindUsages } from "../state/findUsages";
 import { useTableData } from "../hooks/useTableData";
 import { useSettings } from "../lib/settings";
@@ -31,111 +38,183 @@ export function Workspace({ onCommit }: { onCommit?: () => void } = {}) {
   const tabs = useTabs((s) => s.tabs);
   const activeId = useTabs((s) => s.activeId);
   const split = useTabs((s) => s.split);
-  const setActive = useTabs((s) => s.setActive);
-  const clearSplit = useTabs((s) => s.clearSplit);
+  const paneActive = useTabs((s) => s.paneActive);
+  const focusedPane = useTabs((s) => s.focusedPane);
   const active = tabs.find((t) => t.id === activeId) ?? null;
+  // Fraction of the split given to the primary pane; dragging the divider moves it.
+  const [ratio, setRatio] = useState(0.5);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const startDividerDrag = (e: React.MouseEvent) => {
+    e.preventDefault();
+    const el = containerRef.current;
+    if (!el) return;
+    const sideBySide = split === "vertical";
+    const onMove = (ev: MouseEvent) => {
+      const rect = el.getBoundingClientRect();
+      const r = sideBySide
+        ? (ev.clientX - rect.left) / rect.width
+        : (ev.clientY - rect.top) / rect.height;
+      setRatio(Math.min(0.85, Math.max(0.15, r)));
+    };
+    const onUp = () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+    document.body.style.cursor = sideBySide ? "col-resize" : "row-resize";
+    document.body.style.userSelect = "none";
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+  };
 
   if (!active) {
     return <EmptyWorkspace />;
   }
 
-  if (split) {
-    const primary = tabs.find((t) => t.id === split.primaryId) ?? active;
-    const secondary = tabs.find((t) => t.id === split.secondaryId) ?? null;
-    if (primary && secondary && primary.id !== secondary.id) {
-      return (
+  const primary =
+    split && (tabs.find((t) => t.id === paneActive[0]) ?? null);
+  const secondary =
+    split && (tabs.find((t) => t.id === paneActive[1]) ?? null);
+
+  const content =
+    primary && secondary && primary.id !== secondary.id ? (
+      <div
+        ref={containerRef}
+        className={
+          "flex min-h-0 flex-1 overflow-hidden bg-bg-inset " +
+          (split === "horizontal" ? "flex-col" : "flex-row")
+        }
+      >
+        <SplitPane
+          pane={0}
+          tab={primary}
+          focused={focusedPane === 0}
+          grow={ratio}
+          onCommit={onCommit}
+        />
         <div
+          role="separator"
+          onMouseDown={startDividerDrag}
           className={
-            "flex min-h-0 flex-1 overflow-hidden bg-bg-inset " +
-            (split.orientation === "horizontal" ? "flex-col" : "flex-row")
+            "group relative z-10 shrink-0 " +
+            (split === "vertical"
+              ? "w-[7px] -mx-[3px] cursor-col-resize"
+              : "h-[7px] -my-[3px] cursor-row-resize")
           }
         >
-          <SplitPane
-            tab={primary}
-            active={primary.id === activeId}
-            onActivate={() => setActive(primary.id)}
-            onCloseSplit={clearSplit}
-            onCommit={onCommit}
-          />
           <div
             className={
-              "shrink-0 bg-border-default " +
-              (split.orientation === "horizontal" ? "h-px" : "w-px")
+              "absolute bg-border-default transition-colors duration-100 group-hover:bg-accent-line group-active:bg-accent " +
+              (split === "vertical"
+                ? "inset-y-0 left-1/2 w-px -translate-x-1/2"
+                : "inset-x-0 top-1/2 h-px -translate-y-1/2")
             }
           />
-          <SplitPane
-            tab={secondary}
-            active={secondary.id === activeId}
-            onActivate={() => setActive(secondary.id)}
-            onCloseSplit={clearSplit}
-            onCommit={onCommit}
-          />
         </div>
-      );
-    }
-  }
+        <SplitPane
+          pane={1}
+          tab={secondary}
+          focused={focusedPane === 1}
+          grow={1 - ratio}
+          onCommit={onCommit}
+        />
+      </div>
+    ) : (
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        {renderTab(active, onCommit)}
+      </div>
+    );
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-      {renderTab(active, onCommit)}
+    <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
+      {content}
+      <SplitDropZones />
     </div>
   );
 }
 
 function SplitPane({
+  pane,
   tab,
-  active,
-  onActivate,
-  onCloseSplit,
+  focused,
+  grow,
   onCommit,
 }: {
+  pane: PaneIndex;
   tab: WorkspaceTab;
-  active: boolean;
-  onActivate: () => void;
-  onCloseSplit: () => void;
+  focused: boolean;
+  grow: number;
   onCommit?: () => void;
 }) {
+  const focusPane = useTabs((s) => s.focusPane);
   return (
     <section
+      style={{ flexGrow: grow }}
       className={
         "flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden " +
-        (active ? "bg-bg-0" : "bg-bg-inset")
+        (focused ? "bg-bg-0" : "bg-bg-inset")
       }
-      onMouseDown={onActivate}
+      onMouseDown={() => focusPane(pane)}
     >
-      <div
-        className={
-          "flex h-6 shrink-0 items-center justify-between border-b border-border-default px-2 text-[10.5px] " +
-          (active ? "bg-bg-1 text-fg-1" : "bg-bg-inset text-fg-3")
-        }
-      >
-        <button
-          type="button"
-          className="flex min-w-0 items-center gap-1.5 text-left"
-          onClick={onActivate}
-          title={tabTitle(tab)}
-        >
-          <span className="inline-flex shrink-0 text-fg-3">
-            <TabIcon tab={tab} />
-          </span>
-          <span className="truncate font-mono">{tabTitle(tab)}</span>
-        </button>
-        <button
-          type="button"
-          className="icon-btn h-[18px] w-[18px]"
-          onClick={(event) => {
-            event.stopPropagation();
-            onCloseSplit();
-          }}
-          title="Close split"
-        >
-          <Icon.close size={10} />
-        </button>
-      </div>
+      <TabBar pane={pane} />
       <div className="flex min-h-0 flex-1 overflow-hidden">
         {renderTab(tab, onCommit)}
       </div>
     </section>
+  );
+}
+
+/** Edge bands that turn a dropped tab into a split. Shown only during a drag. */
+function SplitDropZones() {
+  const draggingTabId = useTabs((s) => s.draggingTabId);
+  const tabCount = useTabs((s) => s.tabs.length);
+  const dropTabToSplit = useTabs((s) => s.dropTabToSplit);
+  const [edge, setEdge] = useState<SplitEdge | null>(null);
+
+  // Need at least two tabs to leave both panes non-empty.
+  if (!draggingTabId || tabCount < 2) return null;
+
+  const zone = (e: SplitEdge, className: string) => (
+    <div
+      className={"pointer-events-auto absolute " + className}
+      onDragOver={(ev) => {
+        ev.preventDefault();
+        ev.dataTransfer.dropEffect = "move";
+        setEdge(e);
+      }}
+      onDragLeave={() => setEdge((cur) => (cur === e ? null : cur))}
+      onDrop={(ev) => {
+        ev.preventDefault();
+        const id = ev.dataTransfer.getData("text/plain") || draggingTabId;
+        if (id) dropTabToSplit(id, e);
+        setEdge(null);
+      }}
+    />
+  );
+
+  const previewClass: Record<SplitEdge, string> = {
+    left: "inset-y-0 left-0 w-1/2",
+    right: "inset-y-0 right-0 w-1/2",
+    top: "inset-x-0 top-0 h-1/2",
+    bottom: "inset-x-0 bottom-0 h-1/2",
+  };
+
+  return (
+    <div className="pointer-events-none absolute inset-0 z-20">
+      {edge && (
+        <div
+          className={
+            "absolute border-2 border-accent bg-accent-soft transition-all " +
+            previewClass[edge]
+          }
+        />
+      )}
+      {zone("left", "inset-y-0 left-0 w-[14%]")}
+      {zone("right", "inset-y-0 right-0 w-[14%]")}
+      {zone("bottom", "inset-x-0 bottom-0 h-[18%]")}
+    </div>
   );
 }
 
@@ -154,17 +233,6 @@ function renderTab(tab: WorkspaceTab, onCommit?: () => void) {
   // `key` resets the grid's local state (filters/selection) when the user
   // switches to a different table tab.
   return <TableTabPane key={tab.id} tab={tab} onCommit={onCommit} />;
-}
-
-function TabIcon({ tab }: { tab: WorkspaceTab }) {
-  if (tab.kind === "query") return <Icon.terminal size={11} />;
-  if (tab.kind === "schema-compare") return <Icon.diff size={11} />;
-  if (tab.kind === "er-diagram") return <Icon.diagram size={11} />;
-  return <Icon.table size={11} />;
-}
-
-function tabTitle(tab: WorkspaceTab): string {
-  return tabLabel(tab);
 }
 
 function TableTabPane({

--- a/apps/desktop/src/state/tabs.test.ts
+++ b/apps/desktop/src/state/tabs.test.ts
@@ -26,6 +26,9 @@ describe("tab workspace state", () => {
       activeId: null,
       closedTabs: [],
       split: null,
+      tabPane: {},
+      paneActive: [null, null],
+      focusedPane: 0,
       tableChanges: {},
       tableLayouts: {},
       refreshKeys: {},
@@ -36,18 +39,19 @@ describe("tab workspace state", () => {
     useNotices.setState({ byScope: {} });
   });
 
-  it("splits the active tab against a neighboring tab", () => {
+  it("moves the active tab into the secondary pane when splitting", () => {
     const store = useTabs.getState();
     const first = store.newQueryTab("conn-1", "app");
     const second = useTabs.getState().newQueryTab("conn-1", "app");
 
     useTabs.getState().splitActiveTab("vertical");
 
-    expect(useTabs.getState().split).toEqual({
-      orientation: "vertical",
-      primaryId: second,
-      secondaryId: first,
-    });
+    const s = useTabs.getState();
+    expect(s.split).toBe("vertical");
+    expect(s.tabPane[second]).toBe(1);
+    expect(s.paneActive).toEqual([first, second]);
+    expect(s.focusedPane).toBe(1);
+    expect(s.activeId).toBe(second);
   });
 
   it("toggles a split off when the active split button is clicked again", () => {
@@ -56,25 +60,94 @@ describe("tab workspace state", () => {
     useTabs.getState().newQueryTab("conn-1", "app");
 
     useTabs.getState().splitActiveTab("horizontal");
-    expect(useTabs.getState().split?.orientation).toBe("horizontal");
+    expect(useTabs.getState().split).toBe("horizontal");
 
     useTabs.getState().splitActiveTab("horizontal");
     expect(useTabs.getState().split).toBeNull();
+    expect(useTabs.getState().tabPane).toEqual({});
   });
 
-  it("keeps a split useful when a different tab is selected", () => {
+  it("focuses the primary pane when selecting one of its tabs", () => {
     const store = useTabs.getState();
     const first = store.newQueryTab("conn-1", "app");
-    const second = useTabs.getState().newQueryTab("conn-1", "app");
     useTabs.getState().newQueryTab("conn-1", "app");
+    const third = useTabs.getState().newQueryTab("conn-1", "app");
 
+    // `third` is active, so it moves to the secondary pane; the rest stay.
     useTabs.getState().splitActiveTab("vertical");
     useTabs.getState().setActive(first);
 
-    expect(useTabs.getState().split).toMatchObject({
-      primaryId: first,
-      secondaryId: second,
-    });
+    const s = useTabs.getState();
+    expect(s.split).toBe("vertical");
+    expect(s.focusedPane).toBe(0);
+    expect(s.activeId).toBe(first);
+    expect(s.paneActive).toEqual([first, third]);
+  });
+
+  it("collapses the split when a pane is left empty", () => {
+    const store = useTabs.getState();
+    const first = store.newQueryTab("conn-1", "app");
+    const second = useTabs.getState().newQueryTab("conn-1", "app");
+
+    useTabs.getState().splitActiveTab("vertical");
+    // `second` is the only tab in the secondary pane — closing it collapses.
+    useTabs.getState().closeTab(second);
+
+    const s = useTabs.getState();
+    expect(s.split).toBeNull();
+    expect(s.activeId).toBe(first);
+    expect(s.tabPane).toEqual({});
+  });
+
+  it("creates a split by dropping a tab on the right edge", () => {
+    const store = useTabs.getState();
+    const first = store.newQueryTab("conn-1", "app");
+    const second = useTabs.getState().newQueryTab("conn-1", "app");
+    const third = useTabs.getState().newQueryTab("conn-1", "app");
+
+    // Drop `first` on the right → vertical split, `first` alone on the right,
+    // everything else on the left.
+    useTabs.getState().dropTabToSplit(first, "right");
+
+    const s = useTabs.getState();
+    expect(s.split).toBe("vertical");
+    expect(s.tabPane[first]).toBe(1);
+    expect(s.tabPane[second] ?? 0).toBe(0);
+    expect(s.tabPane[third] ?? 0).toBe(0);
+    expect(s.focusedPane).toBe(1);
+    expect(s.activeId).toBe(first);
+    expect(s.draggingTabId).toBeNull();
+  });
+
+  it("splits below the rest when dropping on the bottom edge", () => {
+    const store = useTabs.getState();
+    const first = store.newQueryTab("conn-1", "app");
+    const second = useTabs.getState().newQueryTab("conn-1", "app");
+
+    useTabs.getState().dropTabToSplit(second, "bottom");
+
+    const s = useTabs.getState();
+    expect(s.split).toBe("horizontal");
+    expect(s.tabPane[second]).toBe(1);
+    expect(s.tabPane[first] ?? 0).toBe(0);
+  });
+
+  it("moves a tab across panes", () => {
+    const store = useTabs.getState();
+    const first = store.newQueryTab("conn-1", "app");
+    const second = useTabs.getState().newQueryTab("conn-1", "app");
+    const third = useTabs.getState().newQueryTab("conn-1", "app");
+
+    // third → secondary pane; first & second stay in primary.
+    useTabs.getState().splitActiveTab("vertical");
+    useTabs.getState().moveTabToPane(first, 1);
+
+    const s = useTabs.getState();
+    expect(s.tabPane[first]).toBe(1);
+    expect(s.tabPane[third]).toBe(1);
+    expect(s.tabPane[second] ?? 0).toBe(0);
+    expect(s.focusedPane).toBe(1);
+    expect(s.activeId).toBe(first);
   });
 
   it("reopens the most recently closed tab with its query buffer intact", () => {

--- a/apps/desktop/src/state/tabs.ts
+++ b/apps/desktop/src/state/tabs.ts
@@ -61,17 +61,16 @@ export type WorkspaceTab =
   | SchemaCompareTab
   | ErDiagramTab;
 export type SplitOrientation = "horizontal" | "vertical";
+/** Edge a tab was dropped on to create/redirect a split. */
+export type SplitEdge = "left" | "right" | "top" | "bottom";
 
 /** Short label for a tab — title for query/ER tabs, `schema.table` for tables. */
 export function tabLabel(tab: WorkspaceTab): string {
   return tab.kind === "table" ? `${tab.schema}.${tab.table}` : tab.title;
 }
 
-export interface WorkspaceSplit {
-  orientation: SplitOrientation;
-  primaryId: string;
-  secondaryId: string;
-}
+/** 0 = primary (left/top) pane, 1 = secondary (right/bottom) pane. */
+export type PaneIndex = 0 | 1;
 
 export type TableLayouts = Record<string, GridColumnLayout>;
 
@@ -80,9 +79,19 @@ let schemaCompareSeq = 0;
 
 interface TabsStore {
   tabs: WorkspaceTab[];
+  /** The globally focused tab — mirrors the focused pane's active tab. */
   activeId: string | null;
   closedTabs: WorkspaceTab[];
-  split: WorkspaceSplit | null;
+  /** Split orientation, or `null` when the workspace is a single pane. */
+  split: SplitOrientation | null;
+  /** Pane each tab lives in; absence means the primary pane (0). */
+  tabPane: Record<string, PaneIndex>;
+  /** Active tab per pane: [primary, secondary]. */
+  paneActive: [string | null, string | null];
+  /** Which pane has focus — drives `activeId` and where new tabs land. */
+  focusedPane: PaneIndex;
+  /** Tab id currently being dragged, or `null` — drives the drop-zone overlay. */
+  draggingTabId: string | null;
   tableChanges: Record<string, PendingChanges>;
   tableLayouts: TableLayouts;
   refreshKeys: Record<string, number>;
@@ -121,6 +130,13 @@ interface TabsStore {
   closeTabsToRight: (id: string) => void;
   closeConnectionTabs: (connectionId: string) => void;
   reorderTab: (sourceId: string, targetId: string) => void;
+  /** Move a tab into a pane (used when dragging onto the other pane's strip). */
+  moveTabToPane: (id: string, pane: PaneIndex) => void;
+  /** Focus a pane without changing its active tab (e.g. clicking its "+"). */
+  focusPane: (pane: PaneIndex) => void;
+  setDraggingTab: (id: string | null) => void;
+  /** Split (or re-split) by dropping a tab on a workspace edge. */
+  dropTabToSplit: (id: string, edge: SplitEdge) => void;
   setActive: (id: string) => void;
   setTableLayout: (id: string, layout: GridColumnLayout) => void;
   /** Merge imported per-table layouts over the current ones and persist. */
@@ -210,15 +226,62 @@ function clearTabResults(ids: string[]) {
   useNotices.getState().dropTabs(ids);
 }
 
-function splitForTabs(
-  tabs: WorkspaceTab[],
-  split: WorkspaceSplit | null,
-): WorkspaceSplit | null {
-  return split &&
-    tabs.some((t) => t.id === split.primaryId) &&
-    tabs.some((t) => t.id === split.secondaryId)
-    ? split
-    : null;
+/** The pane a tab lives in (primary unless explicitly placed in secondary). */
+function paneOf(tabPane: Record<string, PaneIndex>, id: string): PaneIndex {
+  return tabPane[id] ?? 0;
+}
+
+function setPaneActive(
+  paneActive: [string | null, string | null],
+  pane: PaneIndex,
+  id: string | null,
+): [string | null, string | null] {
+  return pane === 0 ? [id, paneActive[1]] : [paneActive[0], id];
+}
+
+type SplitState = Pick<
+  TabsStore,
+  "split" | "tabPane" | "paneActive" | "focusedPane" | "activeId"
+>;
+
+/**
+ * Re-derive the split-layout fields so they stay consistent with `tabs`:
+ * drop stale pane membership, collapse the split if a pane is empty, and pick a
+ * valid active tab per pane (keeping the requested one when it's still valid,
+ * else the last tab in that pane). `activeId` mirrors the focused pane.
+ */
+function reconcile(s: { tabs: WorkspaceTab[] } & SplitState): SplitState {
+  const ids = new Set(s.tabs.map((t) => t.id));
+  let tabPane: Record<string, PaneIndex> = Object.fromEntries(
+    Object.entries(s.tabPane).filter(([id]) => ids.has(id)),
+  );
+
+  let split = s.split;
+  if (split) {
+    const hasPrimary = s.tabs.some((t) => paneOf(tabPane, t.id) === 0);
+    const hasSecondary = s.tabs.some((t) => paneOf(tabPane, t.id) === 1);
+    if (!hasPrimary || !hasSecondary) split = null;
+  }
+  // Collapsed (or never split): everything lives in the primary pane.
+  if (!split) tabPane = {};
+
+  const pickActive = (pane: PaneIndex): string | null => {
+    const requested = s.paneActive[pane];
+    if (requested && ids.has(requested) && paneOf(tabPane, requested) === pane) {
+      return requested;
+    }
+    const inPane = s.tabs.filter((t) => paneOf(tabPane, t.id) === pane);
+    return inPane.length ? inPane[inPane.length - 1]!.id : null;
+  };
+  const paneActive: [string | null, string | null] = [
+    pickActive(0),
+    pickActive(1),
+  ];
+
+  const focusedPane: PaneIndex = split ? s.focusedPane : 0;
+  const activeId = paneActive[focusedPane] ?? paneActive[focusedPane ? 0 : 1];
+
+  return { split, tabPane, paneActive, focusedPane, activeId };
 }
 
 function stackClosedTabs(
@@ -228,84 +291,106 @@ function stackClosedTabs(
   return [...closed, ...current].slice(0, 12);
 }
 
+/** Append a new tab into the focused pane and make it active there. */
+function openInFocusedPane(s: TabsStore, tab: WorkspaceTab): Partial<TabsStore> {
+  const pane: PaneIndex = s.split ? s.focusedPane : 0;
+  const tabs = [...s.tabs, tab];
+  const tabPane = pane === 1 ? { ...s.tabPane, [tab.id]: pane } : s.tabPane;
+  const paneActive = setPaneActive(s.paneActive, pane, tab.id);
+  return { tabs, ...reconcile({ ...s, tabs, tabPane, paneActive, focusedPane: pane }) };
+}
+
+/** Focus an already-open tab in whichever pane it lives. */
+function activateExisting(s: TabsStore, id: string): Partial<TabsStore> {
+  const pane = paneOf(s.tabPane, id);
+  return reconcile({
+    ...s,
+    focusedPane: pane,
+    paneActive: setPaneActive(s.paneActive, pane, id),
+  });
+}
+
 export const useTabs = create<TabsStore>((set, get) => ({
   tabs: [],
   activeId: null,
   closedTabs: [],
   split: null,
+  tabPane: {},
+  paneActive: [null, null],
+  focusedPane: 0,
+  draggingTabId: null,
   tableChanges: {},
   tableLayouts: loadTableLayouts(),
   refreshKeys: {},
 
   openTable(connectionId, database, schema, table) {
     const id = tableKey(connectionId, database, schema, table);
-    const existing = get().tabs.find((t) => t.id === id);
-    if (existing) {
-      set({ activeId: id });
-      return;
-    }
-    set((s) => ({
-      tabs: [
-        ...s.tabs,
-        { id, kind: "table", connectionId, database, schema, table },
-      ],
-      activeId: id,
-    }));
+    set((s) =>
+      s.tabs.some((t) => t.id === id)
+        ? activateExisting(s, id)
+        : openInFocusedPane(s, {
+            id,
+            kind: "table",
+            connectionId,
+            database,
+            schema,
+            table,
+          }),
+    );
   },
 
   openErDiagram(connectionId, database, schemas) {
     const scope =
       schemas && schemas.length > 0 ? [...schemas].sort() : null;
     const id = `er:${connectionId}::${database}::${scope?.join(",") ?? "all"}`;
-    const existing = get().tabs.find((t) => t.id === id);
-    if (existing) {
-      set({ activeId: id });
-      return;
-    }
     const title =
       scope && scope.length === 1
         ? `ER: ${scope[0]}`
         : `ER: ${database}`;
-    set((s) => ({
-      tabs: [
-        ...s.tabs,
-        { id, kind: "er-diagram", connectionId, database, title, schemas: scope },
-      ],
-      activeId: id,
-    }));
+    set((s) =>
+      s.tabs.some((t) => t.id === id)
+        ? activateExisting(s, id)
+        : openInFocusedPane(s, {
+            id,
+            kind: "er-diagram",
+            connectionId,
+            database,
+            title,
+            schemas: scope,
+          }),
+    );
   },
 
   newQueryTab(connectionId, database) {
     const id = `query:${++queryTabSeq}:${connectionId}`;
     const title = `untitled-${queryTabSeq}.sql`;
-    set((s) => ({
-      tabs: [
-        ...s.tabs,
-        {
-          id,
-          kind: "query",
-          connectionId,
-          database,
-          title,
-          sql: "",
-          savedSql: "",
-          dirty: false,
-        },
-      ],
-      activeId: id,
-    }));
+    set((s) =>
+      openInFocusedPane(s, {
+        id,
+        kind: "query",
+        connectionId,
+        database,
+        title,
+        sql: "",
+        savedSql: "",
+        dirty: false,
+      }),
+    );
     return id;
   },
 
   openSchemaCompare(title, connectionId, database, config) {
     const id = `schema-compare:${++schemaCompareSeq}`;
-    set((s) => ({
-      tabs: [
-        ...s.tabs,
-        { id, kind: "schema-compare", connectionId, database, title, config },
-      ],
-      activeId: id,
-    }));
+    set((s) =>
+      openInFocusedPane(s, {
+        id,
+        kind: "schema-compare",
+        connectionId,
+        database,
+        title,
+        config,
+      }),
+    );
     return id;
   },
 
@@ -347,8 +432,6 @@ export const useTabs = create<TabsStore>((set, get) => ({
     set((s) => {
       const closed = s.tabs.find((t) => t.id === id);
       const tabs = s.tabs.filter((t) => t.id !== id);
-      const activeId =
-        s.activeId === id ? tabs[tabs.length - 1]?.id ?? null : s.activeId;
       const { tableChanges, refreshKeys } = dropTabScopedState(
         [id],
         s.tableChanges,
@@ -356,11 +439,10 @@ export const useTabs = create<TabsStore>((set, get) => ({
       );
       return {
         tabs,
-        activeId,
         closedTabs: closed ? [closed, ...s.closedTabs].slice(0, 12) : s.closedTabs,
-        split: splitForTabs(tabs, s.split),
         tableChanges,
         refreshKeys,
+        ...reconcile({ ...s, tabs }),
       };
     });
     clearTabResults([id]);
@@ -381,11 +463,10 @@ export const useTabs = create<TabsStore>((set, get) => ({
       );
       return {
         tabs,
-        activeId: tabs[0]?.id ?? null,
         closedTabs: stackClosedTabs(closed, s.closedTabs),
-        split: null,
         tableChanges,
         refreshKeys,
+        ...reconcile({ ...s, tabs }),
       };
     });
     clearTabResults(closedIds);
@@ -400,7 +481,6 @@ export const useTabs = create<TabsStore>((set, get) => ({
     set((s) => {
       const tabs = s.tabs.slice(0, tabIndex + 1);
       const closed = s.tabs.slice(tabIndex + 1);
-      const activeId = closedIds.includes(s.activeId ?? "") ? id : s.activeId;
       const { tableChanges, refreshKeys } = dropTabScopedState(
         closedIds,
         s.tableChanges,
@@ -408,11 +488,10 @@ export const useTabs = create<TabsStore>((set, get) => ({
       );
       return {
         tabs,
-        activeId,
         closedTabs: stackClosedTabs(closed, s.closedTabs),
-        split: splitForTabs(tabs, s.split),
         tableChanges,
         refreshKeys,
+        ...reconcile({ ...s, tabs }),
       };
     });
     clearTabResults(closedIds);
@@ -425,9 +504,6 @@ export const useTabs = create<TabsStore>((set, get) => ({
     set((s) => {
       const removed = new Set(removedIds);
       const tabs = s.tabs.filter((t) => !removed.has(t.id));
-      const activeId = removed.has(s.activeId ?? "")
-        ? tabs[tabs.length - 1]?.id ?? null
-        : s.activeId;
       const { tableChanges, refreshKeys } = dropTabScopedState(
         removedIds,
         s.tableChanges,
@@ -435,15 +511,14 @@ export const useTabs = create<TabsStore>((set, get) => ({
       );
       return {
         tabs,
-        activeId,
         // Drop the connection's tabs from the reopen stack too, so undo-close
         // can't resurrect a tab that points at a connection that no longer exists.
         closedTabs: s.closedTabs.filter(
           (t) => t.connectionId !== connectionId,
         ),
-        split: splitForTabs(tabs, s.split),
         tableChanges,
         refreshKeys,
+        ...reconcile({ ...s, tabs }),
       };
     });
     if (removedIds.length > 0) clearTabResults(removedIds);
@@ -453,13 +528,70 @@ export const useTabs = create<TabsStore>((set, get) => ({
     if (sourceId === targetId) return;
     set((s) => {
       const sourceIndex = s.tabs.findIndex((t) => t.id === sourceId);
-      const targetIndex = s.tabs.findIndex((t) => t.id === targetId);
-      if (sourceIndex === -1 || targetIndex === -1) return {};
+      if (sourceIndex === -1 || !s.tabs.some((t) => t.id === targetId)) {
+        return {};
+      }
       const tabs = [...s.tabs];
       const [moved] = tabs.splice(sourceIndex, 1);
       if (!moved) return {};
-      tabs.splice(targetIndex, 0, moved);
-      return { tabs, split: splitForTabs(tabs, s.split) };
+      tabs.splice(tabs.findIndex((t) => t.id === targetId), 0, moved);
+      // When split, dropping onto another pane's tab moves the source into it.
+      const tabPane = s.split
+        ? { ...s.tabPane, [sourceId]: paneOf(s.tabPane, targetId) }
+        : s.tabPane;
+      return { tabs, ...reconcile({ ...s, tabs, tabPane }) };
+    });
+  },
+
+  moveTabToPane(id, pane) {
+    set((s) => {
+      if (!s.split || !s.tabs.some((t) => t.id === id)) return {};
+      if (paneOf(s.tabPane, id) === pane) return activateExisting(s, id);
+      const tabPane = { ...s.tabPane, [id]: pane };
+      return reconcile({
+        ...s,
+        tabPane,
+        paneActive: setPaneActive(s.paneActive, pane, id),
+        focusedPane: pane,
+      });
+    });
+  },
+
+  focusPane(pane) {
+    set((s) => (s.split ? reconcile({ ...s, focusedPane: pane }) : {}));
+  },
+
+  setDraggingTab(id) {
+    set({ draggingTabId: id });
+  },
+
+  dropTabToSplit(id, edge) {
+    set((s) => {
+      if (!s.tabs.some((t) => t.id === id)) return { draggingTabId: null };
+      const orientation: SplitOrientation =
+        edge === "left" || edge === "right" ? "vertical" : "horizontal";
+      const targetPane: PaneIndex = edge === "left" || edge === "top" ? 0 : 1;
+      let tabPane: Record<string, PaneIndex>;
+      if (s.split) {
+        // Already split — just move the dropped tab to the chosen pane.
+        tabPane = { ...s.tabPane, [id]: targetPane };
+      } else {
+        // Fresh split — the dropped tab takes its edge, everything else the
+        // opposite pane (a no-op when it's the only tab: reconcile collapses).
+        const other: PaneIndex = targetPane === 0 ? 1 : 0;
+        tabPane = {};
+        for (const t of s.tabs) tabPane[t.id] = t.id === id ? targetPane : other;
+      }
+      return {
+        draggingTabId: null,
+        ...reconcile({
+          ...s,
+          split: orientation,
+          tabPane,
+          paneActive: setPaneActive(s.paneActive, targetPane, id),
+          focusedPane: targetPane,
+        }),
+      };
     });
   },
 
@@ -467,57 +599,47 @@ export const useTabs = create<TabsStore>((set, get) => ({
     set((s) => {
       const [closed, ...closedTabs] = s.closedTabs;
       if (!closed) return {};
-
-      const existing = s.tabs.find((t) => t.id === closed.id);
-      if (existing) {
-        return { activeId: existing.id, closedTabs };
-      }
-
-      return {
-        tabs: [...s.tabs, closed],
-        activeId: closed.id,
-        closedTabs,
-      };
+      return s.tabs.some((t) => t.id === closed.id)
+        ? { closedTabs, ...activateExisting(s, closed.id) }
+        : { closedTabs, ...openInFocusedPane(s, closed) };
     });
   },
 
   splitActiveTab(orientation) {
     set((s) => {
-      if (!s.activeId || s.tabs.length < 2) return {};
-
-      if (s.split?.orientation === orientation) {
-        return { split: null };
+      // Same orientation again → collapse back to a single pane.
+      if (s.split === orientation) {
+        return reconcile({
+          ...s,
+          split: null,
+          paneActive: [s.activeId, null],
+          focusedPane: 0,
+        });
       }
-
-      const activeIndex = s.tabs.findIndex((t) => t.id === s.activeId);
-      if (activeIndex === -1) return {};
-
-      const secondary =
-        s.tabs[activeIndex + 1] ?? s.tabs[activeIndex - 1] ?? null;
-      if (!secondary) return {};
-
-      return {
-        split: {
-          orientation,
-          primaryId: s.activeId,
-          secondaryId: secondary.id,
-        },
-      };
+      // Already split the other way → just flip the orientation.
+      if (s.split) return reconcile({ ...s, split: orientation });
+      // Create a split: move the active tab into the secondary pane and keep
+      // the rest in the primary (needs another tab so neither pane is empty).
+      if (!s.activeId || s.tabs.length < 2) return {};
+      const tabPane = { ...s.tabPane, [s.activeId]: 1 as PaneIndex };
+      return reconcile({
+        ...s,
+        split: orientation,
+        tabPane,
+        paneActive: [null, s.activeId],
+        focusedPane: 1,
+      });
     });
   },
 
   clearSplit() {
-    set({ split: null });
+    set((s) =>
+      reconcile({ ...s, split: null, paneActive: [s.activeId, null], focusedPane: 0 }),
+    );
   },
 
   setActive(id) {
-    set((s) => ({
-      activeId: id,
-      split:
-        s.split && id !== s.split.primaryId && id !== s.split.secondaryId
-          ? { ...s.split, primaryId: id }
-          : s.split,
-    }));
+    set((s) => activateExisting(s, id));
   },
 
   setTableLayout(id, layout) {


### PR DESCRIPTION
Reworks the split workspace into two independent tab groups instead of one shared strip. Each pane now has its own tab strip with its own active tab and "+" button, and tabs can be dragged between panes. The divider between panes is draggable to resize them, and dragging a tab onto the left, right, or bottom edge of the workspace creates a split in that direction. Splitting now moves the active tab into the new pane (DataGrip-style) and a split collapses automatically when one pane is emptied. The tab store keeps `tabs`/`activeId` meaning the same so the rest of the app is untouched; tab-state tests were updated and extended for the new model.