### PR TITLE
fix(desktop): add vite/client types reference for import.meta.env

### DIFF
--- a/apps/desktop/src/vite-env.d.ts
+++ b/apps/desktop/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
The desktop app had no `vite-env.d.ts`, so `tsc --noEmit` failed on `import.meta.env.DEV` with `TS2339: Property 'env' does not exist on type 'ImportMeta'`, breaking the `tauri build` (`beforeBuildCommand` step). This adds the canonical Vite types reference file so `import.meta.env` is typed across the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)