### PR TITLE
Add SQL comparison operators, themed filter dropdowns, guid filter fixes

### DIFF
--- a/apps/desktop/src/lib/browseFilters.test.ts
+++ b/apps/desktop/src/lib/browseFilters.test.ts
@@ -38,10 +38,22 @@ describe("advancedFiltersToClauses", () => {
     expect(advancedFiltersToClauses([chip({ value: "  " })])).toEqual([]);
   });
 
-  it("skips operators without a server equivalent (startsWith)", () => {
+  it("maps text pattern operators to server clauses", () => {
     expect(
       advancedFiltersToClauses([chip({ operator: "startsWith", value: "a" })]),
-    ).toEqual([]);
+    ).toEqual([{ column: "status", operator: "starts_with", value: "a" }]);
+    expect(
+      advancedFiltersToClauses([chip({ operator: "notContains", value: "a" })]),
+    ).toEqual([{ column: "status", operator: "not_contains", value: "a" }]);
+  });
+
+  it("wraps bare like patterns in wildcards, leaves explicit ones alone", () => {
+    expect(
+      advancedFiltersToClauses([chip({ operator: "like", value: "abc" })]),
+    ).toEqual([{ column: "status", operator: "like", value: "%abc%" }]);
+    expect(
+      advancedFiltersToClauses([chip({ operator: "like", value: "abc%" })]),
+    ).toEqual([{ column: "status", operator: "like", value: "abc%" }]);
   });
 
   it("pushes nothing when chips use OR (no server grouping)", () => {

--- a/apps/desktop/src/lib/browseFilters.ts
+++ b/apps/desktop/src/lib/browseFilters.ts
@@ -22,10 +22,13 @@ const ADVANCED_OPERATOR_MAP: Partial<Record<FilterOperator, TableFilterOperator>
   notEquals: "not_equals",
   contains: "contains",
   greaterThan: "greater_than",
+  greaterThanOrEqual: "greater_than_or_equal",
   lessThan: "less_than",
+  lessThanOrEqual: "less_than_or_equal",
   isNull: "is_null",
   isNotNull: "is_not_null",
-  // `startsWith` has no server operator — it stays a local page filter.
+  // `startsWith`/`endsWith`/`notContains`/`like` have no server operator —
+  // they stay local page filters.
 };
 
 function operatorNeedsValue(operator: TableFilterOperator): boolean {

--- a/apps/desktop/src/lib/browseFilters.ts
+++ b/apps/desktop/src/lib/browseFilters.ts
@@ -1,4 +1,4 @@
-import { operatorsForColumn } from "@cellar/data-grid";
+import { normalizeLikePattern, operatorsForColumn } from "@cellar/data-grid";
 import type {
   FilterClause,
   FilterOperator,
@@ -21,14 +21,16 @@ const ADVANCED_OPERATOR_MAP: Partial<Record<FilterOperator, TableFilterOperator>
   equals: "equals",
   notEquals: "not_equals",
   contains: "contains",
+  notContains: "not_contains",
+  startsWith: "starts_with",
+  endsWith: "ends_with",
+  like: "like",
   greaterThan: "greater_than",
   greaterThanOrEqual: "greater_than_or_equal",
   lessThan: "less_than",
   lessThanOrEqual: "less_than_or_equal",
   isNull: "is_null",
   isNotNull: "is_not_null",
-  // `startsWith`/`endsWith`/`notContains`/`like` have no server operator —
-  // they stay local page filters.
 };
 
 function operatorNeedsValue(operator: TableFilterOperator): boolean {
@@ -51,8 +53,10 @@ export function advancedFiltersToClauses(
     const operator = ADVANCED_OPERATOR_MAP[filter.operator];
     if (!operator) continue;
     const needsValue = operatorNeedsValue(operator);
-    const value = (filter.value ?? "").trim();
+    let value = (filter.value ?? "").trim();
     if (needsValue && value.length === 0) continue;
+    // Match the grid's local `like` semantics: bare text means %text%.
+    if (operator === "like") value = normalizeLikePattern(value);
     clauses.push({
       column: filter.columnKey,
       operator,

--- a/apps/desktop/src/styles/grid.css
+++ b/apps/desktop/src/styles/grid.css
@@ -141,6 +141,62 @@
   box-shadow: 0 4px 14px rgba(0,0,0,0.18);
   flex-shrink: 0;
 }
+.grid-select {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 18px;
+  min-width: 0;
+  max-width: 150px;
+  padding: 0 5px;
+  border: 1px solid var(--border-default);
+  border-radius: 3px;
+  background: var(--bg-inset);
+  color: var(--fg-0);
+  font-size: var(--fs-sm);
+  cursor: default;
+}
+.grid-select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent-line);
+}
+.grid-select-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.grid-select > svg {
+  flex-shrink: 0;
+  color: var(--fg-3);
+}
+.grid-select-menu {
+  position: fixed;
+  z-index: 1000;
+  max-height: 260px;
+  overflow-y: auto;
+  padding: 3px;
+  border: 1px solid var(--border-strong);
+  border-radius: 5px;
+  background: var(--bg-2);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.3);
+  font-size: var(--fs-sm);
+}
+.grid-select-option {
+  padding: 3px 8px;
+  border-radius: 3px;
+  color: var(--fg-1);
+  white-space: nowrap;
+  cursor: default;
+}
+.grid-select-option.is-active {
+  background: var(--bg-3);
+  color: var(--fg-0);
+}
+.grid-select-option.is-selected {
+  color: var(--accent);
+}
+
 .grid-filter-select,
 .grid-filter-input {
   height: 18px;
@@ -176,18 +232,18 @@
   height: 18px;
   padding: 0 6px;
   border-radius: 3px;
-  background: var(--accent-soft);
-  color: var(--accent);
+  background: var(--accent);
+  color: var(--accent-fg);
   font-size: var(--fs-sm);
   font-weight: 600;
 }
 .grid-filter-apply:hover:not(:disabled) {
-  background: var(--accent-line);
-  color: var(--fg-0);
+  filter: brightness(1.15);
 }
 .grid-filter-apply:disabled {
   cursor: default;
-  opacity: 0.45;
+  background: var(--bg-3);
+  color: var(--fg-3);
 }
 .grid-filter-clear {
   height: 20px;

--- a/crates/cellar-core/src/query.rs
+++ b/crates/cellar-core/src/query.rs
@@ -303,6 +303,11 @@ pub enum TableFilterOperator {
     Equals,
     NotEquals,
     Contains,
+    NotContains,
+    StartsWith,
+    EndsWith,
+    /// Raw SQL LIKE pattern (`%`/`_` supplied by the user), matched case-insensitively.
+    Like,
     IsNull,
     IsNotNull,
     GreaterThan,

--- a/crates/cellar-core/src/table_browse.rs
+++ b/crates/cellar-core/src/table_browse.rs
@@ -120,6 +120,17 @@ pub fn reject_value(filter: &TableFilterClause) -> Result<(), TableBrowseError> 
     Ok(())
 }
 
+/// Escape LIKE wildcards (`\`, `%`, `_`) in user text so contains/starts
+/// with/ends with match it literally. Backslash is the escape character in
+/// Postgres and MySQL by default; SQL Server drivers must add `ESCAPE '\'`.
+/// Not used for the `like` operator, where the user controls the wildcards.
+pub fn escape_like_wildcards(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
+}
+
 pub fn unsupported(column: &Column, operator: TableFilterOperator) -> TableBrowseError {
     TableBrowseError::UnsupportedOperator {
         column: column.name.clone(),

--- a/crates/cellar-diff/src/lib.rs
+++ b/crates/cellar-diff/src/lib.rs
@@ -360,7 +360,10 @@ mod tests {
         })
         .expect("plan");
 
-        assert!(plan.preview.sql.contains("ON CONFLICT (\"id\") DO NOTHING;"));
+        assert!(plan
+            .preview
+            .sql
+            .contains("ON CONFLICT (\"id\") DO NOTHING;"));
     }
 
     fn assign(column: &str, value: Option<&str>) -> CellAssignment {

--- a/crates/cellar-drivers/mysql/src/table_browse.rs
+++ b/crates/cellar-drivers/mysql/src/table_browse.rs
@@ -186,15 +186,42 @@ fn push_filter<'args>(
             push_ident(builder, &column.name);
             builder.push(" IS NOT NULL");
         }
-        TableFilterOperator::Contains => {
+        TableFilterOperator::Contains
+        | TableFilterOperator::NotContains
+        | TableFilterOperator::StartsWith
+        | TableFilterOperator::EndsWith
+        | TableFilterOperator::Like => {
             let value = require_value(filter)?;
             if !matches!(kind, ColumnKind::Text) {
                 return Err(unsupported(column, filter.operator));
             }
             push_ident(builder, &column.name);
-            builder.push(" LIKE CONCAT('%', ");
-            builder.push_bind(value);
-            builder.push(", '%')");
+            match filter.operator {
+                TableFilterOperator::NotContains => {
+                    builder.push(" NOT LIKE CONCAT('%', ");
+                    builder.push_bind(value);
+                    builder.push(", '%')");
+                }
+                TableFilterOperator::StartsWith => {
+                    builder.push(" LIKE CONCAT(");
+                    builder.push_bind(value);
+                    builder.push(", '%')");
+                }
+                TableFilterOperator::EndsWith => {
+                    builder.push(" LIKE CONCAT('%', ");
+                    builder.push_bind(value);
+                    builder.push(")");
+                }
+                TableFilterOperator::Like => {
+                    builder.push(" LIKE ");
+                    builder.push_bind(value);
+                }
+                _ => {
+                    builder.push(" LIKE CONCAT('%', ");
+                    builder.push_bind(value);
+                    builder.push(", '%')");
+                }
+            }
         }
         TableFilterOperator::Equals | TableFilterOperator::NotEquals => {
             let value = require_value(filter)?;

--- a/crates/cellar-drivers/mysql/src/table_browse.rs
+++ b/crates/cellar-drivers/mysql/src/table_browse.rs
@@ -8,8 +8,8 @@ use cellar_core::query::{
 };
 use cellar_core::schema::Table;
 use cellar_core::table_browse::{
-    column_for, normalized_limit, normalized_offset, reject_value, require_value, unsupported,
-    validate_table_request, TableBrowseError,
+    column_for, escape_like_wildcards, normalized_limit, normalized_offset, reject_value,
+    require_value, unsupported, validate_table_request, TableBrowseError,
 };
 use cellar_core::value::{ColumnMeta, Row};
 use futures::TryStreamExt;
@@ -192,6 +192,13 @@ fn push_filter<'args>(
         | TableFilterOperator::EndsWith
         | TableFilterOperator::Like => {
             let value = require_value(filter)?;
+            // `like` passes the user's pattern through; the literal-text
+            // operators must not treat %/_ in the value as wildcards.
+            let value = if filter.operator == TableFilterOperator::Like {
+                value
+            } else {
+                escape_like_wildcards(&value)
+            };
             if !matches!(kind, ColumnKind::Text) {
                 return Err(unsupported(column, filter.operator));
             }

--- a/crates/cellar-drivers/postgres/src/table_browse.rs
+++ b/crates/cellar-drivers/postgres/src/table_browse.rs
@@ -7,8 +7,8 @@ use cellar_core::query::{
 };
 use cellar_core::schema::{Column, Table};
 use cellar_core::table_browse::{
-    column_for, normalized_limit, normalized_offset, reject_value, require_value, unsupported,
-    validate_table_request, TableBrowseError,
+    column_for, escape_like_wildcards, normalized_limit, normalized_offset, reject_value,
+    require_value, unsupported, validate_table_request, TableBrowseError,
 };
 use cellar_core::value::{ColumnMeta, Row};
 use futures::TryStreamExt;
@@ -203,6 +203,13 @@ fn push_filter<'args>(
         | TableFilterOperator::EndsWith
         | TableFilterOperator::Like => {
             let value = require_value(filter)?;
+            // `like` passes the user's pattern through; the literal-text
+            // operators must not treat %/_ in the value as wildcards.
+            let value = if filter.operator == TableFilterOperator::Like {
+                value
+            } else {
+                escape_like_wildcards(&value)
+            };
             let is_uuid = matches!(kind, ColumnKind::Typed("uuid", _));
             if !matches!(kind, ColumnKind::Text) && !is_uuid {
                 return Err(unsupported(column, filter.operator));
@@ -425,9 +432,18 @@ mod tests {
     #[test]
     fn builds_pattern_operators_as_ilike_variants() {
         let cases = [
-            (TableFilterOperator::NotContains, r#"NOT ("email" ILIKE ('%' || $1 || '%'))"#),
-            (TableFilterOperator::StartsWith, r#""email" ILIKE ($1 || '%')"#),
-            (TableFilterOperator::EndsWith, r#""email" ILIKE ('%' || $1)"#),
+            (
+                TableFilterOperator::NotContains,
+                r#"NOT ("email" ILIKE ('%' || $1 || '%'))"#,
+            ),
+            (
+                TableFilterOperator::StartsWith,
+                r#""email" ILIKE ($1 || '%')"#,
+            ),
+            (
+                TableFilterOperator::EndsWith,
+                r#""email" ILIKE ('%' || $1)"#,
+            ),
             (TableFilterOperator::Like, r#""email" ILIKE $1"#),
         ];
         for (operator, expected) in cases {
@@ -451,10 +467,7 @@ mod tests {
             value: Some("fe27".into()),
         });
         let sql = sql_for(&req).expect("sql");
-        assert!(
-            sql.contains(r#""external_id"::text ILIKE"#),
-            "got: {sql}"
-        );
+        assert!(sql.contains(r#""external_id"::text ILIKE"#), "got: {sql}");
     }
 
     #[test]

--- a/crates/cellar-drivers/postgres/src/table_browse.rs
+++ b/crates/cellar-drivers/postgres/src/table_browse.rs
@@ -197,20 +197,48 @@ fn push_filter<'args>(
             push_ident(builder, &column.name);
             builder.push(" IS NOT NULL");
         }
-        TableFilterOperator::Contains => {
+        TableFilterOperator::Contains
+        | TableFilterOperator::NotContains
+        | TableFilterOperator::StartsWith
+        | TableFilterOperator::EndsWith
+        | TableFilterOperator::Like => {
             let value = require_value(filter)?;
             let is_uuid = matches!(kind, ColumnKind::Typed("uuid", _));
             if !matches!(kind, ColumnKind::Text) && !is_uuid {
                 return Err(unsupported(column, filter.operator));
+            }
+            if filter.operator == TableFilterOperator::NotContains {
+                builder.push("NOT (");
             }
             push_ident(builder, &column.name);
             if is_uuid {
                 // ILIKE needs text; uuid has no implicit cast.
                 builder.push("::text");
             }
-            builder.push(" ILIKE ('%' || ");
-            builder.push_bind(value);
-            builder.push(" || '%')");
+            match filter.operator {
+                TableFilterOperator::StartsWith => {
+                    builder.push(" ILIKE (");
+                    builder.push_bind(value);
+                    builder.push(" || '%')");
+                }
+                TableFilterOperator::EndsWith => {
+                    builder.push(" ILIKE ('%' || ");
+                    builder.push_bind(value);
+                    builder.push(")");
+                }
+                TableFilterOperator::Like => {
+                    builder.push(" ILIKE ");
+                    builder.push_bind(value);
+                }
+                _ => {
+                    builder.push(" ILIKE ('%' || ");
+                    builder.push_bind(value);
+                    builder.push(" || '%')");
+                }
+            }
+            if filter.operator == TableFilterOperator::NotContains {
+                builder.push(")");
+            }
         }
         TableFilterOperator::Equals | TableFilterOperator::NotEquals => {
             let value = require_value(filter)?;
@@ -392,6 +420,26 @@ mod tests {
         Ok(build_table_browse_query(request, &table())?
             .sql()
             .to_string())
+    }
+
+    #[test]
+    fn builds_pattern_operators_as_ilike_variants() {
+        let cases = [
+            (TableFilterOperator::NotContains, r#"NOT ("email" ILIKE ('%' || $1 || '%'))"#),
+            (TableFilterOperator::StartsWith, r#""email" ILIKE ($1 || '%')"#),
+            (TableFilterOperator::EndsWith, r#""email" ILIKE ('%' || $1)"#),
+            (TableFilterOperator::Like, r#""email" ILIKE $1"#),
+        ];
+        for (operator, expected) in cases {
+            let mut req = request();
+            req.filters.push(TableFilterClause {
+                column: "email".into(),
+                operator,
+                value: Some("a%".into()),
+            });
+            let sql = sql_for(&req).expect("sql");
+            assert!(sql.contains(expected), "{operator:?}: got {sql}");
+        }
     }
 
     #[test]

--- a/crates/cellar-drivers/postgres/src/table_browse.rs
+++ b/crates/cellar-drivers/postgres/src/table_browse.rs
@@ -199,10 +199,15 @@ fn push_filter<'args>(
         }
         TableFilterOperator::Contains => {
             let value = require_value(filter)?;
-            if !matches!(kind, ColumnKind::Text) {
+            let is_uuid = matches!(kind, ColumnKind::Typed("uuid", _));
+            if !matches!(kind, ColumnKind::Text) && !is_uuid {
                 return Err(unsupported(column, filter.operator));
             }
             push_ident(builder, &column.name);
+            if is_uuid {
+                // ILIKE needs text; uuid has no implicit cast.
+                builder.push("::text");
+            }
             builder.push(" ILIKE ('%' || ");
             builder.push_bind(value);
             builder.push(" || '%')");
@@ -366,6 +371,7 @@ mod tests {
                 column("age", "int4", false),
                 column("deleted_at", "timestamptz", false),
                 column("payload", "jsonb", false),
+                column("external_id", "uuid", false),
             ],
         }
     }
@@ -386,6 +392,21 @@ mod tests {
         Ok(build_table_browse_query(request, &table())?
             .sql()
             .to_string())
+    }
+
+    #[test]
+    fn contains_casts_uuid_columns_to_text() {
+        let mut req = request();
+        req.filters.push(TableFilterClause {
+            column: "external_id".into(),
+            operator: TableFilterOperator::Contains,
+            value: Some("fe27".into()),
+        });
+        let sql = sql_for(&req).expect("sql");
+        assert!(
+            sql.contains(r#""external_id"::text ILIKE"#),
+            "got: {sql}"
+        );
     }
 
     #[test]

--- a/crates/cellar-drivers/sqlserver/src/table_browse.rs
+++ b/crates/cellar-drivers/sqlserver/src/table_browse.rs
@@ -216,15 +216,23 @@ fn filter_sql(filter: &TableFilterClause, table: &Table) -> Result<String, Table
             reject_value(filter)?;
             Ok(format!("{ident} IS NOT NULL"))
         }
-        TableFilterOperator::Contains => {
+        TableFilterOperator::Contains
+        | TableFilterOperator::NotContains
+        | TableFilterOperator::StartsWith
+        | TableFilterOperator::EndsWith
+        | TableFilterOperator::Like => {
             let value = require_value(filter)?;
             if !is_text_type(&column.data_type) {
                 return Err(unsupported(column, filter.operator));
             }
-            Ok(format!(
-                "{ident} LIKE {}",
-                quote_literal(&format!("%{value}%"))
-            ))
+            let (keyword, pattern) = match filter.operator {
+                TableFilterOperator::NotContains => ("NOT LIKE", format!("%{value}%")),
+                TableFilterOperator::StartsWith => ("LIKE", format!("{value}%")),
+                TableFilterOperator::EndsWith => ("LIKE", format!("%{value}")),
+                TableFilterOperator::Like => ("LIKE", value.clone()),
+                _ => ("LIKE", format!("%{value}%")),
+            };
+            Ok(format!("{ident} {keyword} {}", quote_literal(&pattern)))
         }
         TableFilterOperator::Equals | TableFilterOperator::NotEquals => {
             let value = require_value(filter)?;

--- a/crates/cellar-drivers/sqlserver/src/table_browse.rs
+++ b/crates/cellar-drivers/sqlserver/src/table_browse.rs
@@ -7,8 +7,8 @@ use cellar_core::query::{
 };
 use cellar_core::schema::Table;
 use cellar_core::table_browse::{
-    column_for, normalized_limit, normalized_offset, reject_value, require_value, unsupported,
-    validate_table_request, TableBrowseError,
+    column_for, escape_like_wildcards, normalized_limit, normalized_offset, reject_value,
+    require_value, unsupported, validate_table_request, TableBrowseError,
 };
 use cellar_core::value::{ColumnMeta, Row};
 use futures_util::TryStreamExt;
@@ -225,14 +225,23 @@ fn filter_sql(filter: &TableFilterClause, table: &Table) -> Result<String, Table
             if !is_text_type(&column.data_type) {
                 return Err(unsupported(column, filter.operator));
             }
+            if filter.operator == TableFilterOperator::Like {
+                // User-controlled pattern, passed through verbatim.
+                return Ok(format!("{ident} LIKE {}", quote_literal(&value)));
+            }
+            // Literal text: escape LIKE wildcards, including SQL Server's `[`
+            // character-class wildcard, and declare the escape character.
+            let escaped = escape_like_wildcards(&value).replace('[', "\\[");
             let (keyword, pattern) = match filter.operator {
-                TableFilterOperator::NotContains => ("NOT LIKE", format!("%{value}%")),
-                TableFilterOperator::StartsWith => ("LIKE", format!("{value}%")),
-                TableFilterOperator::EndsWith => ("LIKE", format!("%{value}")),
-                TableFilterOperator::Like => ("LIKE", value.clone()),
-                _ => ("LIKE", format!("%{value}%")),
+                TableFilterOperator::NotContains => ("NOT LIKE", format!("%{escaped}%")),
+                TableFilterOperator::StartsWith => ("LIKE", format!("{escaped}%")),
+                TableFilterOperator::EndsWith => ("LIKE", format!("%{escaped}")),
+                _ => ("LIKE", format!("%{escaped}%")),
             };
-            Ok(format!("{ident} {keyword} {}", quote_literal(&pattern)))
+            Ok(format!(
+                "{ident} {keyword} {} ESCAPE '\\'",
+                quote_literal(&pattern)
+            ))
         }
         TableFilterOperator::Equals | TableFilterOperator::NotEquals => {
             let value = require_value(filter)?;

--- a/crates/cellar-drivers/sqlserver/src/table_browse.rs
+++ b/crates/cellar-drivers/sqlserver/src/table_browse.rs
@@ -272,7 +272,12 @@ fn quote_literal(value: &str) -> String {
 
 fn is_text_type(data_type: &str) -> bool {
     let lower = data_type.to_lowercase();
-    lower.contains("char") || lower == "text" || lower == "ntext" || lower == "xml"
+    // uniqueidentifier: LIKE implicitly converts it to char, so contains works.
+    lower.contains("char")
+        || lower == "text"
+        || lower == "ntext"
+        || lower == "xml"
+        || lower == "uniqueidentifier"
 }
 
 fn supports_ordering(data_type: &str) -> bool {
@@ -404,6 +409,30 @@ mod tests {
         assert_eq!(err, TableBrowseError::UnknownColumn("missing".into()));
     }
 
+    #[test]
+    fn contains_allows_uniqueidentifier_columns() {
+        let table = table();
+        let request = TableBrowseRequest {
+            connection_id: "conn".into(),
+            database: Some("main".into()),
+            schema: "dbo".into(),
+            table: "orders]archive".into(),
+            limit: Some(25),
+            offset: None,
+            sorts: Vec::new(),
+            filters: vec![TableFilterClause {
+                column: "guid".into(),
+                operator: TableFilterOperator::Contains,
+                value: Some("fe27".into()),
+            }],
+            primary_key_fallback_ordering: true,
+            include_total: false,
+        };
+
+        let sql = build_table_browse_query(&request, &table).unwrap();
+        assert!(sql.contains("[guid] LIKE N'%fe27%'"), "got: {sql}");
+    }
+
     fn table() -> Table {
         Table {
             name: "orders]archive".into(),
@@ -426,6 +455,15 @@ mod tests {
                     default: None,
                     is_primary_key: false,
                     ordinal: 2,
+                    comment: None,
+                },
+                Column {
+                    name: "guid".into(),
+                    data_type: "uniqueidentifier".into(),
+                    nullable: true,
+                    default: None,
+                    is_primary_key: false,
+                    ordinal: 3,
                     comment: None,
                 },
             ],

--- a/packages/data-grid/package.json
+++ b/packages/data-grid/package.json
@@ -13,10 +13,13 @@
     ".": "./src/index.ts"
   },
   "peerDependencies": {
-    "react": "^18.0.0"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",
-    "react": "^18.3.1"
+    "@types/react-dom": "^18.3.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   }
 }

--- a/packages/data-grid/src/FilterBar.tsx
+++ b/packages/data-grid/src/FilterBar.tsx
@@ -8,6 +8,7 @@ import {
   operatorsForColumn,
 } from "./filters";
 import { GridIcon } from "./icons";
+import { GridSelect } from "./GridSelect";
 import type {
   ColumnFilters,
   FilterClause,
@@ -55,7 +56,7 @@ export function FilterBar({
   serverRows,
 }: FilterBarProps) {
   const [draft, setDraft] = useState<ComposerDraft | null>(null);
-  const columnRef = useRef<HTMLSelectElement | null>(null);
+  const columnRef = useRef<HTMLButtonElement | null>(null);
   const valueRef = useRef<HTMLInputElement | null>(null);
   const columnsByKey = useMemo(
     () => new Map(columns.map((column) => [column.key, column])),
@@ -190,19 +191,17 @@ export function FilterBar({
             aria-label="Quick filter"
           />
           {textColumns.length > 0 && (
-            <select
-              className="grid-filter-select grid-quickfilter-column"
+            <GridSelect
+              className="grid-quickfilter-column"
               value={quickColumnValue}
-              onChange={(e) => onQuickFilterColumnChange?.(e.target.value || null)}
+              options={textColumns.map((column) => ({
+                value: column.key,
+                label: column.name,
+              }))}
+              onChange={(next) => onQuickFilterColumnChange?.(next || null)}
               aria-label="Quick filter column"
               title="Text column searched by the quick filter (numeric values match the id/primary key)"
-            >
-              {textColumns.map((column) => (
-                <option key={column.key} value={column.key}>
-                  {column.name}
-                </option>
-              ))}
-            </select>
+            />
           )}
           {quickActive && (
             <button
@@ -284,56 +283,52 @@ export function FilterBar({
             }}
           >
             {filters.length > 0 && !draft.id && (
-              <select
-                className="grid-filter-select grid-filter-logic-select"
+              <GridSelect
+                className="grid-filter-logic-select"
                 value={draft.logic}
-                onChange={(e) =>
-                  setDraft({ ...draft, logic: e.target.value as FilterLogic })
+                options={[
+                  { value: "and", label: "and" },
+                  { value: "or", label: "or" },
+                ]}
+                onChange={(next) =>
+                  setDraft({ ...draft, logic: next as FilterLogic })
                 }
                 aria-label="Filter join"
-              >
-                <option value="and">and</option>
-                <option value="or">or</option>
-              </select>
+              />
             )}
-            <select
+            <GridSelect
               ref={columnRef}
-              className="grid-filter-select"
               value={draft.columnKey}
-              onChange={(e) => {
-                const nextColumn = columnsByKey.get(e.target.value);
+              options={columns.map((column) => ({
+                value: column.key,
+                label: column.name,
+              }))}
+              onChange={(next) => {
+                const nextColumn = columnsByKey.get(next);
                 if (!nextColumn) return;
                 const operator = nextOperatorForColumn(nextColumn, draft.operator);
                 setDraft({ ...draft, columnKey: nextColumn.key, operator });
               }}
               aria-label="Filter column"
-            >
-              {columns.map((column) => (
-                <option key={column.key} value={column.key}>
-                  {column.name}
-                </option>
-              ))}
-            </select>
-            <select
-              className="grid-filter-select grid-filter-operator-select"
+            />
+            <GridSelect
+              className="grid-filter-operator-select"
               value={draft.operator}
-              onChange={(e) =>
+              options={draftOperators.map((operator) => ({
+                value: operator,
+                label: filterOperatorLabel(operator),
+              }))}
+              onChange={(next) =>
                 setDraft({
                   ...draft,
-                  operator: e.target.value as FilterOperator,
-                  value: filterNeedsValue(e.target.value as FilterOperator)
+                  operator: next as FilterOperator,
+                  value: filterNeedsValue(next as FilterOperator)
                     ? draft.value
                     : "",
                 })
               }
               aria-label="Filter operator"
-            >
-              {draftOperators.map((operator) => (
-                <option key={operator} value={operator}>
-                  {filterOperatorLabel(operator)}
-                </option>
-              ))}
-            </select>
+            />
             {needsValue && (
               <input
                 ref={valueRef}

--- a/packages/data-grid/src/GridSelect.tsx
+++ b/packages/data-grid/src/GridSelect.tsx
@@ -1,0 +1,151 @@
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { GridIcon } from "./icons";
+
+export type GridSelectOption = { value: string; label: string };
+
+type GridSelectProps = {
+  value: string;
+  options: readonly GridSelectOption[];
+  onChange: (value: string) => void;
+  className?: string;
+  "aria-label": string;
+  title?: string;
+};
+
+/**
+ * Styled replacement for a native `<select>` so the dropdown matches the app
+ * theme instead of the OS menu. Renders the menu in a portal with fixed
+ * positioning because the filter bar clips overflow.
+ */
+export const GridSelect = forwardRef<HTMLButtonElement, GridSelectProps>(
+  function GridSelect({ value, options, onChange, className, title, ...aria }, ref) {
+    const buttonRef = useRef<HTMLButtonElement | null>(null);
+    useImperativeHandle(ref, () => buttonRef.current!, []);
+    const menuRef = useRef<HTMLDivElement | null>(null);
+    const [open, setOpen] = useState(false);
+    const [active, setActive] = useState(0);
+    const [pos, setPos] = useState({ left: 0, top: 0, minWidth: 0 });
+
+    const openMenu = () => {
+      const rect = buttonRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      // The app scales the UI with CSS `zoom` on <body> (font-size setting).
+      // The portaled menu lives inside that zoomed body, so its fixed coords
+      // are in zoomed space while getBoundingClientRect() is in viewport
+      // pixels — divide by the zoom to line them up.
+      const zoom =
+        Number(
+          (getComputedStyle(document.body) as CSSStyleDeclaration & { zoom?: string }).zoom,
+        ) || 1;
+      setPos({
+        left: rect.left / zoom,
+        top: (rect.bottom + 2) / zoom,
+        minWidth: rect.width / zoom,
+      });
+      const current = options.findIndex((option) => option.value === value);
+      setActive(current >= 0 ? current : 0);
+      setOpen(true);
+    };
+
+    useEffect(() => {
+      if (!open) return;
+      const onPointerDown = (e: MouseEvent) => {
+        const target = e.target as Node;
+        if (menuRef.current?.contains(target)) return;
+        if (buttonRef.current?.contains(target)) return;
+        setOpen(false);
+      };
+      const close = () => setOpen(false);
+      window.addEventListener("mousedown", onPointerDown);
+      window.addEventListener("scroll", close, true);
+      window.addEventListener("resize", close);
+      return () => {
+        window.removeEventListener("mousedown", onPointerDown);
+        window.removeEventListener("scroll", close, true);
+        window.removeEventListener("resize", close);
+      };
+    }, [open]);
+
+    const select = (option: GridSelectOption) => {
+      setOpen(false);
+      if (option.value !== value) onChange(option.value);
+      buttonRef.current?.focus();
+    };
+
+    const onKeyDown = (e: React.KeyboardEvent) => {
+      if (!open) {
+        if (e.key === "ArrowDown" || e.key === "ArrowUp" || e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          e.stopPropagation();
+          openMenu();
+        }
+        return;
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        setOpen(false);
+        return;
+      }
+      if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+        e.preventDefault();
+        const delta = e.key === "ArrowDown" ? 1 : -1;
+        setActive((prev) => (prev + delta + options.length) % options.length);
+        return;
+      }
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        e.stopPropagation();
+        const option = options[active];
+        if (option) select(option);
+      }
+    };
+
+    const selected = options.find((option) => option.value === value);
+
+    return (
+      <>
+        <button
+          ref={buttonRef}
+          type="button"
+          className={`grid-select ${className ?? ""}`}
+          title={title}
+          aria-haspopup="listbox"
+          aria-expanded={open}
+          {...aria}
+          onClick={() => (open ? setOpen(false) : openMenu())}
+          onKeyDown={onKeyDown}
+        >
+          <span className="grid-select-label">{selected?.label ?? value}</span>
+          <GridIcon.chevronDown size={8} />
+        </button>
+        {open &&
+          createPortal(
+            <div
+              ref={menuRef}
+              className="grid-select-menu"
+              role="listbox"
+              style={{ left: pos.left, top: pos.top, minWidth: pos.minWidth }}
+            >
+              {options.map((option, index) => (
+                <div
+                  key={option.value}
+                  role="option"
+                  aria-selected={option.value === value}
+                  className={`grid-select-option${index === active ? " is-active" : ""}${
+                    option.value === value ? " is-selected" : ""
+                  }`}
+                  onMouseEnter={() => setActive(index)}
+                  onClick={() => select(option)}
+                >
+                  {option.label}
+                </div>
+              ))}
+            </div>,
+            document.body,
+          )}
+      </>
+    );
+  },
+);

--- a/packages/data-grid/src/GridSelect.tsx
+++ b/packages/data-grid/src/GridSelect.tsx
@@ -1,4 +1,11 @@
-import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react";
 import { createPortal } from "react-dom";
 import { GridIcon } from "./icons";
 
@@ -33,10 +40,12 @@ export const GridSelect = forwardRef<HTMLButtonElement, GridSelectProps>(
       // The app scales the UI with CSS `zoom` on <body> (font-size setting).
       // The portaled menu lives inside that zoomed body, so its fixed coords
       // are in zoomed space while getBoundingClientRect() is in viewport
-      // pixels — divide by the zoom to line them up.
+      // pixels — divide by the scale to line them up. Read the app's
+      // --ui-scale variable (set alongside the zoom) rather than the computed
+      // `zoom` value, which some webview engines don't report.
       const zoom =
         Number(
-          (getComputedStyle(document.body) as CSSStyleDeclaration & { zoom?: string }).zoom,
+          getComputedStyle(document.documentElement).getPropertyValue("--ui-scale"),
         ) || 1;
       setPos({
         left: rect.left / zoom,
@@ -73,7 +82,7 @@ export const GridSelect = forwardRef<HTMLButtonElement, GridSelectProps>(
       buttonRef.current?.focus();
     };
 
-    const onKeyDown = (e: React.KeyboardEvent) => {
+    const onKeyDown = (e: KeyboardEvent) => {
       if (!open) {
         if (e.key === "ArrowDown" || e.key === "ArrowUp" || e.key === "Enter" || e.key === " ") {
           e.preventDefault();

--- a/packages/data-grid/src/filters.test.ts
+++ b/packages/data-grid/src/filters.test.ts
@@ -110,7 +110,9 @@ describe("operatorsForColumn", () => {
       "equals",
       "notEquals",
       "greaterThan",
+      "greaterThanOrEqual",
       "lessThan",
+      "lessThanOrEqual",
     ]);
     expect(operatorsForColumn(columns[4]!)).toEqual(["equals", "notEquals"]);
   });
@@ -132,5 +134,65 @@ describe("evaluateFilterClause", () => {
         logic: "and",
       }),
     ).toBe(true);
+  });
+
+  it("handles >=, <=, ends with, and not contains", () => {
+    const numClause = (operator: "greaterThanOrEqual" | "lessThanOrEqual", value: string) =>
+      evaluateFilterClause(100, columns[1]!, {
+        id: "a",
+        columnKey: "total",
+        operator,
+        value,
+        logic: "and",
+      });
+    expect(numClause("greaterThanOrEqual", "100")).toBe(true);
+    expect(numClause("greaterThanOrEqual", "101")).toBe(false);
+    expect(numClause("lessThanOrEqual", "100")).toBe(true);
+    expect(numClause("lessThanOrEqual", "99")).toBe(false);
+
+    const textClause = (operator: "endsWith" | "notContains", value: string) =>
+      evaluateFilterClause("invoice", columns[0]!, {
+        id: "a",
+        columnKey: columns[0]!.key,
+        operator,
+        value,
+        logic: "and",
+      });
+    expect(textClause("endsWith", "ice")).toBe(true);
+    expect(textClause("endsWith", "inv")).toBe(false);
+    expect(textClause("notContains", "xyz")).toBe(true);
+    expect(textClause("notContains", "voi")).toBe(false);
+  });
+
+  it("matches SQL LIKE patterns with % and _", () => {
+    const like = (pattern: string) =>
+      evaluateFilterClause("invoice", columns[0]!, {
+        id: "a",
+        columnKey: columns[0]!.key,
+        operator: "like",
+        value: pattern,
+        logic: "and",
+      });
+    expect(like("inv%")).toBe(true);
+    expect(like("%voice")).toBe(true);
+    expect(like("inv_ice")).toBe(true);
+    expect(like("invoice")).toBe(true);
+    // No wildcards → implicit %contains%.
+    expect(like("voice")).toBe(true);
+    expect(like("vo")).toBe(true);
+    expect(like("xyz")).toBe(false);
+    expect(like("inv.ice")).toBe(false);
+    // Any explicit wildcard → exact SQL semantics.
+    expect(like("voice%")).toBe(false);
+  });
+
+  it("offers text operators for guid columns", () => {
+    const guidColumn: GridColumn = {
+      key: "id",
+      name: "id",
+      type: "uniqueidentifier",
+      width: 120,
+    };
+    expect(operatorsForColumn(guidColumn)).toContain("contains");
   });
 });

--- a/packages/data-grid/src/filters.ts
+++ b/packages/data-grid/src/filters.ts
@@ -14,9 +14,14 @@ export const FILTER_OPERATORS: readonly {
   { value: "equals", label: "=", needsValue: true },
   { value: "notEquals", label: "!=", needsValue: true },
   { value: "contains", label: "contains", needsValue: true },
+  { value: "notContains", label: "not contains", needsValue: true },
   { value: "startsWith", label: "starts with", needsValue: true },
+  { value: "endsWith", label: "ends with", needsValue: true },
+  { value: "like", label: "like", needsValue: true },
   { value: "greaterThan", label: ">", needsValue: true },
+  { value: "greaterThanOrEqual", label: ">=", needsValue: true },
   { value: "lessThan", label: "<", needsValue: true },
+  { value: "lessThanOrEqual", label: "<=", needsValue: true },
   { value: "isNull", label: "is null", needsValue: false },
   { value: "isNotNull", label: "is not null", needsValue: false },
 ];
@@ -44,7 +49,17 @@ const NUMERIC_TYPES = [
 
 const DATE_TYPES = ["date", "time", "timestamp", "timestamptz", "timetz"];
 const BOOL_TYPES = ["bool", "boolean"];
-const TEXT_TYPES = ["text", "char", "varchar", "citext", "uuid", "json", "jsonb"];
+const TEXT_TYPES = [
+  "text",
+  "char",
+  "varchar",
+  "citext",
+  "uuid",
+  "guid",
+  "uniqueidentifier",
+  "json",
+  "jsonb",
+];
 
 function operatorMeta(operator: FilterOperator) {
   return FILTER_OPERATORS.find((op) => op.value === operator) ?? FILTER_OPERATORS[0]!;
@@ -63,11 +78,11 @@ export function operatorsForColumn(column: GridColumn): FilterOperator[] {
   const category = columnCategory(column);
 
   if (category === "text") {
-    base.push("contains", "startsWith");
+    base.push("contains", "notContains", "startsWith", "endsWith", "like");
   }
 
   if (category === "number" || category === "date") {
-    base.push("greaterThan", "lessThan");
+    base.push("greaterThan", "greaterThanOrEqual", "lessThan", "lessThanOrEqual");
   }
 
   if (column.nullable) {
@@ -143,7 +158,12 @@ export function evaluateFilterClause(
   if (needle.length === 0) return true;
 
   const category = columnCategory(column);
-  if (clause.operator === "greaterThan" || clause.operator === "lessThan") {
+  if (
+    clause.operator === "greaterThan" ||
+    clause.operator === "greaterThanOrEqual" ||
+    clause.operator === "lessThan" ||
+    clause.operator === "lessThanOrEqual"
+  ) {
     return compareOrdered(value, needle, category, clause.operator);
   }
 
@@ -153,7 +173,10 @@ export function evaluateFilterClause(
   if (clause.operator === "equals") return current === expected;
   if (clause.operator === "notEquals") return current !== expected;
   if (clause.operator === "contains") return current.includes(expected);
+  if (clause.operator === "notContains") return !current.includes(expected);
   if (clause.operator === "startsWith") return current.startsWith(expected);
+  if (clause.operator === "endsWith") return current.endsWith(expected);
+  if (clause.operator === "like") return likeMatch(current, expected);
   return true;
 }
 
@@ -179,7 +202,7 @@ function compareOrdered(
   value: GridRow[string],
   needle: string,
   category: ReturnType<typeof columnCategory>,
-  operator: "greaterThan" | "lessThan",
+  operator: "greaterThan" | "greaterThanOrEqual" | "lessThan" | "lessThanOrEqual",
 ): boolean {
   if (value === null || value === undefined) return false;
 
@@ -196,7 +219,32 @@ function compareOrdered(
   }
 
   if (!Number.isFinite(left) || !Number.isFinite(right)) return false;
-  return operator === "greaterThan" ? left > right : left < right;
+  switch (operator) {
+    case "greaterThan":
+      return left > right;
+    case "greaterThanOrEqual":
+      return left >= right;
+    case "lessThan":
+      return left < right;
+    case "lessThanOrEqual":
+      return left <= right;
+  }
+}
+
+/**
+ * SQL LIKE semantics: `%` matches any run, `_` matches one char. Case-insensitive.
+ * A pattern with no wildcards is treated as `%pattern%` so plain text "just works";
+ * typing any `%`/`_` switches to exact SQL semantics.
+ */
+function likeMatch(value: string, pattern: string): boolean {
+  if (!pattern.includes("%") && !pattern.includes("_")) {
+    pattern = `%${pattern}%`;
+  }
+  const regex = pattern
+    .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+    .replaceAll("%", ".*")
+    .replaceAll("_", ".");
+  return new RegExp(`^${regex}$`).test(value);
 }
 
 function columnCategory(

--- a/packages/data-grid/src/filters.ts
+++ b/packages/data-grid/src/filters.ts
@@ -232,15 +232,17 @@ function compareOrdered(
 }
 
 /**
- * SQL LIKE semantics: `%` matches any run, `_` matches one char. Case-insensitive.
- * A pattern with no wildcards is treated as `%pattern%` so plain text "just works";
- * typing any `%`/`_` switches to exact SQL semantics.
+ * A `like` pattern with no wildcards is treated as `%pattern%` so plain text
+ * "just works"; typing any `%`/`_` switches to exact SQL semantics. Shared with
+ * the server request builder so local and server-side matching agree.
  */
+export function normalizeLikePattern(pattern: string): string {
+  return pattern.includes("%") || pattern.includes("_") ? pattern : `%${pattern}%`;
+}
+
+/** SQL LIKE semantics: `%` matches any run, `_` matches one char. Case-insensitive. */
 function likeMatch(value: string, pattern: string): boolean {
-  if (!pattern.includes("%") && !pattern.includes("_")) {
-    pattern = `%${pattern}%`;
-  }
-  const regex = pattern
+  const regex = normalizeLikePattern(pattern)
     .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
     .replaceAll("%", ".*")
     .replaceAll("_", ".");

--- a/packages/data-grid/src/icons.tsx
+++ b/packages/data-grid/src/icons.tsx
@@ -42,6 +42,7 @@ export const GridIcon = {
   close: (p: IconProps) => <I {...p} d="M6 6l12 12M18 6L6 18" />,
   chevronLeft: (p: IconProps) => <I {...p} d="M15 18l-6-6 6-6" />,
   chevronRight: (p: IconProps) => <I {...p} d="M9 18l6-6-6-6" />,
+  chevronDown: (p: IconProps) => <I {...p} d="M6 9l6 6 6-6" />,
   undo: (p: IconProps) => <I {...p} d="M3 8h10a5 5 0 010 10H8M3 8l4-4M3 8l4 4" />,
   commit: (p: IconProps) => (
     <I {...p}>

--- a/packages/data-grid/src/index.ts
+++ b/packages/data-grid/src/index.ts
@@ -30,6 +30,7 @@ export {
   filterRows,
   filterValuePreview,
   nextOperatorForColumn,
+  normalizeLikePattern,
   operatorsForColumn,
   rowMatchesFilters,
 } from "./filters";

--- a/packages/data-grid/src/types.ts
+++ b/packages/data-grid/src/types.ts
@@ -74,9 +74,14 @@ export type FilterOperator =
   | "equals"
   | "notEquals"
   | "contains"
+  | "notContains"
   | "startsWith"
+  | "endsWith"
+  | "like"
   | "greaterThan"
+  | "greaterThanOrEqual"
   | "lessThan"
+  | "lessThanOrEqual"
   | "isNull"
   | "isNotNull";
 

--- a/packages/ipc/src/generated.ts
+++ b/packages/ipc/src/generated.ts
@@ -760,7 +760,11 @@ export type TableFilterClause = { column: string; operator: TableFilterOperator;
  * instead of overloading this field.
  */
 value: string | null }
-export type TableFilterOperator = "equals" | "not_equals" | "contains" | "is_null" | "is_not_null" | "greater_than" | "greater_than_or_equal" | "less_than" | "less_than_or_equal"
+export type TableFilterOperator = "equals" | "not_equals" | "contains" | "not_contains" | "starts_with" | "ends_with" | 
+/**
+ * Raw SQL LIKE pattern (`%`/`_` supplied by the user), matched case-insensitively.
+ */
+"like" | "is_null" | "is_not_null" | "greater_than" | "greater_than_or_equal" | "less_than" | "less_than_or_equal"
 export type TableSortClause = { column: string; direction: SortDirection }
 /**
  * What kind of database object references a searched table or column. Returned

--- a/packages/ipc/src/index.test.ts
+++ b/packages/ipc/src/index.test.ts
@@ -35,6 +35,7 @@ describe("@cellar/ipc", () => {
         "erGraph",
         "explainQuery",
         "findUsages",
+        "importDatagrip",
         "introspect",
         "listQueryHistory",
         "listConnections",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,9 +104,15 @@ importers:
       '@types/react':
         specifier: ^18.3.3
         version: 18.3.29
+      '@types/react-dom':
+        specifier: ^18.3.0
+        version: 18.3.7(@types/react@18.3.29)
       react:
         specifier: ^18.3.1
         version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
 
   packages/ipc:
     dependencies:


### PR DESCRIPTION
Adds `>=`, `<=`, `not contains`, `ends with`, and `like` (plain text implicitly matches as `%value%`; explicit `%`/`_` use exact SQL semantics) to the data-grid where-clause filter bar. Recognizes `guid`/`uniqueidentifier` columns as text so they get the full operator set, and fixes the server-side "table load failed" by allowing `contains` on uniqueidentifier (SQL Server) and uuid via `::text` cast (Postgres). Replaces the native `<select>` popups with a themed `GridSelect` dropdown, positioned correctly under the app's CSS zoom font scaling. Also restyles the apply button so the enabled state no longer looks disabled. Covered by new vitest and Rust driver tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a custom grid dropdown (GridSelect) for filter controls with keyboard navigation and improved fixed positioning.
  * Added new filtering operators (ends with, not contains, like) plus inclusive comparisons (≥, ≤) with consistent pattern matching.
  * Added a chevron-down icon for grid controls.
* **Bug Fixes**
  * Improved text/pattern filtering for UUID/GUID (casts/compatibility), including correct server-side clause mapping.
  * Standardized LIKE/wildcard handling across database browsing to match expected semantics.
* **Style**
  * Refreshed grid select and filter apply button styling.
* **Chores**
  * Updated data-grid package metadata for React DOM; re-exported like-pattern normalization helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->