### PR TITLE
fix(theme): make resizable pane separators visible on the dark theme

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -95,7 +95,7 @@ function ResizeHandle({
     >
       <div
         className={
-          "absolute bg-border-default transition-colors duration-100 group-hover:bg-accent-line group-active:bg-accent " +
+          "absolute bg-border-separator transition-colors duration-100 group-hover:bg-accent-line group-active:bg-accent " +
           (vertical
             ? "inset-y-0 left-1/2 w-px -translate-x-1/2"
             : "inset-x-0 top-1/2 h-px -translate-y-1/2")

--- a/apps/desktop/src/components/Workspace.tsx
+++ b/apps/desktop/src/components/Workspace.tsx
@@ -107,7 +107,7 @@ export function Workspace({ onCommit }: { onCommit?: () => void } = {}) {
         >
           <div
             className={
-              "absolute bg-border-default transition-colors duration-100 group-hover:bg-accent-line group-active:bg-accent " +
+              "absolute bg-border-separator transition-colors duration-100 group-hover:bg-accent-line group-active:bg-accent " +
               (split === "vertical"
                 ? "inset-y-0 left-1/2 w-px -translate-x-1/2"
                 : "inset-x-0 top-1/2 h-px -translate-y-1/2")

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -27,6 +27,7 @@
   --color-border-default: var(--border-default);
   --color-border-strong: var(--border-strong);
   --color-border-divider: var(--border-divider);
+  --color-border-separator: var(--border-separator);
 
   /* Text */
   --color-fg-strong: var(--fg-strong);

--- a/apps/desktop/src/styles/tokens.css
+++ b/apps/desktop/src/styles/tokens.css
@@ -21,6 +21,9 @@
   --border-default: rgba(255, 255, 255, 0.04);
   --border-strong: rgba(255, 255, 255, 0.13);
   --border-divider: rgba(255, 255, 255, 0.05);
+  /* Resizable pane separators: a dark seam (darker than the surfaces) rather
+     than a light hairline, so the divider reads clearly on the dark theme. */
+  --border-separator: rgba(0, 0, 0, 0.32);
   /* Vertical separator between grid columns: stronger than the row divider so
      columns read as distinct. */
   --grid-column-line: rgba(255, 255, 255, 0.08);
@@ -120,6 +123,7 @@
   --border-default: rgba(0, 0, 0, 0.08);
   --border-strong: rgba(0, 0, 0, 0.16);
   --border-divider: rgba(0, 0, 0, 0.06);
+  --border-separator: rgba(0, 0, 0, 0.16);
   --grid-column-line: rgba(0, 0, 0, 0.12);
 
   --fg-strong: #000000;


### PR DESCRIPTION
The resize handles between panes used a near-invisible white hairline (`border-default`, 4% white) that was effectively undetectable on the dark theme. This adds a dedicated `--border-separator` token — a dark seam darker than the surrounding surfaces (`rgba(0,0,0,0.32)` on dark, `rgba(0,0,0,0.16)` on light) — and points the left/right/bottom resize handles and the workspace split divider at it. The line stays the original 1px width with the existing accent hover/active states untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated separator and divider lines across the desktop app to use a more distinct border color.
  * Added theme support for a dedicated separator color in both light and dark modes, improving visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->