### PR TITLE
feat(settings): font picker dropdowns for interface and editor fonts

### DIFF
--- a/apps/desktop/src/components/modals/settingsWorkspacePanels.tsx
+++ b/apps/desktop/src/components/modals/settingsWorkspacePanels.tsx
@@ -17,6 +17,56 @@ import {
   Toggle,
 } from "./settingsPrimitives";
 
+// Curated, broadly-available fonts. Picking one not installed locally falls
+// through the stack in applySettingsSideEffects, so it stays safe.
+const SANS_FONTS = [
+  "Geist",
+  "Inter",
+  "SF Pro Text",
+  "Helvetica Neue",
+  "Arial",
+  "Roboto",
+  "Segoe UI",
+];
+const MONO_FONTS = [
+  "JetBrains Mono",
+  "Geist Mono",
+  "SF Mono",
+  "Menlo",
+  "Monaco",
+  "Fira Code",
+  "Cascadia Code",
+  "Source Code Pro",
+  "Consolas",
+];
+
+function FontSelect({
+  value,
+  onChange,
+  options,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  options: string[];
+}) {
+  // Keep any legacy/custom value selectable so it isn't silently dropped.
+  const list = options.includes(value) ? options : [value, ...options];
+  return (
+    <select
+      className={CD_INPUT}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      style={{ flex: 1, fontFamily: `"${value}"` }}
+    >
+      {list.map((f) => (
+        <option key={f} value={f} style={{ fontFamily: `"${f}"` }}>
+          {f}
+        </option>
+      ))}
+    </select>
+  );
+}
+
 export function SettingsAppearance() {
   const { settings, set } = useSettings();
 
@@ -70,19 +120,17 @@ export function SettingsAppearance() {
 
       <Section title="Type">
         <Row label="Interface font">
-          <input
-            className={CD_INPUT + " font-sans"}
+          <FontSelect
             value={settings.interfaceFont}
-            onChange={(e) => set("interfaceFont", e.target.value)}
-            style={{ flex: 1 }}
+            onChange={(v) => set("interfaceFont", v)}
+            options={SANS_FONTS}
           />
         </Row>
         <Row label="Editor / mono font">
-          <input
-            className={CD_INPUT + " font-mono"}
+          <FontSelect
             value={settings.monoFont}
-            onChange={(e) => set("monoFont", e.target.value)}
-            style={{ flex: 1 }}
+            onChange={(v) => set("monoFont", v)}
+            options={MONO_FONTS}
           />
         </Row>
         <Row

--- a/apps/desktop/src/lib/settings.tsx
+++ b/apps/desktop/src/lib/settings.tsx
@@ -131,6 +131,17 @@ export function applySettingsSideEffects(s: Settings) {
   html.setAttribute("data-theme", resolvedTheme);
   html.setAttribute("data-density", s.density);
 
+  // User-selected fonts override the leading family; the rest of the stack in
+  // tokens.css remains as graceful fallback for anything not installed.
+  html.style.setProperty(
+    "--font-sans",
+    `"${s.interfaceFont}", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif`,
+  );
+  html.style.setProperty(
+    "--font-mono",
+    `"${s.monoFont}", "Geist Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace`,
+  );
+
   html.style.setProperty("--accent", s.accent);
   html.style.setProperty(
     "--accent-soft",


### PR DESCRIPTION
Replaces the free-text interface and editor/mono font inputs in appearance settings with dropdowns of curated, broadly-available fonts, each option previewed in its own typeface. Any existing custom/legacy value is preserved as a selectable option. Also wires the selected fonts into `--font-sans`/`--font-mono` in `applySettingsSideEffects` — previously these settings were stored but never applied — keeping the original fallback stack so an uninstalled font degrades gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)