### PR TITLE
fix(grid): make data rows track the density font-size token

### DIFF
--- a/apps/desktop/src/styles/grid.css
+++ b/apps/desktop/src/styles/grid.css
@@ -248,7 +248,7 @@
   display: flex;
   flex-direction: column;
   font-family: var(--font-mono);
-  font-size: 11.5px;
+  font-size: var(--fs-sm);
   line-height: 1;
 }
 .grid-virtual-body {


### PR DESCRIPTION
## Summary
The data grid rows looked smaller than the toolbar/quick-filter text. They were styled by two decoupled rules.

## What changed
`.grid-table` hardcoded `font-size: 11.5px`; the toolbar and quick filter use `var(--fs-sm)`. In `comfortable` density `--fs-sm` is `12.5px`, so the toolbar grew while rows stayed pinned at 11.5px. Swapped the table to use `var(--fs-sm)` so rows track the same density token as everything else.

## User impact
Toolbar text and data rows now render at the same size in every density.

## Validation
None run — single CSS token swap to a variable already defined in `tokens.css` and used throughout `grid.css`.

## Known warnings / follow-ups
None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated table text sizing to use the app’s standard small font variable, improving consistency across the desktop UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->