### PR TITLE
fix(settings): live version number and clearer General placeholder

### DIFF
--- a/apps/desktop/src/components/modals/Settings.tsx
+++ b/apps/desktop/src/components/modals/Settings.tsx
@@ -319,8 +319,8 @@ function SettingsNav({
         );
       })}
       <div className="mt-auto flex items-center gap-1.5 border-t border-border-divider px-[14px] py-2.5 text-[10px]">
-        <span className="font-mono text-fg-3">{appVersion ? `v${appVersion}` : ""}</span>
-        <span className="text-fg-3">·</span>
+        {appVersion && <span className="font-mono text-fg-3">{`v${appVersion}`}</span>}
+        {appVersion && <span className="text-fg-3">·</span>}
         <button
           type="button"
           disabled

--- a/apps/desktop/src/components/modals/Settings.tsx
+++ b/apps/desktop/src/components/modals/Settings.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { getVersion } from "@tauri-apps/api/app";
 import { Icon, type IconName } from "../icons";
 import { Modal } from "./Modal";
 import { SettingsAI } from "./settingsAIPanel";
@@ -232,6 +233,12 @@ function SettingsNav({
   q: string;
   searchResults: SettingsSearchResult[];
 }) {
+  const [appVersion, setAppVersion] = useState<string>("");
+  useEffect(() => {
+    getVersion()
+      .then(setAppVersion)
+      .catch(() => setAppVersion(""));
+  }, []);
   const filter = q.toLowerCase().trim();
   const matchingCats = new Set(searchResults.map((result) => result.cat));
   const counts = searchResults.reduce<Partial<Record<SettingsCatId, number>>>(
@@ -312,7 +319,7 @@ function SettingsNav({
         );
       })}
       <div className="mt-auto flex items-center gap-1.5 border-t border-border-divider px-[14px] py-2.5 text-[10px]">
-        <span className="font-mono text-fg-3">v0.1.0-alpha</span>
+        <span className="font-mono text-fg-3">{appVersion ? `v${appVersion}` : ""}</span>
         <span className="text-fg-3">·</span>
         <button
           type="button"

--- a/apps/desktop/src/components/modals/settingsWorkspacePanels.tsx
+++ b/apps/desktop/src/components/modals/settingsWorkspacePanels.tsx
@@ -145,7 +145,7 @@ export function SettingsGeneral() {
   return (
     <div className="flex-1 overflow-y-auto pb-6 pt-1">
       <p className="px-5 pt-4 text-[11.5px] text-fg-3">
-        General settings will appear here as features are built.
+        General settings and more config coming soon.
       </p>
     </div>
   );


### PR DESCRIPTION
The Settings footer was hardcoded to `v0.1.0-alpha` even though the app is at 0.2.0; it now reads the real app version via Tauri's `getVersion()` (the same API already used in `updater.ts`) so it stays in sync with `tauri.conf.json`. The empty General panel copy was reworded to "General settings and more config coming soon."

🤖 Generated with [Claude Code](https://claude.com/claude-code)