### PR TITLE
fix(theme): unify sidebar tree label font size and weight

### DIFF
--- a/apps/desktop/src/components/SidebarTree.tsx
+++ b/apps/desktop/src/components/SidebarTree.tsx
@@ -148,7 +148,7 @@ export function ConnectionRow({
           )}
         </button>
         <EngineBadge engine={config.engine as Engine} size={12} color={accent} />
-        <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[13px] font-medium">
+        <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[12px] font-medium">
           {config.name}
         </span>
         {config.env_tag === "prod" && (
@@ -307,7 +307,7 @@ function DatabaseRow({
         </span>
         <span
           className={
-            "flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[13px] " +
+            "flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[12px] font-medium " +
             (visibleEmpty ? "text-fg-3" : "")
           }
         >
@@ -401,7 +401,7 @@ function SchemaRow({
         </span>
         <span
           className={
-            "flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[13px] " +
+            "flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[12px] font-medium " +
             (hidden ? "text-fg-3" : "")
           }
         >
@@ -459,7 +459,7 @@ function SchemaRow({
                   <span className={ICON_SLOT}>
                     <Icon.tree size={11} />
                   </span>
-                  <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[13px]">
+                  <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[12px] font-medium">
                     {v.name}
                   </span>
                 </div>
@@ -515,7 +515,7 @@ function GroupFolder({
         <span className={ICON_SLOT}>
           {open ? <Icon.folderOpen size={12} /> : <Icon.folder size={12} />}
         </span>
-        <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[13px]">
+        <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[12px] font-medium">
           {label}
         </span>
         <span className={META + " font-mono"}>{count}</span>
@@ -566,7 +566,7 @@ function TableRow({
       <span className={ICON_SLOT} style={{ color: "var(--fg-1)" }}>
         <Icon.table size={11} />
       </span>
-      <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[13px]">
+      <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[12px] font-medium">
         {table.name}
       </span>
       {table.row_count != null && (


### PR DESCRIPTION
Every sidebar tree row name now renders at `text-[12px] font-medium` — connection, database, schema, view, group folder, and table — matching the folder row. Previously leaf nodes were 13px and lacked `font-medium`, so names appeared at mismatched sizes and weights down the tree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated sidebar row labels to use a slightly smaller, more consistent text style.
  * Standardized label weight across connection, database, schema, view, group folder, and table rows for a more uniform look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->