### PR TITLE
docs: add 0.3.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+## 0.3.1
+
+### Features
+
+- **New default theme** — neutral default palette, SF Pro interface font, and
+  1px icons, with the saved interface/editor font now respected throughout.
+- **Font pickers in Settings** — dropdowns to choose the interface and editor
+  fonts.
+- **Reliable table row counts** — total row count shown without blocking the
+  table load.
+- **Cleaner sidebar** — the dashed "New connection" button only appears when
+  there are no connections.
+- **Wired-up About screen** — footer links and attribution now work.
+- **Marketing site redesign** — cinematic hero, fixed social link previews, and
+  improved SEO.
+
+### Bug fixes
+
+- **Quick filter** — clears immediately instead of waiting on the debounce, and
+  stays smooth on large tables (fixed a notices leak).
+- **Table caching** — `include_total` is now part of the browse cache key, so
+  row-count results aren't served stale.
+- **Settings** — live version number, separator dot hidden until the version
+  loads, and a clearer General-tab placeholder.
+- **Import** — vertically centered the mode selection dots.
+- **Theme polish** — accent color stays visible everywhere, grid/data rows track
+  the density font-size token, and the active bottom-panel tab is visible.
+
+### Internal
+
+- Release workflow stamps the release version into `tauri.conf.json` at build
+  time from the pushed tag.


### PR DESCRIPTION
Adds `CHANGELOG.md` documenting the 0.3.1 release (features + bug fixes since 0.3.0).

The `0.3.1` tag has already been pushed off `origin/main` to trigger the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a default theme and new font pickers.
  * Improved the About screen and refreshed the marketing pages.
  * Updated table row counts and sidebar behavior for a smoother experience.

* **Bug Fixes**
  * Improved quick filter responsiveness.
  * Fixed table caching so results stay accurate.
  * Polished settings loading, import layout alignment, and theme visuals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->