### PR TITLE
fix(site): repair social link preview and add SEO scaffolding

### DIFF
--- a/apps/site/index.html
+++ b/apps/site/index.html
@@ -6,14 +6,40 @@
   <title>Cellar — Open-source desktop database client</title>
   <meta name="description" content="Cellar is a local-first desktop database client for browsing schemas, running SQL, and reviewing data changes. Supports PostgreSQL, SQL Server, Azure SQL, and Firestore." />
 
+  <link rel="canonical" href="https://cellar.run/" />
+
   <link rel="icon" type="image/png" sizes="128x128" href="/assets/favicon-128.png" />
   <link rel="icon" type="image/svg+xml" href="/assets/cellar-mark.svg" />
 
-  <meta property="og:title" content="Cellar" />
+  <meta property="og:url" content="https://cellar.run/" />
+  <meta property="og:title" content="Cellar — Open-source desktop database client" />
   <meta property="og:description" content="Cellar is a local-first desktop database client for browsing schemas, running SQL, and reviewing data changes." />
   <meta property="og:type" content="website" />
-  <meta property="og:image" content="/assets/main.png" />
+  <!-- og:image must be an absolute URL or crawlers (X, Slack, …) silently drop it and fall back to a placeholder card -->
+  <meta property="og:image" content="https://cellar.run/assets/cellar-main.png" />
+  <meta property="og:image:width" content="3164" />
+  <meta property="og:image:height" content="1635" />
+  <meta property="og:image:alt" content="Cellar desktop database client, main window" />
   <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:image" content="https://cellar.run/assets/cellar-main.png" />
+
+  <!-- Structured data: makes Cellar eligible for Google's rich app result (name, icon, description, screenshot) -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Cellar",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "macOS",
+    "url": "https://cellar.run/",
+    "downloadUrl": "https://github.com/MRL-00/cellar/releases",
+    "softwareHelp": "https://github.com/MRL-00/cellar",
+    "description": "Cellar is a local-first desktop database client for browsing schemas, running SQL, and reviewing data changes. Supports PostgreSQL, SQL Server, Azure SQL, and Firestore.",
+    "image": "https://cellar.run/assets/cellar-main.png",
+    "license": "https://opensource.org/licenses/MIT",
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
+  }
+  </script>
 
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/apps/site/public/robots.txt
+++ b/apps/site/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://cellar.run/sitemap.xml

--- a/apps/site/public/sitemap.xml
+++ b/apps/site/public/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://cellar.run/</loc>
+    <lastmod>2026-06-28</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
The `og:image` on cellar.run used a relative URL, so social crawlers (X, Slack, etc.) couldn't resolve it and fell back to a generic placeholder card. This switches it to an absolute URL pointing at the polished hero screenshot, adds image dimensions, `og:url`, and `twitter:image` so the large card renders properly. It also adds a canonical link, `SoftwareApplication` JSON-LD, `robots.txt`, and `sitemap.xml` to make the site eligible for richer Google results and reliable indexing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)