### PR TITLE
Add order by control to the data grid filter bar

### DIFF
--- a/apps/desktop/src/styles/grid.css
+++ b/apps/desktop/src/styles/grid.css
@@ -207,6 +207,16 @@
   font-size: 10.5px;
 }
 
+/* ── order by (pinned before the row summary) ─────────────── */
+.grid-orderby {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+  padding-left: 8px;
+  border-left: 1px solid var(--border-default);
+}
+
 /* ── quick filter (pinned, alongside advanced chips) ──────── */
 .grid-quickfilter {
   display: inline-flex;

--- a/packages/data-grid/src/DataGrid.tsx
+++ b/packages/data-grid/src/DataGrid.tsx
@@ -704,6 +704,8 @@ export function DataGrid({
         totalRows={rows.length}
         filteredRows={visibleRows.length}
         serverRows={totalRows}
+        sort={activeSort}
+        onSortChange={applySort}
       />
 
       <div

--- a/packages/data-grid/src/FilterBar.tsx
+++ b/packages/data-grid/src/FilterBar.tsx
@@ -14,6 +14,7 @@ import type {
   FilterLogic,
   FilterOperator,
   GridColumn,
+  SortState,
 } from "./types";
 
 type ComposerDraft = {
@@ -40,6 +41,8 @@ export type FilterBarProps = {
   totalRows: number;
   filteredRows: number;
   serverRows?: number;
+  sort?: SortState;
+  onSortChange?: (next: SortState) => void;
 };
 
 export function FilterBar({
@@ -53,6 +56,8 @@ export function FilterBar({
   totalRows,
   filteredRows,
   serverRows,
+  sort,
+  onSortChange,
 }: FilterBarProps) {
   const [draft, setDraft] = useState<ComposerDraft | null>(null);
   const columnRef = useRef<HTMLSelectElement | null>(null);
@@ -386,6 +391,54 @@ export function FilterBar({
           </button>
         )}
       </div>
+      {onSortChange && (
+        <div className="grid-orderby">
+          <span className="grid-filterbar-label">
+            {sort?.direction === "desc" ? (
+              <GridIcon.sortDesc size={11} style={{ color: "var(--accent)" }} />
+            ) : (
+              <GridIcon.sortAsc
+                size={11}
+                style={{ color: sort ? "var(--accent)" : "var(--fg-3)" }}
+              />
+            )}
+            <span>order by</span>
+          </span>
+          <select
+            className="grid-filter-select"
+            value={sort?.columnKey ?? ""}
+            onChange={(e) =>
+              onSortChange(
+                e.target.value
+                  ? { columnKey: e.target.value, direction: sort?.direction ?? "asc" }
+                  : null,
+              )
+            }
+            aria-label="Order by column"
+          >
+            <option value="">—</option>
+            {columns.map((column) => (
+              <option key={column.key} value={column.key}>
+                {column.name}
+              </option>
+            ))}
+          </select>
+          {sort && (
+            <button
+              className="grid-filter-logic"
+              onClick={() =>
+                onSortChange({
+                  columnKey: sort.columnKey,
+                  direction: sort.direction === "asc" ? "desc" : "asc",
+                })
+              }
+              title="Toggle sort direction"
+            >
+              {sort.direction}
+            </button>
+          )}
+        </div>
+      )}
       <div
         className="grid-filterbar-summary mono"
         title={


### PR DESCRIPTION
Adds a DataGrip-style "order by" section to the grid's top filter bar, pinned before the row-count summary. It exposes the grid's existing single-column sort state via a column dropdown (with a clear option) and an asc/desc toggle, staying in sync with header-click sorting and the server query. Includes a small CSS rule for the new container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “order by” control to the data grid filter bar for sorting results directly from the UI.
  * Users can choose a column, switch between ascending and descending order, or clear sorting.
* **Style**
  * Added styling for the new sort control to match the existing grid layout and theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->