### PR TITLE
ci(release): stamp release version into tauri.conf.json before build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,16 @@ jobs:
           echo "$APP_STORE_CONNECT_API_KEY_BASE64" | base64 -D > "$api_key_path"
           chmod 600 "$api_key_path"
 
+      - name: Stamp release version into tauri.conf.json
+        shell: bash
+        run: |
+          set -euo pipefail
+          conf="apps/desktop/src-tauri/tauri.conf.json"
+          tmp="$(mktemp)"
+          jq --arg v "${{ steps.release.outputs.version }}" '.version = $v' "$conf" > "$tmp"
+          mv "$tmp" "$conf"
+          echo "tauri.conf.json version set to ${{ steps.release.outputs.version }}"
+
       - name: Build and upload installers
         uses: tauri-apps/tauri-action@v0
         env:


### PR DESCRIPTION
The release workflow derived the version from the git tag for `latest.json` and the release name, but never bumped `tauri.conf.json`, so each build baked in the stale hardcoded version. The result: the updater would download and install a new release, yet the app still reported the old version. This adds a step that stamps the resolved tag version into `tauri.conf.json` before `tauri-action` builds, making the git tag the single source of truth for the displayed version, the updater comparison, and `latest.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)