### PR TITLE
feat(grid): softer contrast, content-fit column widths

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -208,7 +208,7 @@ export function App() {
         {!empty && panels.left && (
           <>
             <div
-              className="flex min-w-0 flex-col bg-bg-1"
+              className="flex min-w-0 flex-col bg-bg-0"
               style={{ width: leftWidth }}
             >
               <Sidebar
@@ -281,7 +281,7 @@ export function App() {
               )}
             />
             <div
-              className="flex min-w-0 flex-col bg-bg-1"
+              className="flex min-w-0 flex-col bg-bg-0"
               style={{ width: rightWidth }}
             >
               <AIPanel

--- a/apps/desktop/src/styles/grid.css
+++ b/apps/desktop/src/styles/grid.css
@@ -294,9 +294,17 @@
   border-right: 1px solid var(--grid-column-line);
 }
 .grid-row:hover { background: var(--bg-2); }
-/* No zebra striping: column lines + row dividers already separate cells; a
-   third mechanism made the grid busy. .is-stripe is still applied in JS
-   (GridRowView) but intentionally unstyled. */
+/* Zebra striping is opt-in (stripeRows setting); the grid defaults to
+   column lines + row dividers only. The .is-stripe class is applied in JS
+   (GridRowView) using the absolute rowIndex so it stays correct in
+   virtual-scroll mode, and is skipped on rows carrying a pending-change
+   tint (is-update / is-insert / is-delete). */
+.grid-row.is-stripe {
+  background: var(--bg-2);
+}
+.grid-row.is-stripe:hover {
+  background: var(--bg-3);
+}
 
 .grid-row.is-update { background: var(--update-bg); }
 .grid-row.is-update:hover { background: color-mix(in oklab, var(--update-bg) 70%, var(--bg-3)); }

--- a/apps/desktop/src/styles/grid.css
+++ b/apps/desktop/src/styles/grid.css
@@ -12,7 +12,9 @@
   /* Match the 13px base used by the body / sidebar so grid data and the rest of
      the UI read at the same size. */
   font-size: var(--fs-sm);
-  background: var(--bg-inset);
+  /* bg-1 rather than bg-inset: near-black under bright mono text read too
+     harsh; a lighter base + fg-1 data text keeps contrast comfortable. */
+  background: var(--bg-1);
 }
 
 /* ── filter bar ───────────────────────────────────────────── */
@@ -253,6 +255,7 @@
   font-feature-settings: "calt", "ss01";
   font-size: var(--fs-sm);
   line-height: 1;
+  color: var(--fg-1);
 }
 .grid-virtual-body {
   position: relative;
@@ -281,7 +284,7 @@
   display: flex;
   align-items: center;
   gap: 4px;
-  padding: 0 8px;
+  padding: 0 10px;
   min-width: 0;
   white-space: nowrap;
   overflow: hidden;
@@ -291,18 +294,9 @@
   border-right: 1px solid var(--grid-column-line);
 }
 .grid-row:hover { background: var(--bg-2); }
-/* Stripe rows: the .is-stripe class is applied in JS (GridRowView) using the
-   absolute rowIndex so it is correct in virtual-scroll mode where nth-child
-   only reflects the current render window.  The rule intentionally does NOT
-   apply to rows that already carry a pending-change tint (is-update / is-insert
-   / is-delete) — those classes are guarded in the JS so this selector is just a
-   safety net for specificity parity. */
-.grid-row.is-stripe {
-  background: var(--bg-2);
-}
-.grid-row.is-stripe:hover {
-  background: var(--bg-3);
-}
+/* No zebra striping: column lines + row dividers already separate cells; a
+   third mechanism made the grid busy. .is-stripe is still applied in JS
+   (GridRowView) but intentionally unstyled. */
 
 .grid-row.is-update { background: var(--update-bg); }
 .grid-row.is-update:hover { background: color-mix(in oklab, var(--update-bg) 70%, var(--bg-3)); }
@@ -354,7 +348,7 @@
 
 /* ── frozen columns + headers ─────────────────────────────── */
 .grid-cell.frozen {
-  background: var(--bg-inset);
+  background: var(--bg-1);
   position: sticky;
   z-index: 2;
 }
