### PR TITLE
perf(grid): smooth quick filter on large tables; fix notices leak

### DIFF
--- a/apps/desktop/src/components/Workspace.tsx
+++ b/apps/desktop/src/components/Workspace.tsx
@@ -254,15 +254,11 @@ function TableTabPane({
   const [pageSize, setPageSize] = useState(500);
   const grid = useGridState();
   // Quick filter is kept separate from the advanced chips (`grid.filters`) so
-  // clearing one never disturbs the other. `quickInput` is the immediate text
-  // box value; `quickFilter` is its debounced form that drives the server query.
-  const [quickInput, setQuickInput] = useState("");
+  // clearing one never disturbs the other. FilterBar owns the typed text and
+  // debounces it, so `quickFilter` only updates (and re-queries) once the user
+  // pauses — keystrokes never re-render the grid.
   const [quickFilter, setQuickFilter] = useState("");
   const [quickColumn, setQuickColumn] = useState<string | null>(null);
-  useEffect(() => {
-    const handle = setTimeout(() => setQuickFilter(quickInput.trim()), 250);
-    return () => clearTimeout(handle);
-  }, [quickInput]);
   const data = useTableData(
     tab.connectionId,
     tab.database,
@@ -422,8 +418,8 @@ function TableTabPane({
         renderEditor={renderGridEditor}
         filters={grid.filters}
         onFiltersChange={grid.setFilters}
-        quickFilter={quickInput}
-        onQuickFilterChange={setQuickInput}
+        quickFilter={quickFilter}
+        onQuickFilterChange={setQuickFilter}
         quickFilterColumn={quickColumn}
         onQuickFilterColumnChange={setQuickColumn}
         sort={grid.sort}

--- a/apps/desktop/src/hooks/useTableData.ts
+++ b/apps/desktop/src/hooks/useTableData.ts
@@ -170,7 +170,10 @@ export function useTableData(
           hasNextPage: result.truncated,
         }));
         useNotices.getState().recordQueryResult(
-          { tabId: tableTabId(connectionId, database, schema, table), connectionId, database },
+          // Scope to the live tab id (same key the bottom panel reads and that
+          // tab close drops) — not the table path, which leaked entries nothing
+          // ever cleared.
+          { tabId: messageTabId, connectionId, database },
           result,
         );
         useQueryMessages

--- a/apps/desktop/src/state/notices.ts
+++ b/apps/desktop/src/state/notices.ts
@@ -31,6 +31,16 @@ export const EMPTY_ENTRY: NoticeLogEntry = {
   retain: true,
 };
 
+// Cap retained notices so a long-lived tab that keeps querying (e.g. typing in
+// the quick filter, one query per keystroke) can't grow this array without
+// bound. Mirrors trimMessages() in queryMessages.ts.
+const MAX_NOTICES = 200;
+
+function trimNotices(notices: DatabaseNotice[]): DatabaseNotice[] {
+  if (notices.length <= MAX_NOTICES) return notices;
+  return notices.slice(notices.length - MAX_NOTICES);
+}
+
 export function noticeScopeKey(scope: NoticeScope): string {
   if (scope.tabId) return `tab:${scope.tabId}`;
   if (scope.connectionId) {
@@ -48,7 +58,7 @@ export const useNotices = create<NoticeStore>((set) => ({
     set((s) => {
       const previous = s.byScope[key] ?? structuredClone(EMPTY_ENTRY);
       const notices = previous.retain
-        ? [...previous.notices, ...result.notices]
+        ? trimNotices([...previous.notices, ...result.notices])
         : result.notices;
       return {
         byScope: {
@@ -73,7 +83,7 @@ export const useNotices = create<NoticeStore>((set) => ({
           ...s.byScope,
           [key]: {
             ...previous,
-            notices: [...previous.notices, notice],
+            notices: trimNotices([...previous.notices, notice]),
           },
         },
       };

--- a/packages/data-grid/src/DataGrid.test.ts
+++ b/packages/data-grid/src/DataGrid.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, it } from "vitest";
 import { calculateVirtualRows, shouldVirtualizeRows } from "./DataGrid";
 
 describe("shouldVirtualizeRows", () => {
-  it("keeps ordinary 500-row pages in normal row flow", () => {
-    expect(shouldVirtualizeRows(500)).toBe(false);
+  it("keeps small pages in normal row flow", () => {
+    expect(shouldVirtualizeRows(100)).toBe(false);
   });
 
-  it("only virtualizes larger result sets", () => {
-    expect(shouldVirtualizeRows(1_000)).toBe(false);
-    expect(shouldVirtualizeRows(1_001)).toBe(true);
+  it("virtualizes ordinary 500-row pages so the DOM stays small", () => {
+    expect(shouldVirtualizeRows(101)).toBe(true);
+    expect(shouldVirtualizeRows(500)).toBe(true);
   });
 });
 

--- a/packages/data-grid/src/DataGrid.tsx
+++ b/packages/data-grid/src/DataGrid.tsx
@@ -53,7 +53,11 @@ const HEADER_HEIGHT = 26;
 const DEFAULT_ROW_HEIGHT = 22;
 const MIN_ROW_OVERSCAN = 24;
 const OVERSCAN_VIEWPORTS = 3;
-const VIRTUAL_ROW_THRESHOLD = 1_000;
+// Below this, full row flow is cheap enough; above it we window the rows so a
+// wide table never puts thousands of cells in the DOM (which makes every
+// interaction — typing in the filter included — janky). The default page size
+// is 500, so this must sit under it or ordinary pages never virtualize.
+const VIRTUAL_ROW_THRESHOLD = 100;
 
 export function calculateVirtualRows({
   rowCount,

--- a/packages/data-grid/src/FilterBar.tsx
+++ b/packages/data-grid/src/FilterBar.tsx
@@ -157,7 +157,22 @@ export function FilterBar({
     [columns],
   );
   const showQuickFilter = !!onQuickFilterChange;
-  const quickValue = quickFilter ?? "";
+  // Keep the typed text local so each keystroke only re-renders this toolbar,
+  // not the whole grid (which can hold 100k+ rows). The trimmed value is pushed
+  // to the parent — and the server query — only after the user pauses.
+  const [quickDraft, setQuickDraft] = useState(quickFilter ?? "");
+  // Adopt external changes (tab switch, programmatic clear) but ignore the
+  // parent echoing back our own trimmed value, so a trailing space isn't eaten.
+  useEffect(() => {
+    setQuickDraft((prev) => (prev.trim() === (quickFilter ?? "") ? prev : quickFilter ?? ""));
+  }, [quickFilter]);
+  const onQuickRef = useRef(onQuickFilterChange);
+  onQuickRef.current = onQuickFilterChange;
+  useEffect(() => {
+    const handle = setTimeout(() => onQuickRef.current?.(quickDraft.trim()), 250);
+    return () => clearTimeout(handle);
+  }, [quickDraft]);
+  const quickValue = quickDraft;
   const quickColumnValue = quickFilterColumn ?? textColumns[0]?.key ?? "";
   const quickActive = quickValue.trim().length > 0;
   const activeCount = filters.length + (quickActive ? 1 : 0);
@@ -170,7 +185,7 @@ export function FilterBar({
           <input
             className="grid-quickfilter-input mono"
             value={quickValue}
-            onChange={(e) => onQuickFilterChange?.(e.target.value)}
+            onChange={(e) => setQuickDraft(e.target.value)}
             placeholder="Quick filter (id or text)…"
             aria-label="Quick filter"
           />
@@ -192,7 +207,7 @@ export function FilterBar({
           {quickActive && (
             <button
               className="grid-filter-remove"
-              onClick={() => onQuickFilterChange?.("")}
+              onClick={() => setQuickDraft("")}
               aria-label="Clear quick filter"
             >
               <GridIcon.close size={9} />

--- a/packages/data-grid/src/FilterBar.tsx
+++ b/packages/data-grid/src/FilterBar.tsx
@@ -207,7 +207,10 @@ export function FilterBar({
           {quickActive && (
             <button
               className="grid-filter-remove"
-              onClick={() => setQuickDraft("")}
+              onClick={() => {
+                setQuickDraft("");
+                onQuickFilterChange?.("");
+              }}
               aria-label="Clear quick filter"
             >
               <GridIcon.close size={9} />


### PR DESCRIPTION
Quick-filter typing was janky on large tables because the input value lived in `Workspace` and flowed through `DataGrid`, so every keystroke re-rendered the whole grid — and the default 500-row page rendered un-virtualized since the virtualization threshold sat at 1000. `FilterBar` now owns the typed text and debounces it upward (keystrokes only re-render the toolbar), and `VIRTUAL_ROW_THRESHOLD` drops to 100 so ordinary pages window their rows and keep the DOM small. Separately, per-query database notices were accumulating without bound and were recorded under a scope key nothing ever read, cleared, or freed; they are now capped (`trimNotices`) and recorded under the live tab id so they show in the bottom panel and are dropped on tab close.

Not addressed here (backend): each debounced search still runs an un-cancellable full-table `ILIKE` scan plus `COUNT(*)`, so superseded searches queue on the connection — fixing that needs `browseTable` to return a cancellable query id or to drop the per-search total count.