### PR TITLE
fix(sidebar): use green for connected status dot

### DIFF
--- a/apps/desktop/src/components/SidebarTree.tsx
+++ b/apps/desktop/src/components/SidebarTree.tsx
@@ -580,7 +580,7 @@ function TableRow({
 function StatusDot({ status }: { status: ConnStatus }) {
   const color =
     status === "connected"
-      ? "var(--accent)"
+      ? "var(--insert)"
       : status === "connecting"
         ? "var(--warn)"
         : status === "error"

--- a/apps/desktop/src/styles/tokens.css
+++ b/apps/desktop/src/styles/tokens.css
@@ -140,6 +140,11 @@
   --accent-line: rgba(124, 58, 237, 0.28);
   --accent-fg: #ffffff;
 
+  /* Semantic — darker than the dark-theme values so they read on light surfaces */
+  --insert: #16a34a;
+  --insert-bg: rgba(22, 163, 74, 0.10);
+  --insert-line: rgba(22, 163, 74, 0.25);
+
   --syn-kw: #7c3aed;
   --syn-fn: #2563eb;
   --syn-str: #15803d;


### PR DESCRIPTION
The sidebar connection status dot used the theme accent colour when connected, which reads as a muted grey and isn't obviously "connected". It now uses the same green token (`--insert`) as the status bar's connected indicator, so both match: green when connected, amber while connecting or on error, grey when disconnected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the sidebar status indicator for connected items to use the correct theme “insert” color for improved visual consistency.
* **Style**
  * Adjusted light theme semantic insert color tokens to ensure they remain readable on light surfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->