### PR TITLE
feat(updater): update toast + in-app release notes

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -3,6 +3,7 @@ import { listen } from "@tauri-apps/api/event";
 import { isTauri, type ConnectionConfig } from "@cellar/ipc";
 import { TitleBar } from "./components/TitleBar";
 import { StatusBar } from "./components/StatusBar";
+import { UpdateToast } from "./components/UpdateToast";
 import { Sidebar } from "./components/Sidebar";
 import { TabBar } from "./components/TabBar";
 import { Workspace } from "./components/Workspace";
@@ -26,6 +27,7 @@ import {
   type ComparePreset,
 } from "./components/modals/SchemaCompareDialog";
 import { useLayout } from "./state/layout";
+import { useUpdater } from "./lib/updater";
 
 type ModalId =
   | "commit"
@@ -121,6 +123,8 @@ export function App() {
   const [comparePreset, setComparePreset] = useState<ComparePreset | null>(null);
   const [settingsInitialCat, setSettingsInitialCat] =
     useState<SettingsCatId>("appearance");
+  const updateStatus = useUpdater((s) => s.status);
+  const [updateToastDismissed, setUpdateToastDismissed] = useState(false);
 
   const openModal = useCallback((m: ModalId) => setModal(m), []);
   const closeModal = useCallback(() => setModal(null), []);
@@ -171,6 +175,13 @@ export function App() {
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  // Check for updates once on startup so the bottom-right toast can surface a
+  // new version without the user opening Settings. No-op outside Tauri.
+  useEffect(() => {
+    if (!isTauri) return;
+    void useUpdater.getState().checkForUpdate();
   }, []);
 
   // The native macOS app menu's "Settings…" item (see src-tauri/src/menu.rs)
@@ -281,6 +292,19 @@ export function App() {
       </div>
 
       <StatusBar />
+
+      {updateStatus.kind === "available" &&
+        !updateToastDismissed &&
+        modal !== "settings" && (
+          <UpdateToast
+            version={updateStatus.version}
+            onUpdate={() => {
+              setUpdateToastDismissed(true);
+              openSettings("updates");
+            }}
+            onDismiss={() => setUpdateToastDismissed(true)}
+          />
+        )}
 
       {connDialog && (
         <ConnectionDialog

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -124,7 +124,9 @@ export function App() {
   const [settingsInitialCat, setSettingsInitialCat] =
     useState<SettingsCatId>("appearance");
   const updateStatus = useUpdater((s) => s.status);
-  const [updateToastDismissed, setUpdateToastDismissed] = useState(false);
+  const [dismissedUpdateVersion, setDismissedUpdateVersion] = useState<
+    string | null
+  >(null);
 
   const openModal = useCallback((m: ModalId) => setModal(m), []);
   const closeModal = useCallback(() => setModal(null), []);
@@ -294,15 +296,15 @@ export function App() {
       <StatusBar />
 
       {updateStatus.kind === "available" &&
-        !updateToastDismissed &&
-        modal !== "settings" && (
+        dismissedUpdateVersion !== updateStatus.version &&
+        modal === null && (
           <UpdateToast
             version={updateStatus.version}
             onUpdate={() => {
-              setUpdateToastDismissed(true);
+              setDismissedUpdateVersion(updateStatus.version);
               openSettings("updates");
             }}
-            onDismiss={() => setUpdateToastDismissed(true)}
+            onDismiss={() => setDismissedUpdateVersion(updateStatus.version)}
           />
         )}
 

--- a/apps/desktop/src/components/UpdateToast.tsx
+++ b/apps/desktop/src/components/UpdateToast.tsx
@@ -1,0 +1,41 @@
+import { Icon } from "./icons";
+
+export function UpdateToast({
+  version,
+  onUpdate,
+  onDismiss,
+}: {
+  version: string;
+  onUpdate: () => void;
+  onDismiss: () => void;
+}) {
+  return (
+    <div className="fixed bottom-4 right-4 z-[90] w-[280px] rounded-[7px] border border-border-default bg-bg-1 p-3 shadow-lg">
+      <div className="mb-2 flex items-start gap-2">
+        <Icon.sparkles size={14} stroke="var(--accent)" />
+        <div className="min-w-0 flex-1">
+          <div className="text-[12px] font-semibold text-fg-0">Update available</div>
+          <div className="text-[11px] text-fg-2">
+            Version {version} is ready to download.
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label="Dismiss update notification"
+          className="icon-btn -mr-1 -mt-0.5"
+        >
+          <Icon.close size={12} />
+        </button>
+      </div>
+      <button
+        type="button"
+        onClick={onUpdate}
+        className="inline-flex h-[26px] w-full items-center justify-center gap-1 rounded-[4px] bg-accent px-2 text-[11px] font-medium text-accent-fg hover:brightness-[1.07]"
+      >
+        <Icon.download size={11} />
+        <span>Update</span>
+      </button>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/UpdateToast.tsx
+++ b/apps/desktop/src/components/UpdateToast.tsx
@@ -10,7 +10,12 @@ export function UpdateToast({
   onDismiss: () => void;
 }) {
   return (
-    <div className="fixed bottom-4 right-4 z-[90] w-[280px] rounded-[7px] border border-border-default bg-bg-1 p-3 shadow-lg">
+    <div
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      className="fixed bottom-4 right-4 z-[90] w-[280px] rounded-[7px] border border-border-default bg-bg-1 p-3 shadow-lg"
+    >
       <div className="mb-2 flex items-start gap-2">
         <Icon.sparkles size={14} stroke="var(--accent)" />
         <div className="min-w-0 flex-1">

--- a/apps/desktop/src/components/modals/settingsSystemPanels.tsx
+++ b/apps/desktop/src/components/modals/settingsSystemPanels.tsx
@@ -3,6 +3,59 @@ import { Row, Section, StaticSegment, Toggle } from "./settingsPrimitives";
 import { useConnections } from "../../state/connections";
 import { useUpdater } from "../../lib/updater";
 import { openExternal } from "../../lib/openExternal";
+import changelogMd from "../../../../../CHANGELOG.md?raw";
+
+// Minimal markdown renderer for release notes / changelog: headings, bullets,
+// and **bold**. GitHub release bodies and our CHANGELOG only use this subset,
+// so a dependency-free pass is enough. ponytail: extend if notes get richer.
+function renderInline(text: string, keyBase: string) {
+  return text.split(/(\*\*[^*]+\*\*)/g).map((part, i) =>
+    part.startsWith("**") && part.endsWith("**") ? (
+      <strong key={`${keyBase}-${i}`} className="font-semibold text-fg-0">
+        {part.slice(2, -2)}
+      </strong>
+    ) : (
+      part
+    ),
+  );
+}
+
+function Changelog({ source }: { source: string }) {
+  const lines = source.replace(/\r\n/g, "\n").split("\n");
+  return (
+    <div className="max-h-[260px] overflow-y-auto rounded-[5px] border border-border-default bg-bg-inset px-3 py-2.5 text-[11.5px] leading-[1.55] text-fg-2">
+      {lines.map((raw, i) => {
+        const line = raw.trimEnd();
+        if (!line.trim()) return <div key={i} className="h-1.5" />;
+        const h = /^(#{1,6})\s+(.*)$/.exec(line);
+        if (h) {
+          const top = h[1]!.length <= 2;
+          return (
+            <div
+              key={i}
+              className={
+                "mt-2 mb-1 font-semibold text-fg-0 " +
+                (top ? "text-[13px]" : "text-[12px]")
+              }
+            >
+              {renderInline(h[2]!, `h${i}`)}
+            </div>
+          );
+        }
+        const bullet = /^[-*]\s+(.*)$/.exec(line);
+        if (bullet) {
+          return (
+            <div key={i} className="flex gap-1.5 pl-1">
+              <span className="text-fg-3">•</span>
+              <span>{renderInline(bullet[1]!, `b${i}`)}</span>
+            </div>
+          );
+        }
+        return <div key={i}>{renderInline(line, `p${i}`)}</div>;
+      })}
+    </div>
+  );
+}
 
 export function SettingsPrivacy() {
   const connectionCount = useConnections((s) => s.connections.length);
@@ -142,6 +195,20 @@ export function SettingsUpdates() {
         <Row label="Auto-install on quit">
           <Toggle on={false} ariaLabel="Auto-install on quit" />
         </Row>
+      </Section>
+      <Section
+        title="What's new"
+        sub={
+          status.kind === "available"
+            ? `Release notes for v${status.version}`
+            : `Recent changes in ${versionLabel}`
+        }
+      >
+        <Changelog
+          source={
+            (status.kind === "available" && status.update.body) || changelogMd
+          }
+        />
       </Section>
     </div>
   );

--- a/apps/desktop/src/lib/updater.ts
+++ b/apps/desktop/src/lib/updater.ts
@@ -49,11 +49,9 @@ export const useUpdater = create<UpdaterState>((set, get) => ({
 
   checkForUpdate: async () => {
     set({ status: { kind: "checking" } });
+    const now = new Date().toISOString();
     try {
       const update = await check();
-      const now = new Date().toISOString();
-      writeLastChecked(now);
-      set({ lastChecked: now });
       if (update?.available) {
         set({ status: { kind: "available", version: update.version, update } });
       } else {
@@ -66,6 +64,10 @@ export const useUpdater = create<UpdaterState>((set, get) => ({
           message: err instanceof Error ? err.message : String(err),
         },
       });
+    } finally {
+      // Record every attempt, so a failed check still refreshes "last checked".
+      writeLastChecked(now);
+      set({ lastChecked: now });
     }
   },
 

--- a/apps/desktop/src/lib/updater.ts
+++ b/apps/desktop/src/lib/updater.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { create } from "zustand";
 import { check, type Update } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { getVersion } from "@tauri-apps/api/app";
@@ -30,42 +30,51 @@ function writeLastChecked(value: string) {
   }
 }
 
-export function useUpdater() {
-  const [appVersion, setAppVersion] = useState<string>("");
-  const [status, setStatus] = useState<UpdaterStatus>({ kind: "idle" });
-  const [lastChecked, setLastChecked] = useState<string | null>(() => readLastChecked());
+interface UpdaterState {
+  appVersion: string;
+  status: UpdaterStatus;
+  lastChecked: string | null;
+  checkForUpdate: () => Promise<void>;
+  downloadAndInstall: () => Promise<void>;
+}
 
-  useEffect(() => {
-    getVersion()
-      .then(setAppVersion)
-      .catch(() => setAppVersion(""));
-  }, []);
+// Shared store rather than per-component state: the startup check (App.tsx),
+// the update toast, and the Settings > Updates panel all read the same status,
+// so clicking "Update" in the toast lands on a panel that already knows an
+// update is available and holds the Update object ready to install.
+export const useUpdater = create<UpdaterState>((set, get) => ({
+  appVersion: "",
+  status: { kind: "idle" },
+  lastChecked: readLastChecked(),
 
-  const checkForUpdate = useCallback(async () => {
-    setStatus({ kind: "checking" });
+  checkForUpdate: async () => {
+    set({ status: { kind: "checking" } });
     try {
       const update = await check();
       const now = new Date().toISOString();
       writeLastChecked(now);
-      setLastChecked(now);
+      set({ lastChecked: now });
       if (update?.available) {
-        setStatus({ kind: "available", version: update.version, update });
+        set({ status: { kind: "available", version: update.version, update } });
       } else {
-        setStatus({ kind: "up-to-date" });
+        set({ status: { kind: "up-to-date" } });
       }
     } catch (err) {
-      setStatus({
-        kind: "error",
-        message: err instanceof Error ? err.message : String(err),
+      set({
+        status: {
+          kind: "error",
+          message: err instanceof Error ? err.message : String(err),
+        },
       });
     }
-  }, []);
+  },
 
-  const downloadAndInstall = useCallback(async () => {
+  downloadAndInstall: async () => {
+    const { status } = get();
     if (status.kind !== "available") return;
     const { update } = status;
     try {
-      setStatus({ kind: "downloading", fraction: 0 });
+      set({ status: { kind: "downloading", fraction: 0 } });
       let total = 0;
       let downloaded = 0;
       await update.downloadAndInstall((event) => {
@@ -76,28 +85,27 @@ export function useUpdater() {
           case "Progress":
             downloaded += event.data.chunkLength;
             if (total > 0) {
-              setStatus({ kind: "downloading", fraction: downloaded / total });
+              set({ status: { kind: "downloading", fraction: downloaded / total } });
             }
             break;
           case "Finished":
-            setStatus({ kind: "installing" });
+            set({ status: { kind: "installing" } });
             break;
         }
       });
       await relaunch();
     } catch (err) {
-      setStatus({
-        kind: "error",
-        message: err instanceof Error ? err.message : String(err),
+      set({
+        status: {
+          kind: "error",
+          message: err instanceof Error ? err.message : String(err),
+        },
       });
     }
-  }, [status]);
+  },
+}));
 
-  return {
-    appVersion,
-    status,
-    lastChecked,
-    checkForUpdate,
-    downloadAndInstall,
-  };
-}
+// Fetch the running version once; harmless no-op outside Tauri (web dev).
+getVersion()
+  .then((v) => useUpdater.setState({ appVersion: v }))
+  .catch(() => {});


### PR DESCRIPTION
Adds a bottom-right "Update available" toast that appears on startup when a new version is found, with an Update button that opens Settings → Updates. The Updates panel gains a "What's new" section that renders the pending version's release notes (falling back to the bundled `CHANGELOG.md`). The updater is lifted from a per-component hook into a shared Zustand store so the startup check, toast, and settings panel share one status and the ready-to-install `Update` object. Release notes render via a small dependency-free markdown pass (headings, bullets, bold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic update checks on desktop startup.
  - Shows a bottom-right update notification when a new version is available.
  - Added a “What’s new” section in Settings with release notes/recent changes display.

- **Bug Fixes**
  - Update notifications now stay hidden after dismissal (per version) and won’t show when a modal is open.
  - Update and dismiss actions behave consistently, taking users to the updates area only when choosing to update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->