### PR TITLE
Drop per-folder move items from connection context menu

### DIFF
--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -458,6 +458,27 @@ export function Sidebar({
     );
     const currentFolder =
       folders.find((f) => f.children.includes(config.id)) ?? null;
+    const otherFolders = folders.filter((f) => f.id !== currentFolder?.id);
+    if (otherFolders.length > 0) {
+      // ponytail: second-page menu instead of real submenus; the folder list
+      // reuses the same ContextMenu at the same position.
+      const x = e.clientX;
+      const y = e.clientY;
+      items.push({
+        label: "Move to folder…",
+        icon: <Icon.folder size={12} />,
+        onClick: () =>
+          setMenu({
+            x,
+            y,
+            items: otherFolders.map((f) => ({
+              label: `Move to "${f.name}"`,
+              icon: <Icon.folder size={12} />,
+              onClick: () => moveToFolder(config.id, f.id),
+            })),
+          }),
+      });
+    }
     items.push({
       label: "Move to new folder",
       icon: <Icon.folderPlus size={12} />,

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -458,14 +458,6 @@ export function Sidebar({
     );
     const currentFolder =
       folders.find((f) => f.children.includes(config.id)) ?? null;
-    for (const f of folders) {
-      if (f.id === currentFolder?.id) continue;
-      items.push({
-        label: `Move to "${f.name}"`,
-        icon: <Icon.folder size={12} />,
-        onClick: () => moveToFolder(config.id, f.id),
-      });
-    }
     items.push({
       label: "Move to new folder",
       icon: <Icon.folderPlus size={12} />,


### PR DESCRIPTION
The connection right-click menu added a "Move to \"X\"" item for every sidebar folder, so with many folders the menu became long and the other actions hard to hit. This removes those per-folder items; "Move to new folder" and "Remove from folder" remain, and moving a connection into an existing folder still works via drag-and-drop onto the folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the connection context menu to improve how “move to an existing folder” works.
  * Instead of listing a separate top-level option for each target folder, the menu now offers a single **“Move to folder…”** entry that opens a nested list of available destinations.
  * The **“Move to new folder”** and **“Remove from folder”** options remain available when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->