### PR TITLE
fix(sidebar): render all tree labels at the configured font size

### DIFF
--- a/apps/desktop/src/components/SidebarConnectionList.tsx
+++ b/apps/desktop/src/components/SidebarConnectionList.tsx
@@ -5,6 +5,7 @@ import { Icon } from "./icons";
 import {
   ICON_SLOT,
   META,
+  NODE_LABEL,
   ROW_BASE,
   TWISTY,
   type ConnectionDragHandles,
@@ -427,7 +428,7 @@ function FolderRow({
           onCancel={onCancelRename}
         />
       ) : (
-        <span className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[12px] font-medium leading-[18px]">
+        <span className={NODE_LABEL}>
           {folder.name}
         </span>
       )}
@@ -478,7 +479,7 @@ function FolderRenameInput({
         }
       }}
       onBlur={(e) => commit(e.currentTarget.value)}
-      className="min-w-0 flex-1 rounded-[3px] border border-accent-line bg-bg-inset px-1 py-px text-[12px] font-medium text-fg-0 outline-none"
+      className="min-w-0 flex-1 rounded-[3px] border border-accent-line bg-bg-inset px-1 py-px text-[12px] text-fg-0 outline-none"
     />
   );
 }

--- a/apps/desktop/src/components/SidebarTree.tsx
+++ b/apps/desktop/src/components/SidebarTree.tsx
@@ -56,8 +56,10 @@ export const TWISTY =
 export const META =
   "ml-auto shrink-0 whitespace-nowrap pr-1 text-[10px] font-medium tabular-nums text-fg-3";
 
+// Authored at 12px so labels render at exactly the Settings > Appearance font
+// size after the global --ui-scale zoom (FONT_SIZE_BASELINE = 12).
 export const NODE_LABEL =
-  "min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[13px] leading-[18px]";
+  "min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[12px] leading-[18px]";
 
 const PILL =
   "ml-1 rounded-[3px] bg-bg-2 px-1 py-px text-[9px] font-medium tabular-nums text-fg-3";
@@ -118,7 +120,7 @@ export function ConnectionRow({
       <div
         className={
           ROW_BASE +
-          " h-[26px] border-l-2 pl-1 font-medium text-fg-0 cursor-pointer"
+          " h-[26px] border-l-2 pl-1 text-fg-0 cursor-pointer"
         }
         style={{ borderLeftColor: accent }}
         onClick={onToggle}
@@ -152,7 +154,7 @@ export function ConnectionRow({
           )}
         </button>
         <EngineBadge engine={config.engine as Engine} size={12} color={accent} />
-        <span className={NODE_LABEL + " font-medium"}>
+        <span className={NODE_LABEL}>
           {config.name}
         </span>
         {config.env_tag === "prod" && (


### PR DESCRIPTION
## Summary
Sidebar tree rows (connections, folders, databases, schemas, tables) rendered at inconsistent sizes, and all larger than the Settings > Appearance font size.

## What changed
- `NODE_LABEL` is now authored at 12px — the `--ui-scale` zoom baseline — so labels render at exactly the configured `fontSizePx` (previously 13px authored → ~8% oversized).
- Folder rows in `SidebarConnectionList` reuse the shared `NODE_LABEL` class instead of their own hardcoded 12px/medium style.
- Removed the `font-medium` weight on connection and folder names so all rows read as the same size.

## User impact
Every item in the left-hand nav is now visually uniform and matches the font size chosen in Settings > Appearance.

## Validation
- `tsc --noEmit` passes in `apps/desktop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated sidebar label sizing and typography for a more consistent look.
  * Renamed folders now use the same label styling as other sidebar items.
  * Removed extra emphasis from sidebar rows and rename fields for cleaner visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->