### PR TITLE
feat(theme): neutral default palette, SF Pro, 1px icons

### DIFF
--- a/apps/desktop/src/components/AIMessage.tsx
+++ b/apps/desktop/src/components/AIMessage.tsx
@@ -1,6 +1,9 @@
 import { useState } from "react";
 import { Icon } from "./icons";
 import type { AiChatEntry } from "../state/ai";
+import { tokenizeSql, tokensToLines, renderTokens } from "../lib/sqlTokens";
+
+const SQL_LANGS = /^(sql|postgres|postgresql|pgsql|mysql|sqlite|tsql|mssql)$/i;
 
 /** A run of message content: either prose or a fenced code block. */
 type Segment =
@@ -56,7 +59,15 @@ function CodeBlock({ lang, code }: { lang: string; code: string }) {
         </button>
       </div>
       <pre className="overflow-x-auto px-2.5 py-2 font-mono text-[11.5px] leading-[1.5] text-fg-0">
-        <code>{code}</code>
+        {SQL_LANGS.test(lang.trim()) ? (
+          tokensToLines(tokenizeSql(code)).map((toks, i) => (
+            <div key={i} className="whitespace-pre">
+              {toks.length ? renderTokens(toks) : " "}
+            </div>
+          ))
+        ) : (
+          <code>{code}</code>
+        )}
       </pre>
     </div>
   );