@@ -466,7 +460,7 @@
    columns. The gradient paints one accent-soft layer over an opaque base. */
 .grid-row.is-row-selected .grid-cell.frozen {
   background:
-    linear-gradient(var(--accent-soft), var(--accent-soft)), var(--bg-inset);
+    linear-gradient(var(--accent-soft), var(--accent-soft)), var(--bg-1);
 }
 .grid-row.is-row-selected:hover .grid-cell.frozen {
   background:
@@ -474,7 +468,7 @@
       color-mix(in oklab, var(--accent-soft) 82%, var(--bg-3)),
       color-mix(in oklab, var(--accent-soft) 82%, var(--bg-3))
     ),
-    var(--bg-inset);
+    var(--bg-1);
 }
 .grid-row.is-row-selected .grid-cell-rowno {
   background: var(--accent);

--- a/apps/desktop/src/styles/tokens.css
+++ b/apps/desktop/src/styles/tokens.css
@@ -82,7 +82,7 @@
   --shadow-lg: 0 24px 60px rgba(0, 0, 0, 0.55), 0 2px 8px rgba(0, 0, 0, 0.4);
 
   /* Sizing — compact density */
-  --row-h: 22px;
+  --row-h: 25px;
   --row-h-tight: 20px;
   --tab-h: 30px;
   --titlebar-h: 34px;
@@ -152,7 +152,7 @@
 }
 
 [data-density="compact"] {
-  --row-h: 22px;
+  --row-h: 25px;
   --tab-h: 30px;
 }
 [data-density="comfortable"] {

--- a/packages/data-grid/src/DataGrid.tsx
+++ b/packages/data-grid/src/DataGrid.tsx
@@ -72,7 +72,9 @@ function measureGridText(text: string, fontSize = 13): number {
   return context.measureText(text).width;
 }
 const HEADER_HEIGHT = 26;
-const DEFAULT_ROW_HEIGHT = 22;
+/* Fallback until the CSS --row-h variable is measured — keep in sync with
+   tokens.css so the first virtualized render doesn't jump. */
+const DEFAULT_ROW_HEIGHT = 25;
 const MIN_ROW_OVERSCAN = 24;
 const OVERSCAN_VIEWPORTS = 3;
 // Below this, full row flow is cheap enough; above it we window the rows so a
@@ -298,18 +300,30 @@ export function DataGrid({
      double-click autofit, persisted in the layout) is sized to fit its header
      and the visible data, capped at MAX_AUTO_WIDTH. Computed at render time so
      nothing is written back into the saved layout. */
+  /* The widths object is re-spread on every pointermove during a resize drag,
+     so keying the memo on it would re-measure every unsized column per move.
+     Depend on the stable set of unsized column keys instead. */
+  const unsizedColumnsKey = columns
+    .map((column) => column.key)
+    .filter((key) => activeColumnLayout.widths[key] === undefined)
+    .join("\u0000");
+
   const autoWidths = useMemo(() => {
+    const unsized = new Set(
+      unsizedColumnsKey === "" ? [] : unsizedColumnsKey.split("\u0000"),
+    );
     const widths: Record<string, number> = {};
     const sample = rows.slice(0, AUTO_WIDTH_SAMPLE_ROWS);
     for (const column of columns) {
-      if (activeColumnLayout.widths[column.key] !== undefined) continue;
+      if (!unsized.has(column.key)) continue;
       const adornment = column.fk ? 24 : column.enum ? 18 : 0;
       let width =
         measureGridText(column.name, 11) +
         measureGridText(column.type, 11) +
         HEADER_AUTOFIT_PADDING;
       for (const row of sample) {
-        const value = row[column.key];
+        const edit = changes[row.id]?.edits?.[column.key];
+        const value = edit ? edit.to : row[column.key];
         const text = value === null || value === undefined ? "NULL" : String(value);
         width = Math.max(
           width,
@@ -323,7 +337,7 @@ export function DataGrid({
       );
     }
     return widths;
-  }, [activeColumnLayout.widths, columns, rows]);
+  }, [changes, columns, rows, unsizedColumnsKey]);
 
   const renderedColumns = useMemo(
     () =>

--- a/packages/data-grid/src/DataGrid.tsx
+++ b/packages/data-grid/src/DataGrid.tsx
@@ -49,6 +49,28 @@ import type {
 const ROWNO_WIDTH = 36;
 const COLUMN_AUTOFIT_PADDING = 32;
 const HEADER_AUTOFIT_PADDING = 58;
+/* Default (data-driven) column widths are capped so one long text column can't
+   eat the viewport; explicit double-click autofit is uncapped. */
+const MAX_AUTO_WIDTH = 420;
+/* ponytail: sample the first N loaded rows for default widths; scanning the
+   whole page buys little once widths have converged. */
+const AUTO_WIDTH_SAMPLE_ROWS = 200;
+
+let measureCanvas: HTMLCanvasElement | null = null;
+/** Measure `text` in the grid's mono font. Cell data renders at 13px
+    (--fs-sm), header names at 11px. */
+function measureGridText(text: string, fontSize = 13): number {
+  if (typeof document === "undefined") return text.length * 8;
+  measureCanvas ??= document.createElement("canvas");
+  const context = measureCanvas.getContext("2d");
+  if (!context) return text.length * 8;
+  const monoFont =
+    getComputedStyle(document.documentElement)
+      .getPropertyValue("--font-mono")
+      .trim() || "monospace";
+  context.font = `${fontSize}px ${monoFont}`;
+  return context.measureText(text).width;
+}
 const HEADER_HEIGHT = 26;
 const DEFAULT_ROW_HEIGHT = 22;
 const MIN_ROW_OVERSCAN = 24;
@@ -270,12 +292,46 @@ export function DataGrid({
   const isResizing = resizing !== null;
   const resizingRef = useRef<ColumnResizeState | null>(null);
   const suppressNextSortRef = useRef(false);
-  const measureCanvasRef = useRef<HTMLCanvasElement | null>(null);
   const insertCounterRef = useRef(0);
 
+  /* Data-driven default widths: any column WITHOUT a user-set width (resize /
+     double-click autofit, persisted in the layout) is sized to fit its header
+     and the visible data, capped at MAX_AUTO_WIDTH. Computed at render time so
+     nothing is written back into the saved layout. */
+  const autoWidths = useMemo(() => {
+    const widths: Record<string, number> = {};
+    const sample = rows.slice(0, AUTO_WIDTH_SAMPLE_ROWS);
+    for (const column of columns) {
+      if (activeColumnLayout.widths[column.key] !== undefined) continue;
+      const adornment = column.fk ? 24 : column.enum ? 18 : 0;
+      let width =
+        measureGridText(column.name, 11) +
+        measureGridText(column.type, 11) +
+        HEADER_AUTOFIT_PADDING;
+      for (const row of sample) {
+        const value = row[column.key];
+        const text = value === null || value === undefined ? "NULL" : String(value);
+        width = Math.max(
+          width,
+          measureGridText(text) + COLUMN_AUTOFIT_PADDING + adornment,
+        );
+        if (width >= MAX_AUTO_WIDTH) break;
+      }
+      widths[column.key] = Math.min(
+        MAX_AUTO_WIDTH,
+        Math.max(MIN_COLUMN_WIDTH, Math.ceil(width)),
+      );
+    }
+    return widths;
+  }, [activeColumnLayout.widths, columns, rows]);
+
   const renderedColumns = useMemo(
-    () => layoutForColumns(columns, activeColumnLayout),
-    [activeColumnLayout, columns],
+    () =>
+      layoutForColumns(columns, activeColumnLayout).map((column) => {
+        const auto = autoWidths[column.key];
+        return auto === undefined ? column : { ...column, width: auto };
+      }),
+    [activeColumnLayout, autoWidths, columns],
   );
 
   // Local search across visible page. Server-side filtering happens upstream
@@ -567,24 +623,11 @@ export function DataGrid({
     [],
   );
 
-  const measureGridText = useCallback((text: string): number => {
-    if (typeof document === "undefined") return text.length * 8;
-    const canvas =
-      measureCanvasRef.current ??
-      (measureCanvasRef.current = document.createElement("canvas"));
-    const context = canvas.getContext("2d");
-    if (!context) return text.length * 8;
-    const rootStyle = getComputedStyle(document.documentElement);
-    const monoFont = rootStyle.getPropertyValue("--font-mono").trim() || "monospace";
-    context.font = `11px ${monoFont}`;
-    return context.measureText(text).width;
-  }, []);
-
   const autofitColumn = useCallback(
     (column: GridColumn) => {
       const headerWidth =
-        measureGridText(column.name) +
-        measureGridText(column.type) +
+        measureGridText(column.name, 11) +
+        measureGridText(column.type, 11) +
         HEADER_AUTOFIT_PADDING;
       const valueWidth = visibleRows.reduce((maxWidth, row) => {
         const change = changes[row.id]?.edits?.[column.key];
@@ -608,7 +651,7 @@ export function DataGrid({
         },
       });
     },
-    [activeColumnLayout, changes, measureGridText, updateColumnLayout, visibleRows],
+    [activeColumnLayout, changes, updateColumnLayout, visibleRows],
   );
 
   const reorderColumn = useCallback(

--- a/packages/data-grid/src/DataGrid.tsx
+++ b/packages/data-grid/src/DataGrid.tsx
@@ -314,6 +314,11 @@ export function DataGrid({
     );
     const widths: Record<string, number> = {};
     const sample = rows.slice(0, AUTO_WIDTH_SAMPLE_ROWS);
+    /* Inserted rows live only in `changes` (appended to visibleRows later), so
+       sample their pending values too or long inserted text gets clipped. */
+    const inserts = Object.values(changes).filter(
+      (change) => change.kind === "insert",
+    );
     for (const column of columns) {
       if (!unsized.has(column.key)) continue;
       const adornment = column.fk ? 24 : column.enum ? 18 : 0;
@@ -330,6 +335,15 @@ export function DataGrid({
           measureGridText(text) + COLUMN_AUTOFIT_PADDING + adornment,
         );
         if (width >= MAX_AUTO_WIDTH) break;
+      }
+      for (const change of inserts) {
+        if (width >= MAX_AUTO_WIDTH) break;
+        const value = change.edits[column.key]?.to;
+        const text = value === null || value === undefined ? "NULL" : String(value);
+        width = Math.max(
+          width,
+          measureGridText(text) + COLUMN_AUTOFIT_PADDING + adornment,
+        );
       }
       widths[column.key] = Math.min(
         MAX_AUTO_WIDTH,
@@ -430,9 +444,18 @@ export function DataGrid({
     const resizeObserver = new ResizeObserver(scheduleSync);
     resizeObserver.observe(scroller);
 
+    /* --row-h comes from the density attribute on <html> (see tokens.css);
+       remeasure when it flips so virtual row offsets track the CSS height. */
+    const densityObserver = new MutationObserver(scheduleSync);
+    densityObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-density"],
+    });
+
     return () => {
       if (frame) window.cancelAnimationFrame(frame);
       resizeObserver.disconnect();
+      densityObserver.disconnect();
     };
   }, [measureViewport]);
 


### PR DESCRIPTION
Makes the data grid easier on the eyes (was harsh next to DataGrip) and sizes columns to their content.

- Grid body and frozen cells move from near-black `--bg-inset` to `--bg-1` with `--fg-1` data text, dropping text contrast from ~19:1 to a comfortable ~9:1; row height goes 22px → 25px, cell padding 8px → 10px, and zebra striping is removed so column/row lines separate cells alone.
- Columns without a user-set width now auto-fit their header plus the first 200 loaded rows (capped at 420px), computed at render time so persisted layouts and manual resizes still win; double-click autofit now measures at the real 13px cell font.
- The left connections sidebar and right AI panel drop to `--bg-0` so the grid reads as the elevated content surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved automatic column sizing in the data grid by measuring header and cell content to generate better-fit default widths (including support for special column types).

* **Bug Fixes**
  * Made the data grid’s virtualization row positioning respond to density changes so row offsets stay aligned.
  * Updated grid/table surface tones for consistency, including selected/frozen-cell accent gradients and cell text color.

* **Styling**
  * Disabled default zebra striping (leaving it available when applied programmatically).
  * Refreshed grid spacing and increased the dark/compact row height.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->