--- a/apps/desktop/src/components/BottomPanel.tsx
+++ b/apps/desktop/src/components/BottomPanel.tsx
@@ -172,7 +172,7 @@ export function BottomPanel({ onClose }: { onClose: () => void }) {
                 className={
                   "mt-[3px] inline-flex h-[22px] items-center gap-1.5 rounded-[4px] px-2 text-[11px] disabled:cursor-default disabled:opacity-45 " +
                   (isActive
-                    ? "bg-accent-soft text-accent"
+                    ? "bg-bg-3 text-fg-0"
                     : "text-fg-2 hover:bg-bg-2 hover:text-fg-0 disabled:hover:bg-transparent disabled:hover:text-fg-2")
                 }
               >
@@ -184,7 +184,7 @@ export function BottomPanel({ onClose }: { onClose: () => void }) {
                   <span
                     className={
                       "rounded-[8px] px-1 py-px font-mono text-[9.5px] " +
-                      (isActive ? "bg-bg-1 text-accent" : "bg-bg-2 text-fg-2")
+                      (isActive ? "bg-bg-1 text-fg-0" : "bg-bg-2 text-fg-2")
                     }
                   >
                     {t.count}

--- a/apps/desktop/src/components/SidebarTree.tsx
+++ b/apps/desktop/src/components/SidebarTree.tsx
@@ -148,7 +148,7 @@ export function ConnectionRow({
           )}
         </button>
         <EngineBadge engine={config.engine as Engine} size={12} color={accent} />
-        <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[13px] font-medium">
+        <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[12px] font-medium">
           {config.name}
         </span>
         {config.env_tag === "prod" && (
@@ -307,7 +307,7 @@ function DatabaseRow({
         </span>
         <span
           className={
-            "flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[12.5px] " +
+            "flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[11.5px] " +
             (visibleEmpty ? "text-fg-3" : "")
           }
         >
@@ -401,7 +401,7 @@ function SchemaRow({
         </span>
         <span
           className={
-            "flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[12.5px] " +
+            "flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[11.5px] " +
             (hidden ? "text-fg-3" : "")
           }
         >
@@ -459,7 +459,7 @@ function SchemaRow({
                   <span className={ICON_SLOT}>
                     <Icon.tree size={11} />
                   </span>
-                  <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[12.5px]">
+                  <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[11.5px]">
                     {v.name}
                   </span>
                 </div>
@@ -515,7 +515,7 @@ function GroupFolder({
         <span className={ICON_SLOT}>
           {open ? <Icon.folderOpen size={12} /> : <Icon.folder size={12} />}
         </span>
-        <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[12.5px]">
+        <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[11.5px]">
           {label}
         </span>
         <span className={META + " font-mono"}>{count}</span>
@@ -566,7 +566,7 @@ function TableRow({
       <span className={ICON_SLOT} style={{ color: "var(--fg-1)" }}>
         <Icon.table size={11} />
       </span>
-      <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[12.5px]">
+      <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[11.5px]">
         {table.name}
       </span>
       {table.row_count != null && (

--- a/apps/desktop/src/components/SidebarTree.tsx
+++ b/apps/desktop/src/components/SidebarTree.tsx
@@ -148,7 +148,7 @@ export function ConnectionRow({
           )}
         </button>
         <EngineBadge engine={config.engine as Engine} size={12} color={accent} />
-        <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[12px] font-medium">
+        <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[13px] font-medium">
           {config.name}
         </span>
         {config.env_tag === "prod" && (
@@ -307,7 +307,7 @@ function DatabaseRow({
         </span>
         <span
           className={
-            "flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[11.5px] " +
+            "flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[12.5px] " +
             (visibleEmpty ? "text-fg-3" : "")
           }
         >
@@ -401,7 +401,7 @@ function SchemaRow({
         </span>
         <span
           className={
-            "flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[11.5px] " +
+            "flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[12.5px] " +
             (hidden ? "text-fg-3" : "")
           }
         >
@@ -459,7 +459,7 @@ function SchemaRow({
                   <span className={ICON_SLOT}>
                     <Icon.tree size={11} />
                   </span>
-                  <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[11.5px]">
+                  <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[12.5px]">
                     {v.name}
                   </span>
                 </div>
@@ -515,7 +515,7 @@ function GroupFolder({
         <span className={ICON_SLOT}>
           {open ? <Icon.folderOpen size={12} /> : <Icon.folder size={12} />}
         </span>
-        <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[11.5px]">
+        <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[12.5px]">
           {label}
         </span>
         <span className={META + " font-mono"}>{count}</span>
@@ -566,7 +566,7 @@ function TableRow({
       <span className={ICON_SLOT} style={{ color: "var(--fg-1)" }}>
         <Icon.table size={11} />
       </span>
-      <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[11.5px]">
+      <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[12.5px]">
         {table.name}
       </span>
       {table.row_count != null && (

--- a/apps/desktop/src/components/SidebarTree.tsx
+++ b/apps/desktop/src/components/SidebarTree.tsx
@@ -148,7 +148,7 @@ export function ConnectionRow({
           )}
         </button>
         <EngineBadge engine={config.engine as Engine} size={12} color={accent} />
-        <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[12px] font-medium">
+        <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[13px] font-medium">
           {config.name}
         </span>
         {config.env_tag === "prod" && (
@@ -307,7 +307,7 @@ function DatabaseRow({
         </span>
         <span
           className={
-            "flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[11.5px] " +
+            "flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[13px] " +
             (visibleEmpty ? "text-fg-3" : "")
           }
         >
@@ -401,7 +401,7 @@ function SchemaRow({
         </span>
         <span
           className={
-            "flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[11.5px] " +
+            "flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[13px] " +
             (hidden ? "text-fg-3" : "")
           }
         >
@@ -459,7 +459,7 @@ function SchemaRow({
                   <span className={ICON_SLOT}>
                     <Icon.tree size={11} />
                   </span>
-                  <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[11.5px]">
+                  <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[13px]">
                     {v.name}
                   </span>
                 </div>
@@ -515,7 +515,7 @@ function GroupFolder({
         <span className={ICON_SLOT}>
           {open ? <Icon.folderOpen size={12} /> : <Icon.folder size={12} />}
         </span>
-        <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[11.5px]">
+        <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[13px]">
           {label}
         </span>
         <span className={META + " font-mono"}>{count}</span>
@@ -566,7 +566,7 @@ function TableRow({
       <span className={ICON_SLOT} style={{ color: "var(--fg-1)" }}>
         <Icon.table size={11} />
       </span>
-      <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[11.5px]">
+      <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[13px]">
         {table.name}
       </span>
       {table.row_count != null && (

--- a/apps/desktop/src/components/StatusBar.tsx
+++ b/apps/desktop/src/components/StatusBar.tsx
@@ -24,9 +24,9 @@ export function StatusBar() {
           <span
             className="inline-block h-1.5 w-1.5 rounded-full"
             style={{
-              background: connected ? "var(--accent)" : "var(--fg-4)",
+              background: connected ? "var(--insert)" : "var(--fg-4)",
               boxShadow: connected
-                ? "0 0 0 2px var(--accent-soft)"
+                ? "0 0 0 2px var(--insert-bg)"
                 : undefined,
             }}
           />

--- a/apps/desktop/src/components/TabBar.tsx
+++ b/apps/desktop/src/components/TabBar.tsx
@@ -244,7 +244,7 @@ export function TabBar({ pane }: { pane?: PaneIndex } = {}) {
                   "absolute left-0 top-0 h-full w-0.5 transition-opacity duration-150 " +
                   (isActive && isStripFocused ? "opacity-100" : "opacity-0")
                 }
-                style={{ background: "var(--eng-postgres)" }}
+                style={{ background: "var(--accent)" }}
               />
               <span className="inline-flex" style={{ color: "var(--fg-1)" }}>
                 {t.kind === "query" ? (

--- a/apps/desktop/src/components/Workspace.tsx
+++ b/apps/desktop/src/components/Workspace.tsx
@@ -541,8 +541,8 @@ function EmptyWorkspace() {
         className="relative h-9 w-9 rounded-lg"
         style={{
           background:
-            "linear-gradient(135deg, #c4b5fd 0%, var(--accent) 55%, #6d4ed1 100%)",
-          boxShadow: "0 0 24px var(--accent-soft)",
+            "linear-gradient(135deg, #c4b5fd 0%, #a78bfa 55%, #6d4ed1 100%)",
+          boxShadow: "0 0 24px rgba(167, 139, 250, 0.14)",
         }}
       >
         <span

--- a/apps/desktop/src/components/icons.tsx
+++ b/apps/desktop/src/components/icons.tsx
@@ -10,7 +10,7 @@ type IconProps = SVGProps<SVGSVGElement> & {
 const I = ({
   d,
   size = 14,
-  sw = 1.5,
+  sw = 1,
   fill = "none",
   stroke = "currentColor",
   children,

--- a/apps/desktop/src/components/modals/EmptyState.tsx
+++ b/apps/desktop/src/components/modals/EmptyState.tsx
@@ -65,8 +65,7 @@ export function EmptyState({ onNew }: { onNew: () => void }) {
             onClick={onNew}
             className="flex h-8 items-center justify-center gap-2 whitespace-nowrap rounded-[6px] border px-3 text-xs font-medium text-accent-fg transition-[filter] duration-[120ms] hover:brightness-[1.07]"
             style={{
-              background:
-                "linear-gradient(135deg, #c4b5fd 0%, var(--accent) 55%, #6d4ed1 100%)",
+              background: "var(--accent)",
               borderColor: "color-mix(in oklab, var(--accent) 40%, black)",
             }}
           >

--- a/apps/desktop/src/components/modals/EmptyState.tsx
+++ b/apps/desktop/src/components/modals/EmptyState.tsx
@@ -37,8 +37,8 @@ export function EmptyState({ onNew }: { onNew: () => void }) {
             className="relative h-9 w-9 rounded-lg"
             style={{
               background:
-                "linear-gradient(135deg, #c4b5fd 0%, var(--accent) 55%, #6d4ed1 100%)",
-              boxShadow: "0 0 24px var(--accent-soft)",
+                "linear-gradient(135deg, #c4b5fd 0%, #a78bfa 55%, #6d4ed1 100%)",
+              boxShadow: "0 0 24px rgba(167, 139, 250, 0.14)",
             }}
           >
             <span

--- a/apps/desktop/src/components/modals/settingsSystemPanels.tsx
+++ b/apps/desktop/src/components/modals/settingsSystemPanels.tsx
@@ -158,8 +158,8 @@ export function SettingsAbout() {
             className="relative h-12 w-12 shrink-0 rounded-[10px]"
             style={{
               background:
-                "linear-gradient(135deg, var(--accent), color-mix(in oklab, var(--accent) 50%, var(--syn-kw)))",
-              boxShadow: "0 0 24px var(--accent-soft)",
+                "linear-gradient(135deg, #c4b5fd 0%, #a78bfa 55%, #6d4ed1 100%)",
+              boxShadow: "0 0 24px rgba(167, 139, 250, 0.14)",
             }}
           >
             <span

--- a/apps/desktop/src/components/modals/settingsWorkspacePanels.tsx
+++ b/apps/desktop/src/components/modals/settingsWorkspacePanels.tsx
@@ -135,7 +135,7 @@ export function SettingsAppearance() {
         </Row>
         <Row
           label="Font size"
-          hint="Scales the entire interface. Default is 13 px."
+          hint="Scales the entire interface. Default is 13.5 px."
         >
           <input
             className={CD_INPUT + " font-mono"}
@@ -158,7 +158,7 @@ export function SettingsAppearance() {
               {FONT_SIZE_MIN}
             </span>
             <span className="absolute top-0 left-1/2 -translate-x-1/2 whitespace-nowrap text-[9.5px] text-fg-3">
-              13
+              13.5
             </span>
             <span className="absolute top-0 right-0 translate-x-1/2 whitespace-nowrap text-[9.5px] text-fg-3">
               {FONT_SIZE_MAX}

--- a/apps/desktop/src/components/modals/settingsWorkspacePanels.tsx
+++ b/apps/desktop/src/components/modals/settingsWorkspacePanels.tsx
@@ -68,7 +68,7 @@ function FontSelect({
 }
 
 export function SettingsAppearance() {
-  const { settings, set } = useSettings();
+  const { settings, set, reset } = useSettings();
 
   return (
     <div className="flex-1 overflow-y-auto pb-6 pt-1">
@@ -135,7 +135,7 @@ export function SettingsAppearance() {
         </Row>
         <Row
           label="Font size"
-          hint="Scales the entire interface. Default is 13.5 px."
+          hint="Scales the entire interface. Default is 13 px."
         >
           <input
             className={CD_INPUT + " font-mono"}
@@ -158,7 +158,7 @@ export function SettingsAppearance() {
               {FONT_SIZE_MIN}
             </span>
             <span className="absolute top-0 left-1/2 -translate-x-1/2 whitespace-nowrap text-[9.5px] text-fg-3">
-              13.5
+              13
             </span>
             <span className="absolute top-0 right-0 translate-x-1/2 whitespace-nowrap text-[9.5px] text-fg-3">
               {FONT_SIZE_MAX}
@@ -183,6 +183,18 @@ export function SettingsAppearance() {
         </Row>
         <Row label="Native window controls">
           <Toggle on={false} ariaLabel="Native window controls" />
+        </Row>
+      </Section>
+
+      <Section title="Reset">
+        <Row label="Appearance" hint="Restore theme, accent, density, fonts and size to defaults.">
+          <button
+            type="button"
+            onClick={reset}
+            className="rounded-[4px] border border-border-strong bg-bg-2 px-2 py-1 text-fg-1 transition-colors hover:bg-bg-3 hover:text-fg-0"
+          >
+            Reset to defaults
+          </button>
         </Row>
       </Section>
     </div>

--- a/apps/desktop/src/lib/settings.test.ts
+++ b/apps/desktop/src/lib/settings.test.ts
@@ -39,16 +39,16 @@ describe("applySettingsSideEffects", () => {
     vi.restoreAllMocks();
   });
 
-  it("maps the default 13px font setting to a 1.0 startup scale", () => {
+  it("maps the default 13.5px font setting to a comfortable startup zoom", () => {
     applySettingsSideEffects(DEFAULTS);
 
     expect(document.documentElement.style.getPropertyValue("--ui-scale")).toBe(
-      "1",
+      "1.125",
     );
-    expect(document.body.style.width).toBe("100vw");
-    expect(document.body.style.height).toBe("100vh");
+    expect(document.body.style.width).toBe("88.88888888888889vw");
+    expect(document.body.style.height).toBe("88.88888888888889vh");
     expect((document.body.style as CSSStyleDeclaration & { zoom?: string }).zoom).toBe(
-      "1",
+      "1.125",
     );
   });
 

--- a/apps/desktop/src/lib/settings.test.ts
+++ b/apps/desktop/src/lib/settings.test.ts
@@ -39,17 +39,30 @@ describe("applySettingsSideEffects", () => {
     vi.restoreAllMocks();
   });
 
-  it("maps the default 13px font setting to a visible startup scale", () => {
+  it("maps the default 13px font setting to a 1.0 startup scale", () => {
     applySettingsSideEffects(DEFAULTS);
 
     expect(document.documentElement.style.getPropertyValue("--ui-scale")).toBe(
-      "1.0833333333333333",
+      "1",
     );
-    expect(document.body.style.width).toBe("92.30769230769232vw");
-    expect(document.body.style.height).toBe("92.30769230769232vh");
+    expect(document.body.style.width).toBe("100vw");
+    expect(document.body.style.height).toBe("100vh");
     expect((document.body.style as CSSStyleDeclaration & { zoom?: string }).zoom).toBe(
-      "1.0833333333333333",
+      "1",
     );
+  });
+
+  it("picks a legible --accent-fg by contrast, not brightness", () => {
+    const fg = (accent: string) => {
+      applySettingsSideEffects({ ...DEFAULTS, accent });
+      return document.documentElement.style.getPropertyValue("--accent-fg");
+    };
+    // Mid neutral gray: dark text (~6:1) beats white (~3.5:1).
+    expect(fg("#8a8a8a")).toBe("#0a0b0e");
+    // Very dark accent needs white text.
+    expect(fg("#000000")).toBe("#ffffff");
+    // Light accent keeps dark text.
+    expect(fg("#fbbf24")).toBe("#0a0b0e");
   });
 });
 

--- a/apps/desktop/src/lib/settings.test.ts
+++ b/apps/desktop/src/lib/settings.test.ts
@@ -64,6 +64,17 @@ describe("applySettingsSideEffects", () => {
     // Light accent keeps dark text.
     expect(fg("#fbbf24")).toBe("#0a0b0e");
   });
+
+  it("nudges an invisible accent into a visible range", () => {
+    const accentVar = (accent: string) => {
+      applySettingsSideEffects({ ...DEFAULTS, accent });
+      return document.documentElement.style.getPropertyValue("--accent");
+    };
+    // Black has no contrast against the dark theme bg → brightened to a gray.
+    expect(accentVar("#000000")).not.toBe("#000000");
+    // A vivid accent already clears the threshold → left untouched.
+    expect(accentVar("#a78bfa")).toBe("#a78bfa");
+  });
 });
 
 function fakeElement() {

--- a/apps/desktop/src/lib/settings.test.ts
+++ b/apps/desktop/src/lib/settings.test.ts
@@ -39,16 +39,16 @@ describe("applySettingsSideEffects", () => {
     vi.restoreAllMocks();
   });
 
-  it("maps the default 13.5px font setting to a visible startup scale", () => {
+  it("maps the default 13px font setting to a visible startup scale", () => {
     applySettingsSideEffects(DEFAULTS);
 
     expect(document.documentElement.style.getPropertyValue("--ui-scale")).toBe(
-      "1.125",
+      "1.0833333333333333",
     );
-    expect(document.body.style.width).toBe("88.88888888888889vw");
-    expect(document.body.style.height).toBe("88.88888888888889vh");
+    expect(document.body.style.width).toBe("92.30769230769232vw");
+    expect(document.body.style.height).toBe("92.30769230769232vh");
     expect((document.body.style as CSSStyleDeclaration & { zoom?: string }).zoom).toBe(
-      "1.125",
+      "1.0833333333333333",
     );
   });
 });

--- a/apps/desktop/src/lib/settings.tsx
+++ b/apps/desktop/src/lib/settings.tsx
@@ -27,6 +27,7 @@ export const ACCENT_SWATCHES = [
   "#c9a86a",
   "#a8475c",
   "#ffd60a",
+  "#8a8a8a",
 ] as const;
 
 export type EditorSettings = {
@@ -56,8 +57,8 @@ export const DEFAULTS: Settings = {
   theme: "dark",
   density: "compact",
   accent: "#a78bfa",
-  fontSizePx: 13.5,
-  interfaceFont: "Geist",
+  fontSizePx: 13,
+  interfaceFont: "SF Pro Text",
   monoFont: "JetBrains Mono",
   editor: {
     tabSize: 4,
@@ -151,6 +152,7 @@ export function applySettingsSideEffects(s: Settings) {
     "--accent-line",
     hexToRgba(s.accent, resolvedTheme === "light" ? 0.28 : 0.32),
   );
+  html.style.setProperty("--accent-fg", readableOn(s.accent));
 
   const scale = clamp(s.fontSizePx, FONT_SIZE_MIN, FONT_SIZE_MAX) / FONT_SIZE_BASELINE;
   // Compensate body's layout box for zoom so the App, which fills body, still
@@ -173,6 +175,21 @@ function hexToRgba(hex: string, alpha: number) {
   const g = parseInt(m[2], 16);
   const b = parseInt(m[3], 16);
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+// Text/icon color to sit on top of the accent (e.g. the primary button fill).
+// Picks black or white by the accent's perceived brightness so a dark accent
+// (like black) doesn't render black-on-black. ponytail: simple luma threshold,
+// not full WCAG — good enough for a single fg pick.
+function readableOn(hex: string): string {
+  const m = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  if (!m || !m[1] || !m[2] || !m[3]) return "#ffffff";
+  const luma =
+    (0.299 * parseInt(m[1], 16) +
+      0.587 * parseInt(m[2], 16) +
+      0.114 * parseInt(m[3], 16)) /
+    255;
+  return luma > 0.6 ? "#0a0b0e" : "#ffffff";
 }
 
 type Ctx = {

--- a/apps/desktop/src/lib/settings.tsx
+++ b/apps/desktop/src/lib/settings.tsx
@@ -73,9 +73,10 @@ export const DEFAULTS: Settings = {
 };
 
 const STORAGE_KEY = "cellar.settings.v1";
-// Most compact UI labels are authored around 10-12px. Treat the user's setting
-// as the target readable size, so the default 13.5px setting is not a no-op.
-const FONT_SIZE_BASELINE = 12;
+// The type scale (tokens.css) is authored at real readable px with a 13px base,
+// so the default setting maps to a 1.0 scale (no zoom) and larger/smaller values
+// scale the whole interface from there.
+const FONT_SIZE_BASELINE = 13;
 export const FONT_SIZE_MIN = 10;
 export const FONT_SIZE_MAX = 22;
 
@@ -178,18 +179,22 @@ function hexToRgba(hex: string, alpha: number) {
 }
 
 // Text/icon color to sit on top of the accent (e.g. the primary button fill).
-// Picks black or white by the accent's perceived brightness so a dark accent
-// (like black) doesn't render black-on-black. ponytail: simple luma threshold,
-// not full WCAG — good enough for a single fg pick.
+// Picks dark or white by whichever has the higher WCAG contrast ratio against
+// the accent, so dark accents (black) and mid neutrals (#8a8a8a) both stay
+// legible — a fixed brightness cutoff mis-picks white on mid grays.
 function readableOn(hex: string): string {
   const m = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
   if (!m || !m[1] || !m[2] || !m[3]) return "#ffffff";
-  const luma =
-    (0.299 * parseInt(m[1], 16) +
-      0.587 * parseInt(m[2], 16) +
-      0.114 * parseInt(m[3], 16)) /
-    255;
-  return luma > 0.6 ? "#0a0b0e" : "#ffffff";
+  const toLinear = (c: string) => {
+    const v = parseInt(c, 16) / 255;
+    return v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4;
+  };
+  const lum =
+    0.2126 * toLinear(m[1]) + 0.7152 * toLinear(m[2]) + 0.0722 * toLinear(m[3]);
+  // Contrast vs black (L≈0) and white (L≈1); dark text wins on light accents.
+  const darkContrast = (lum + 0.05) / 0.05;
+  const lightContrast = 1.05 / (lum + 0.05);
+  return darkContrast >= lightContrast ? "#0a0b0e" : "#ffffff";
 }
 
 type Ctx = {

--- a/apps/desktop/src/lib/settings.tsx
+++ b/apps/desktop/src/lib/settings.tsx
@@ -144,16 +144,22 @@ export function applySettingsSideEffects(s: Settings) {
     `"${s.monoFont}", "Geist Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace`,
   );
 
-  html.style.setProperty("--accent", s.accent);
+  // Use an accent that's guaranteed visible against the theme background, so a
+  // dark/neutral pick doesn't render accent-colored UI (tabs, selection, icons)
+  // invisible. The raw value stays in settings (and drives the swatch picker).
+  const accent = visibleAccent(s.accent, resolvedTheme !== "light");
+  html.style.setProperty("--accent", accent);
   html.style.setProperty(
     "--accent-soft",
-    hexToRgba(s.accent, resolvedTheme === "light" ? 0.1 : 0.14),
+    hexToRgba(accent, resolvedTheme === "light" ? 0.1 : 0.14),
   );
   html.style.setProperty(
     "--accent-line",
-    hexToRgba(s.accent, resolvedTheme === "light" ? 0.28 : 0.32),
+    hexToRgba(accent, resolvedTheme === "light" ? 0.28 : 0.32),
   );
-  html.style.setProperty("--accent-fg", readableOn(s.accent));
+  html.style.setProperty("--accent-fg", readableOn(accent));
+  // Editor ghost/inline-suggestion text tracks the accent too.
+  html.style.setProperty("--syn-ghost", hexToRgba(accent, 0.55));
 
   const scale = clamp(s.fontSizePx, FONT_SIZE_MIN, FONT_SIZE_MAX) / FONT_SIZE_BASELINE;
   // Compensate body's layout box for zoom so the App, which fills body, still
@@ -169,13 +175,34 @@ function clamp(n: number, min: number, max: number) {
   return Math.min(Math.max(n, min), max);
 }
 
-function hexToRgba(hex: string, alpha: number) {
+function parseHex(hex: string): [number, number, number] | null {
   const m = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-  if (!m || !m[1] || !m[2] || !m[3]) return hex;
-  const r = parseInt(m[1], 16);
-  const g = parseInt(m[2], 16);
-  const b = parseInt(m[3], 16);
-  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  if (!m || !m[1] || !m[2] || !m[3]) return null;
+  return [parseInt(m[1], 16), parseInt(m[2], 16), parseInt(m[3], 16)];
+}
+
+function hexToRgba(hex: string, alpha: number) {
+  const rgb = parseHex(hex);
+  if (!rgb) return hex;
+  return `rgba(${rgb[0]}, ${rgb[1]}, ${rgb[2]}, ${alpha})`;
+}
+
+function toHex([r, g, b]: [number, number, number]): string {
+  const byte = (n: number) => clamp(Math.round(n), 0, 255).toString(16).padStart(2, "0");
+  return `#${byte(r)}${byte(g)}${byte(b)}`;
+}
+
+// WCAG relative luminance (0 = black, 1 = white) for an sRGB 0-255 triple.
+function relLuminance([r, g, b]: [number, number, number]): number {
+  const lin = (c: number) => {
+    const v = c / 255;
+    return v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+
+function contrastRatio(l1: number, l2: number): number {
+  return (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
 }
 
 // Text/icon color to sit on top of the accent (e.g. the primary button fill).
@@ -183,18 +210,30 @@ function hexToRgba(hex: string, alpha: number) {
 // the accent, so dark accents (black) and mid neutrals (#8a8a8a) both stay
 // legible — a fixed brightness cutoff mis-picks white on mid grays.
 function readableOn(hex: string): string {
-  const m = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-  if (!m || !m[1] || !m[2] || !m[3]) return "#ffffff";
-  const toLinear = (c: string) => {
-    const v = parseInt(c, 16) / 255;
-    return v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4;
-  };
-  const lum =
-    0.2126 * toLinear(m[1]) + 0.7152 * toLinear(m[2]) + 0.0722 * toLinear(m[3]);
-  // Contrast vs black (L≈0) and white (L≈1); dark text wins on light accents.
-  const darkContrast = (lum + 0.05) / 0.05;
-  const lightContrast = 1.05 / (lum + 0.05);
-  return darkContrast >= lightContrast ? "#0a0b0e" : "#ffffff";
+  const rgb = parseHex(hex);
+  if (!rgb) return "#ffffff";
+  const lum = relLuminance(rgb);
+  return contrastRatio(lum, 0) >= contrastRatio(lum, 1) ? "#0a0b0e" : "#ffffff";
+}
+
+// The accent is used directly as a foreground/border/indicator color in dozens
+// of places, so an accent too close to the theme background (e.g. black on the
+// dark theme) renders those elements invisible. Nudge such accents toward the
+// opposite end until they clear a minimum contrast against bg-0, keeping the
+// user's hue while guaranteeing it shows up. Vivid accents are left untouched.
+function visibleAccent(hex: string, dark: boolean): string {
+  let rgb = parseHex(hex);
+  if (!rgb) return hex;
+  const bgLum = dark ? 0.006 : 0.92; // ≈ luminance of --bg-0 per theme
+  const target = dark ? 255 : 0; // blend toward white on dark, black on light
+  for (let i = 0; i < 12 && contrastRatio(relLuminance(rgb), bgLum) < 2.2; i++) {
+    rgb = [
+      rgb[0] + (target - rgb[0]) * 0.12,
+      rgb[1] + (target - rgb[1]) * 0.12,
+      rgb[2] + (target - rgb[2]) * 0.12,
+    ];
+  }
+  return toHex(rgb);
 }
 
 type Ctx = {

--- a/apps/desktop/src/lib/settings.tsx
+++ b/apps/desktop/src/lib/settings.tsx
@@ -57,7 +57,7 @@ export const DEFAULTS: Settings = {
   theme: "dark",
   density: "compact",
   accent: "#a78bfa",
-  fontSizePx: 13,
+  fontSizePx: 13.5,
   interfaceFont: "SF Pro Text",
   monoFont: "JetBrains Mono",
   editor: {
@@ -73,10 +73,10 @@ export const DEFAULTS: Settings = {
 };
 
 const STORAGE_KEY = "cellar.settings.v1";
-// The type scale (tokens.css) is authored at real readable px with a 13px base,
-// so the default setting maps to a 1.0 scale (no zoom) and larger/smaller values
-// scale the whole interface from there.
-const FONT_SIZE_BASELINE = 13;
+// The interface is authored compact and zoomed up for comfort: the font-size
+// setting divided by this baseline gives the global UI scale, so the default
+// 13.5px setting renders at ~1.125× rather than being a no-op.
+const FONT_SIZE_BASELINE = 12;
 export const FONT_SIZE_MIN = 10;
 export const FONT_SIZE_MAX = 22;
 

--- a/apps/desktop/src/lib/settings.tsx
+++ b/apps/desktop/src/lib/settings.tsx
@@ -85,6 +85,9 @@ function load(): Settings {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return DEFAULTS;
     const parsed = JSON.parse(raw) as Partial<Settings>;
+    // Migrate the pre-SF-Pro default interface font so existing installs pick up
+    // the new neutral default instead of being stuck on the old "Geist" default.
+    if (parsed.interfaceFont === "Geist") parsed.interfaceFont = DEFAULTS.interfaceFont;
     // Deep-merge nested sub-objects so new fields added to DEFAULTS are
     // forward-compatible with older persisted values that lack them.
     return sanitize({
@@ -135,9 +138,12 @@ export function applySettingsSideEffects(s: Settings) {
 
   // User-selected fonts override the leading family; the rest of the stack in
   // tokens.css remains as graceful fallback for anything not installed.
+  // -apple-system / SF Pro come right after the chosen family so that if it
+  // isn't installed we fall back to the system font (SF on macOS) rather than
+  // to Inter.
   html.style.setProperty(
     "--font-sans",
-    `"${s.interfaceFont}", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif`,
+    `"${s.interfaceFont}", -apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro Display", "Inter", "Segoe UI", system-ui, sans-serif`,
   );
   html.style.setProperty(
     "--font-mono",

--- a/apps/desktop/src/lib/settings.tsx
+++ b/apps/desktop/src/lib/settings.tsx
@@ -85,9 +85,6 @@ function load(): Settings {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return DEFAULTS;
     const parsed = JSON.parse(raw) as Partial<Settings>;
-    // Migrate the pre-SF-Pro default interface font so existing installs pick up
-    // the new neutral default instead of being stuck on the old "Geist" default.
-    if (parsed.interfaceFont === "Geist") parsed.interfaceFont = DEFAULTS.interfaceFont;
     // Deep-merge nested sub-objects so new fields added to DEFAULTS are
     // forward-compatible with older persisted values that lack them.
     return sanitize({
@@ -138,12 +135,11 @@ export function applySettingsSideEffects(s: Settings) {
 
   // User-selected fonts override the leading family; the rest of the stack in
   // tokens.css remains as graceful fallback for anything not installed.
-  // -apple-system / SF Pro come right after the chosen family so that if it
-  // isn't installed we fall back to the system font (SF on macOS) rather than
-  // to Inter.
+  // The user-selected family leads; the rest is a graceful fallback only used
+  // when that font isn't installed.
   html.style.setProperty(
     "--font-sans",
-    `"${s.interfaceFont}", -apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro Display", "Inter", "Segoe UI", system-ui, sans-serif`,
+    `"${s.interfaceFont}", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif`,
   );
   html.style.setProperty(
     "--font-mono",

--- a/apps/desktop/src/styles/base.css
+++ b/apps/desktop/src/styles/base.css
@@ -9,7 +9,7 @@
     margin: 0;
     padding: 0;
     font-family: var(--font-sans);
-    font-size: var(--fs-md);
+    font-size: var(--fs-sm);
     color: var(--fg-0);
     background: var(--bg-0);
     -webkit-font-smoothing: antialiased;

--- a/apps/desktop/src/styles/grid.css
+++ b/apps/desktop/src/styles/grid.css
@@ -9,7 +9,9 @@
      `min-width: 0` a flex item's min-width defaults to its intrinsic content
      width (~1850px here), so `.grid-scroll` never sees overflow to scroll. */
   min-width: 0;
-  font-size: var(--fs-md);
+  /* Match the 13px base used by the body / sidebar so grid data and the rest of
+     the UI read at the same size. */
+  font-size: var(--fs-sm);
   background: var(--bg-inset);
 }
 

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -20,6 +20,7 @@
   --color-bg-4: var(--bg-4);
   --color-bg-inset: var(--bg-inset);
   --color-bg-overlay: var(--bg-overlay);
+  --color-bg-selected: var(--bg-selected);
 
   /* Borders */
   --color-border-subtle: var(--border-subtle);
@@ -28,6 +29,7 @@
   --color-border-divider: var(--border-divider);
 
   /* Text */
+  --color-fg-strong: var(--fg-strong);
   --color-fg-0: var(--fg-0);
   --color-fg-1: var(--fg-1);
   --color-fg-2: var(--fg-2);
@@ -83,6 +85,7 @@
   --text-md: var(--fs-md);
   --text-lg: var(--fs-lg);
   --text-xl: var(--fs-xl);
+  --text-2xl: var(--fs-2xl);
 
   /* Shadows */
   --shadow-sm: var(--shadow-sm);

--- a/apps/desktop/src/styles/tokens.css
+++ b/apps/desktop/src/styles/tokens.css
@@ -19,7 +19,7 @@
   /* Borders — default is pure white at 4% per design */
   --border-subtle: rgba(255, 255, 255, 0.03);
   --border-default: rgba(255, 255, 255, 0.04);
-  --border-strong: rgba(255, 255, 255, 0.09);
+  --border-strong: rgba(255, 255, 255, 0.13);
   --border-divider: rgba(255, 255, 255, 0.05);
   /* Vertical separator between grid columns: stronger than the row divider so
      columns read as distinct. */
@@ -66,7 +66,7 @@
   --syn-fn: #60a5fa;
   --syn-str: #86efac;
   --syn-num: #fbbf24;
-  --syn-ident: #ecedef;
+  --syn-ident: #eeeeee;
   --syn-comment: #5e6068;
   --syn-op: #c2c4c9;
   --syn-tbl: #f59e9e;

--- a/apps/desktop/src/styles/tokens.css
+++ b/apps/desktop/src/styles/tokens.css
@@ -93,8 +93,8 @@
   --radius-lg: 8px;
 
   /* Type */
-  --font-sans: "SF Pro Text", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", system-ui, sans-serif;
-  --font-mono: "JetBrains Mono", "Geist Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  --font-sans: "SF Pro Text", "SF Pro Display", -apple-system, "BlinkMacSystemFont", "Inter", "Segoe UI", system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", "Geist Mono", ui-monospace, "SF Mono", "Menlo", "Consolas", monospace;
   /* Size scale: 12, 13 (base), 14, 16, 18, 24. Base lives on --fs-sm, which the
      body uses (see base.css). */
   --fs-xs: 12px;

--- a/apps/desktop/src/styles/tokens.css
+++ b/apps/desktop/src/styles/tokens.css
@@ -5,30 +5,34 @@
   /* Render native controls (date/time pickers, spinners) in dark mode so they
      stay legible against the dark surfaces instead of defaulting to light. */
   color-scheme: dark;
-  /* Surfaces — warm dark neutrals */
-  --bg-0: #0c0d10;
-  --bg-1: #111317;
-  --bg-2: #161920;
-  --bg-3: #1c1f27;
-  --bg-4: #232631;
-  --bg-inset: #0a0b0e;
-  --bg-overlay: rgba(8, 9, 11, 0.72);
+  /* Surfaces — neutral dark grays (no hue tint, so the accent is the only color) */
+  --bg-0: #0e0e0e;
+  --bg-1: #161616;
+  --bg-2: #1a1a1a;
+  --bg-3: #1f1f1f;
+  --bg-4: #262626;
+  --bg-inset: #0a0a0a;
+  --bg-overlay: rgba(8, 8, 8, 0.72);
+  /* Selected row / list item background */
+  --bg-selected: #212121;
 
-  /* Borders */
-  --border-subtle: rgba(255, 255, 255, 0.045);
-  --border-default: rgba(255, 255, 255, 0.075);
-  --border-strong: rgba(255, 255, 255, 0.12);
-  --border-divider: rgba(255, 255, 255, 0.06);
+  /* Borders — default is pure white at 4% per design */
+  --border-subtle: rgba(255, 255, 255, 0.03);
+  --border-default: rgba(255, 255, 255, 0.04);
+  --border-strong: rgba(255, 255, 255, 0.09);
+  --border-divider: rgba(255, 255, 255, 0.05);
   /* Vertical separator between grid columns: stronger than the row divider so
      columns read as distinct. */
-  --grid-column-line: rgba(255, 255, 255, 0.11);
+  --grid-column-line: rgba(255, 255, 255, 0.08);
 
-  /* Text */
-  --fg-0: #ecedef;
-  --fg-1: #c2c4c9;
-  --fg-2: #8d8f96;
-  --fg-3: #5e6068;
-  --fg-4: #3f4147;
+  /* Text — neutral ramp anchored on the design's three named values:
+     strong #FFF, default #EEE, subtle #B5B5B5. */
+  --fg-strong: #ffffff;
+  --fg-0: #eeeeee;
+  --fg-1: #cccccc;
+  --fg-2: #b5b5b5;
+  --fg-3: #6a6a6a;
+  --fg-4: #484848;
 
   /* Accent — violet (default per design) */
   --accent: #a78bfa;
@@ -89,36 +93,41 @@
   --radius-lg: 8px;
 
   /* Type */
-  --font-sans: "Geist", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  --font-sans: "SF Pro Text", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", system-ui, sans-serif;
   --font-mono: "JetBrains Mono", "Geist Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-  --fs-xs: 10.5px;
-  --fs-sm: 11.5px;
-  --fs-md: 13.5px;
-  --fs-lg: 14.5px;
-  --fs-xl: 15px;
+  /* Size scale: 12, 13 (base), 14, 16, 18, 24. Base lives on --fs-sm, which the
+     body uses (see base.css). */
+  --fs-xs: 12px;
+  --fs-sm: 13px;
+  --fs-md: 14px;
+  --fs-lg: 16px;
+  --fs-xl: 18px;
+  --fs-2xl: 24px;
 }
 
 [data-theme="light"] {
   color-scheme: light;
-  --bg-0: #f8f7f4;
+  --bg-0: #f6f6f6;
   --bg-1: #ffffff;
-  --bg-2: #f3f1ec;
-  --bg-3: #ecebe5;
-  --bg-4: #e3e1d9;
-  --bg-inset: #faf9f5;
-  --bg-overlay: rgba(248, 247, 244, 0.78);
+  --bg-2: #f0f0f0;
+  --bg-3: #e8e8e8;
+  --bg-4: #dedede;
+  --bg-inset: #fafafa;
+  --bg-overlay: rgba(246, 246, 246, 0.78);
+  --bg-selected: #e2e2e2;
 
-  --border-subtle: rgba(0, 0, 0, 0.05);
-  --border-default: rgba(0, 0, 0, 0.09);
+  --border-subtle: rgba(0, 0, 0, 0.04);
+  --border-default: rgba(0, 0, 0, 0.08);
   --border-strong: rgba(0, 0, 0, 0.16);
-  --border-divider: rgba(0, 0, 0, 0.07);
-  --grid-column-line: rgba(0, 0, 0, 0.13);
+  --border-divider: rgba(0, 0, 0, 0.06);
+  --grid-column-line: rgba(0, 0, 0, 0.12);
 
-  --fg-0: #15171b;
-  --fg-1: #43464d;
-  --fg-2: #6b6e76;
-  --fg-3: #9a9da4;
-  --fg-4: #c4c6cb;
+  --fg-strong: #000000;
+  --fg-0: #1a1a1a;
+  --fg-1: #444444;
+  --fg-2: #6e6e6e;
+  --fg-3: #9a9a9a;
+  --fg-4: #c4c4c4;
 
   --accent: #7c3aed;
   --accent-soft: rgba(124, 58, 237, 0.10);
@@ -139,12 +148,8 @@
 [data-density="compact"] {
   --row-h: 22px;
   --tab-h: 30px;
-  --fs-sm: 11.5px;
-  --fs-md: 13.5px;
 }
 [data-density="comfortable"] {
   --row-h: 28px;
   --tab-h: 34px;
-  --fs-sm: 12.5px;
-  --fs-md: 13.5px;
 }

--- a/packages/data-grid/src/icons.tsx
+++ b/packages/data-grid/src/icons.tsx
@@ -15,7 +15,7 @@ type IconProps = SVGProps<SVGSVGElement> & {
 const I = ({
   d,
   size = 14,
-  sw = 1.5,
+  sw = 1,
   fill = "none",
   stroke = "currentColor",
   children,


### PR DESCRIPTION
## Summary
Makes Cellar's out-of-box appearance generic — neutral grays so the user's **accent is the only color** — with a consistent type scale and SF Pro default. Accent and fonts remain fully customizable in Settings → Appearance. Includes follow-up fixes so any accent (including dark/neutral) stays legible everywhere.

## What changed
**Palette & tokens**
- Neutral dark/light surfaces and a text ramp anchored on the design's named values: `strong #FFF`, `default #EEE`, `subtle #B5B5B5`. Added `bg-selected` and a `4%` white default border; strengthened the hover/focus border tier. Bridged new tokens to Tailwind v4 (`fg-strong`, `bg-selected`, `text-2xl`).
- Neutralized the syntax identifier tint; editor ghost text now follows the accent.

**Type & font**
- Fixed size scale **12 / 13(base) / 14 / 16 / 18 / 24**; body, grid data, and sidebar tree all sit on the 13px base for consistency.
- Default interface font is **SF Pro Text** for fresh installs; existing saved fonts are respected (no forced migration). 1px icon stroke (desktop + data-grid).

**Accent robustness**
- `visibleAccent()` nudges an accent that lacks contrast against the background until it's visible, keeping the user's hue — so tabs, row selection, the row-number gutter, icons, and buttons stay legible for any accent. Vivid accents untouched.
- `readableOn()` picks button-text color by WCAG contrast ratio. Connection dot uses semantic green; active-tab indicator uses the accent; empty-state CTA is a solid accent fill; brand logos pinned to fixed violet.
- Bottom-panel active tab uses a solid surface (visible regardless of accent).

**Other**
- AI assistant SQL code blocks now syntax-highlight (reusing the existing `sqlTokens` helper) instead of flat text.
- Surfaced the existing **Reset to defaults** action in Appearance; added a neutral gray accent swatch.

## User impact
Fresh installs get a clean neutral theme on a consistent scale; existing users keep their saved accent/font. Any accent choice stays legible across the UI.

## Validation
- `pnpm typecheck` — passes.
- `pnpm vitest run` — 258 passing; settings tests cover the default scale, accent-fg contrast picks, and the visibility nudge.

## Known warnings / follow-ups
- One **pre-existing, unrelated** failure: `packages/ipc/src/index.test.ts` (command-surface snapshot, 31 vs 30). Present on the branch base with these changes stashed; not touched by this PR.
- **No fonts are bundled** (no `@font-face`/font files) — the font dropdown only renders system-installed families, so non-system fonts (e.g. Geist) fall back. Bundling Geist or trimming the dropdown to available fonts is a follow-up.
- No full normalization of every hardcoded off-scale px size (sidebar/grid still have some 9.5/10.5px values); a scale sweep is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)