### PR TITLE
fix: increase desktop interface font sizes

### DIFF
--- a/apps/desktop/src/components/AIMessage.tsx
+++ b/apps/desktop/src/components/AIMessage.tsx
@@ -46,19 +46,19 @@ function CodeBlock({ lang, code }: { lang: string; code: string }) {
   return (
     <div className="overflow-hidden rounded-[5px] border border-border-default bg-bg-inset">
       <div className="flex items-center justify-between border-b border-border-divider px-2 py-1">
-        <span className="font-mono text-[9.5px] uppercase tracking-[0.05em] text-fg-3">
+        <span className="font-mono text-[10.5px] uppercase tracking-[0.05em] text-fg-3">
           {lang || "code"}
         </span>
         <button
           onClick={copy}
-          className="inline-flex items-center gap-1 rounded-[3px] px-1 text-[10px] text-fg-2 hover:bg-bg-3 hover:text-fg-0"
+          className="inline-flex items-center gap-1 rounded-[3px] px-1 text-[11px] text-fg-2 hover:bg-bg-3 hover:text-fg-0"
           title="Copy"
         >
           <Icon.copy size={10} />
           <span>{copied ? "copied" : "copy"}</span>
         </button>
       </div>
-      <pre className="overflow-x-auto px-2.5 py-2 font-mono text-[11.5px] leading-[1.5] text-fg-0">
+      <pre className="overflow-x-auto px-2.5 py-2 font-mono text-sm leading-[1.5] text-fg-0">
         {SQL_LANGS.test(lang.trim()) ? (
           tokensToLines(tokenizeSql(code)).map((toks, i) => (
             <div key={i} className="whitespace-pre">
@@ -79,11 +79,11 @@ export function AIMessage({ entry }: { entry: AiChatEntry }) {
       <div className="flex flex-col items-end gap-1">
         <div className="max-w-[88%] rounded-[7px] rounded-tr-[2px] border border-accent-line bg-accent-soft px-2.5 py-1.5">
           {entry.topic && entry.topic !== "ask" && (
-            <span className="mb-0.5 block font-mono text-[9.5px] uppercase tracking-[0.05em] text-accent opacity-80">
+            <span className="mb-0.5 block font-mono text-[10.5px] uppercase tracking-[0.05em] text-accent opacity-80">
               {entry.topic}
             </span>
           )}
-          <div className="whitespace-pre-wrap text-[12px] leading-[1.5] text-fg-0">
+          <div className="whitespace-pre-wrap text-sm leading-[1.5] text-fg-0">
             {entry.content || <span className="text-fg-3 italic">(empty)</span>}
           </div>
         </div>
@@ -93,7 +93,7 @@ export function AIMessage({ entry }: { entry: AiChatEntry }) {
 
   if (entry.error) {
     return (
-      <div className="flex items-start gap-2 rounded-[6px] border border-delete-line bg-delete-bg px-2.5 py-2 text-[11.5px] text-delete">
+      <div className="flex items-start gap-2 rounded-[6px] border border-delete-line bg-delete-bg px-2.5 py-2 text-sm text-delete">
         <span className="mt-px shrink-0">
           <Icon.warn size={12} />
         </span>
@@ -111,14 +111,14 @@ export function AIMessage({ entry }: { entry: AiChatEntry }) {
         ) : (
           <div
             key={i}
-            className="whitespace-pre-wrap text-[12px] leading-[1.55] text-fg-1"
+            className="whitespace-pre-wrap text-sm leading-[1.55] text-fg-1"
           >
             {seg.text}
           </div>
         ),
       )}
       {entry.usage && (
-        <div className="text-[9.5px] text-fg-3">
+        <div className="text-[10.5px] text-fg-3">
           {entry.usage.totalTokens} tokens · {entry.usage.promptTokens} in /{" "}
           {entry.usage.completionTokens} out
         </div>

--- a/apps/desktop/src/components/AIPanel.tsx
+++ b/apps/desktop/src/components/AIPanel.tsx
@@ -16,16 +16,16 @@ const chipMeta: Record<AiContextChip["kind"], { icon: ReactNode; color: string }
 function ContextChip({ chip }: { chip: AiContextChip }) {
   const m = chipMeta[chip.kind];
   return (
-    <span className="inline-flex h-5 items-center gap-1 whitespace-nowrap rounded-[4px] border border-border-default bg-bg-1 px-1.5 pl-[5px] text-[10.5px] text-fg-1">
+    <span className="inline-flex h-5 items-center gap-1 whitespace-nowrap rounded-[4px] border border-border-default bg-bg-1 px-1.5 pl-[5px] text-[11.5px] text-fg-1">
       <span
-        className="inline-flex items-center gap-[3px] text-[9.5px] lowercase opacity-85"
+        className="inline-flex items-center gap-[3px] text-[10.5px] lowercase opacity-85"
         style={{ color: m.color }}
       >
         {m.icon}
         <span>{chip.kind}</span>
       </span>
       <span className="text-fg-3">:</span>
-      <span className="font-mono text-[10.5px] text-fg-0">{chip.value}</span>
+      <span className="font-mono text-[11.5px] text-fg-0">{chip.value}</span>
     </span>
   );
 }
@@ -90,16 +90,16 @@ export function AIPanel({
   };
 
   return (
-    <div className="flex h-full flex-col bg-bg-1 text-[12.5px]">
+    <div className="flex h-full flex-col bg-bg-1 text-[13.5px]">
       <div className="flex h-8 shrink-0 items-center justify-between border-b border-border-default pl-2.5 pr-2">
-        <div className="flex min-w-0 flex-1 items-center gap-1.5 text-[11.5px]">
+        <div className="flex min-w-0 flex-1 items-center gap-1.5 text-[12.5px]">
           <span className="inline-flex text-accent">
             <Icon.sparkles size={12} />
           </span>
           <span className="whitespace-nowrap font-semibold text-fg-0">
             AI Assistant
           </span>
-          <span className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap font-mono text-[10.5px] text-fg-2">
+          <span className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap font-mono text-[11.5px] text-fg-2">
             {modelId ? `· ${modelId}` : "· not configured"}
           </span>
         </div>
@@ -135,7 +135,7 @@ export function AIPanel({
       </div>
 
       <div className="flex shrink-0 flex-wrap items-start gap-1.5 border-b border-border-default bg-bg-2 px-2 pt-1.5 pb-[7px]">
-        <div className="inline-flex h-[18px] shrink-0 items-center gap-1 pt-0.5 text-[10px] font-semibold uppercase tracking-[0.05em] text-fg-3">
+        <div className="inline-flex h-[18px] shrink-0 items-center gap-1 pt-0.5 text-[11px] font-semibold uppercase tracking-[0.05em] text-fg-3">
           <Icon.context size={10} />
           <span>context</span>
         </div>
@@ -145,7 +145,7 @@ export function AIPanel({
               <ContextChip key={`${chip.kind}-${i}`} chip={chip} />
             ))
           ) : (
-            <span className="inline-flex h-5 items-center text-[10.5px] text-fg-3">
+            <span className="inline-flex h-5 items-center text-[11.5px] text-fg-3">
               no active connection
             </span>
           )}
@@ -154,19 +154,19 @@ export function AIPanel({
 
       <div className="flex flex-1 flex-col gap-3 overflow-y-auto px-2.5 pt-3 pb-4">
         {messages.length === 0 ? (
-          <div className="flex flex-1 flex-col items-center justify-center gap-1.5 p-6 text-center text-[11.5px] text-fg-3">
+          <div className="flex flex-1 flex-col items-center justify-center gap-1.5 p-6 text-center text-[12.5px] text-fg-3">
             <span className="mb-1 text-accent">
               <Icon.sparkles size={22} />
             </span>
-            <div className="text-[12px] font-medium text-fg-1">Ask Cellar AI</div>
-            <div className="max-w-[280px] text-[10.5px] leading-[1.5] text-fg-3">
+            <div className="text-sm font-medium text-fg-1">Ask Cellar AI</div>
+            <div className="max-w-[280px] text-[11.5px] leading-[1.5] text-fg-3">
               Generate SQL with full schema context, explain a result, or have it
               review a slow query. Bring your own API key; Cellar never proxies.
             </div>
             {!ready && (
               <button
                 onClick={onOpenSettings}
-                className="mt-2 inline-flex h-[24px] items-center gap-1.5 rounded-[5px] border border-accent-line bg-accent-soft px-2.5 text-[11px] font-medium text-accent hover:brightness-110"
+                className="mt-2 inline-flex h-[24px] items-center gap-1.5 rounded-[5px] border border-accent-line bg-accent-soft px-2.5 text-[12px] font-medium text-accent hover:brightness-110"
               >
                 <Icon.settings size={11} />
                 <span>
@@ -179,7 +179,7 @@ export function AIPanel({
           messages.map((m) => <AIMessage key={m.id} entry={m} />)
         )}
         {sending && (
-          <div className="flex items-center gap-2 px-1 text-[11px] text-fg-3">
+          <div className="flex items-center gap-2 px-1 text-[12px] text-fg-3">
             <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-accent" />
             <span>thinking…</span>
           </div>
@@ -196,7 +196,7 @@ export function AIPanel({
                 onClick={() => pickTopic(t)}
                 title={TOPICS[t].hint}
                 className={
-                  "inline-flex h-[22px] items-center gap-1 rounded-[4px] px-2 text-[11px] transition-colors " +
+                  "inline-flex h-[22px] items-center gap-1 rounded-[4px] px-2 text-[12px] transition-colors " +
                   (active
                     ? "bg-accent-soft text-accent"
                     : "text-fg-2 hover:bg-bg-2 hover:text-fg-1")
@@ -208,7 +208,7 @@ export function AIPanel({
             );
           })}
           <div className="flex-1" />
-          <span className="inline-flex h-[22px] items-center gap-1 rounded-[4px] px-2 text-[10.5px] text-fg-3">
+          <span className="inline-flex h-[22px] items-center gap-1 rounded-[4px] px-2 text-[11.5px] text-fg-3">
             <span style={{ color: topic === "ask" ? "var(--accent)" : "var(--fg-2)" }}>
               ask
             </span>
@@ -228,7 +228,7 @@ export function AIPanel({
             onKeyDown={onKeyDown}
             rows={2}
             disabled={!ready}
-            className="w-full resize-none rounded-[5px] border border-border-default bg-bg-inset px-2 py-[7px] text-[12px] leading-[1.45] text-fg-0 outline-none placeholder:text-fg-3 focus:border-accent-line font-sans min-h-[50px] disabled:opacity-60"
+            className="w-full resize-none rounded-[5px] border border-border-default bg-bg-inset px-2 py-[7px] text-sm leading-[1.45] text-fg-0 outline-none placeholder:text-fg-3 focus:border-accent-line font-sans min-h-[50px] disabled:opacity-60"
           />
           <div className="mt-1.5 flex items-center justify-between">
             <div className="flex items-center gap-1">
@@ -239,7 +239,7 @@ export function AIPanel({
               >
                 <Icon.paperclip size={11} />
               </button>
-              <span className="ml-1 inline-flex items-center gap-[3px] text-[10.5px]">
+              <span className="ml-1 inline-flex items-center gap-[3px] text-[11.5px]">
                 {ready ? (
                   <span style={{ color: "var(--fg-3)" }}>
                     {topic} · {modelId}
@@ -257,7 +257,7 @@ export function AIPanel({
             <button
               onClick={submit}
               disabled={!canSend}
-              className="inline-flex h-[22px] items-center gap-1.5 rounded-[4px] bg-accent px-2 text-[11px] font-medium text-accent-fg hover:brightness-[1.07] disabled:opacity-40 disabled:hover:brightness-100"
+              className="inline-flex h-[22px] items-center gap-1.5 rounded-[4px] bg-accent px-2 text-[12px] font-medium text-accent-fg hover:brightness-[1.07] disabled:opacity-40 disabled:hover:brightness-100"
             >
               <span>Send</span>
               <Icon.send size={11} />

--- a/apps/desktop/src/components/BottomMessagesPanel.tsx
+++ b/apps/desktop/src/components/BottomMessagesPanel.tsx
@@ -49,7 +49,7 @@ export function MessagesView({
             />
           ))}
         </div>
-        <div className="font-mono text-[10px] text-fg-3">
+        <div className="font-mono text-[12px] text-fg-3">
           {messages.length === 0 ? "no messages" : `${messages.length} total`}
         </div>
       </div>
@@ -65,7 +65,7 @@ export function MessagesView({
         />
       ) : (
         <div className="min-h-0 flex-1 overflow-auto">
-          <div className="grid min-w-[720px] grid-cols-[92px_74px_86px_minmax(220px,1fr)_160px] border-b border-border-divider px-2 py-1 font-mono text-[10px] uppercase text-fg-3">
+          <div className="grid min-w-[720px] grid-cols-[92px_74px_86px_minmax(220px,1fr)_160px] border-b border-border-divider px-2 py-1 font-mono text-[12px] uppercase text-fg-3">
             <span>time</span>
             <span>level</span>
             <span>source</span>
@@ -96,7 +96,7 @@ function SeverityFilter({
     <button
       onClick={onClick}
       className={
-        "inline-flex h-[22px] items-center gap-1 rounded-[4px] px-2 font-mono text-[10.5px] " +
+        "inline-flex h-[22px] items-center gap-1 rounded-[4px] px-2 font-mono text-[12px] " +
         (active
           ? "bg-accent-soft text-accent"
           : "text-fg-2 hover:bg-bg-2 hover:text-fg-0")
@@ -110,7 +110,7 @@ function SeverityFilter({
 
 function MessageRow({ message }: { message: QueryMessage }) {
   return (
-    <div className="grid min-w-[720px] grid-cols-[92px_74px_86px_minmax(220px,1fr)_160px] items-start border-b border-border-subtle px-2 py-1.5 font-mono text-[10.5px] leading-[1.45] hover:bg-bg-1">
+    <div className="grid min-w-[720px] grid-cols-[92px_74px_86px_minmax(220px,1fr)_160px] items-start border-b border-border-subtle px-2 py-1.5 font-mono text-sm leading-[1.45] hover:bg-bg-1">
       <span className="text-fg-3">{formatMessageTime(message.timestamp)}</span>
       <span className={severityClass(message.severity)}>{message.severity}</span>
       <span className="text-fg-2">{message.source}</span>
@@ -130,9 +130,9 @@ function EmptyMessagePanel({
   detail: string;
 }) {
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-1.5 bg-bg-inset p-6 text-center text-[11.5px] text-fg-3">
-      <div className="text-[12px] font-medium text-fg-1">{title}</div>
-      <div className="max-w-[460px] text-[10.5px] leading-[1.5] text-fg-3">
+    <div className="flex h-full flex-col items-center justify-center gap-1.5 bg-bg-inset p-6 text-center text-[12.5px] text-fg-3">
+      <div className="text-[13px] font-medium text-fg-1">{title}</div>
+      <div className="max-w-[460px] text-[11.5px] leading-[1.5] text-fg-3">
         {detail}
       </div>
     </div>

--- a/apps/desktop/src/components/BottomPanel.tsx
+++ b/apps/desktop/src/components/BottomPanel.tsx
@@ -170,7 +170,7 @@ export function BottomPanel({ onClose }: { onClose: () => void }) {
                 disabled={!t.enabled}
                 title={t.enabled ? t.label : `${t.label} is not wired yet`}
                 className={
-                  "mt-[3px] inline-flex h-[22px] items-center gap-1.5 rounded-[4px] px-2 text-[11px] disabled:cursor-default disabled:opacity-45 " +
+                  "mt-[3px] inline-flex h-[22px] items-center gap-1.5 rounded-[4px] px-2 text-sm disabled:cursor-default disabled:opacity-45 " +
                   (isActive
                     ? "bg-bg-3 text-fg-0"
                     : "text-fg-2 hover:bg-bg-2 hover:text-fg-0 disabled:hover:bg-transparent disabled:hover:text-fg-2")
@@ -183,7 +183,7 @@ export function BottomPanel({ onClose }: { onClose: () => void }) {
                 {t.count != null && (
                   <span
                     className={
-                      "rounded-[8px] px-1 py-px font-mono text-[9.5px] " +
+                      "rounded-[8px] px-1 py-px font-mono text-[10.5px] " +
                       (isActive ? "bg-bg-1 text-fg-0" : "bg-bg-2 text-fg-2")
                     }
                   >
@@ -290,7 +290,7 @@ function HeaderMeta({
   const items = headerItems(activeTab, result);
 
   return (
-    <div className="inline-flex min-w-0 items-center gap-1.5 overflow-hidden font-mono text-[10.5px]">
+    <div className="inline-flex min-w-0 items-center gap-1.5 overflow-hidden font-mono text-[11.5px]">
       {items.map((item, i) => (
         <span
           key={`${item}-${i}`}
@@ -659,7 +659,7 @@ function ReadOnlyResultGrid({
       </div>
       <ContextMenu state={copyMenu} onClose={() => setCopyMenu(null)} />
       {result.truncated && (
-        <div className="flex shrink-0 items-center justify-between border-t border-border-default bg-bg-1 px-3 py-1.5 text-[11px] text-fg-3">
+        <div className="flex shrink-0 items-center justify-between border-t border-border-default bg-bg-1 px-3 py-1.5 text-sm text-fg-3">
           <span>
             First {result.rowCount.toLocaleString("en-US")} rows shown
             {" — "}query result was truncated at the row cap.
@@ -667,7 +667,7 @@ function ReadOnlyResultGrid({
           {onLoadMore && (
             <button
               type="button"
-              className="rounded px-2 py-0.5 text-[11px] text-accent hover:bg-accent-soft"
+              className="rounded px-2 py-0.5 text-sm text-accent hover:bg-accent-soft"
               onClick={onLoadMore}
             >
               Load more
@@ -689,16 +689,16 @@ function EmptyPanel({
   tone?: "muted" | "warn";
 }) {
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-1.5 bg-bg-inset p-6 text-center text-[11.5px] text-fg-3">
+    <div className="flex h-full flex-col items-center justify-center gap-1.5 bg-bg-inset p-6 text-center text-sm text-fg-3">
       <div
         className={
-          "text-[12px] font-medium " +
+          "text-sm font-medium " +
           (tone === "warn" ? "text-warn" : "text-fg-1")
         }
       >
         {title}
       </div>
-      <div className="max-w-[460px] text-[10.5px] leading-[1.5] text-fg-3">
+      <div className="max-w-[460px] text-[11.5px] leading-[1.5] text-fg-3">
         {detail}
       </div>
     </div>
@@ -791,10 +791,10 @@ function HistoryPanel({
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Search SQL or errors"
-            className="h-6 w-full rounded-[4px] border border-border-default bg-bg-1 pl-6 pr-2 font-mono text-[11px] text-fg-1 outline-none placeholder:text-fg-4 focus:border-accent-line"
+            className="h-6 w-full rounded-[4px] border border-border-default bg-bg-1 pl-6 pr-2 font-mono text-sm text-fg-1 outline-none placeholder:text-fg-4 focus:border-accent-line"
           />
         </div>
-        <div className="min-w-0 truncate font-mono text-[10.5px] text-fg-3">
+        <div className="min-w-0 truncate font-mono text-[11.5px] text-fg-3">
           {scopeLabel}
         </div>
       </div>
@@ -855,7 +855,7 @@ function HistoryRow({
   return (
     <div className="group grid grid-cols-[minmax(0,1fr)_auto] gap-3 px-2.5 py-2 hover:bg-bg-1">
       <div className="min-w-0">
-        <div className="mb-1 flex min-w-0 items-center gap-1.5 text-[10.5px]">
+        <div className="mb-1 flex min-w-0 items-center gap-1.5 text-[11.5px]">
           <span
             className={
               "rounded-[3px] px-1 py-px font-mono " +
@@ -873,11 +873,11 @@ function HistoryRow({
           <span className="text-fg-4">·</span>
           <span className="truncate font-mono text-fg-3">{formatTimestamp(record.executed_at_ms)}</span>
         </div>
-        <pre className="m-0 max-h-[58px] overflow-hidden whitespace-pre-wrap break-words font-mono text-[11px] leading-[1.45] text-fg-1">
+        <pre className="m-0 max-h-[58px] overflow-hidden whitespace-pre-wrap break-words font-mono text-sm leading-[1.45] text-fg-1">
           {record.sql}
         </pre>
         {record.error_summary && (
-          <div className="mt-1 truncate font-mono text-[10.5px] text-delete">
+          <div className="mt-1 truncate font-mono text-[11.5px] text-delete">
             {record.error_summary}
           </div>
         )}
@@ -896,18 +896,18 @@ function HistoryRow({
 
 function EmptyHistory({ title, detail }: { title: string; detail?: string }) {
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-1.5 p-6 text-center text-[11.5px] text-fg-3">
-      <div className="text-[12px] font-medium text-fg-1">{title}</div>
-      {detail && <div className="max-w-[360px] text-[10.5px] leading-[1.5]">{detail}</div>}
+    <div className="flex h-full flex-col items-center justify-center gap-1.5 p-6 text-center text-[12.5px] text-fg-3">
+      <div className="text-sm font-medium text-fg-1">{title}</div>
+      {detail && <div className="max-w-[360px] text-[11.5px] leading-[1.5]">{detail}</div>}
     </div>
   );
 }
 
 function Placeholder({ tab }: { tab: BottomTabId }) {
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-1.5 p-6 text-center text-[11.5px] text-fg-3">
-      <div className="text-[12px] font-medium text-fg-1">{labelFor(tab)}</div>
-      <div className="max-w-[320px] text-[10.5px] leading-[1.5] text-fg-3">
+    <div className="flex h-full flex-col items-center justify-center gap-1.5 p-6 text-center text-[12.5px] text-fg-3">
+      <div className="text-sm font-medium text-fg-1">{labelFor(tab)}</div>
+      <div className="max-w-[320px] text-[11.5px] leading-[1.5] text-fg-3">
         {subFor(tab)}
       </div>
     </div>
@@ -937,17 +937,17 @@ function NoticesPanel({
   const unsupported = entry.capture?.supported === false;
 
   return (
-    <div className="flex h-full min-h-0 flex-col text-[11px]">
+    <div className="flex h-full min-h-0 flex-col text-[12px]">
       <div className="flex h-8 shrink-0 items-center justify-between gap-3 border-b border-border-divider px-2">
         <div className="flex min-w-0 items-center gap-2">
           <span className="font-medium text-fg-1">Database notices</span>
-          <span className="min-w-0 truncate font-mono text-[10.5px] text-fg-3">
+          <span className="min-w-0 truncate font-mono text-[11.5px] text-fg-3">
             {activeConnectionName && activeTabLabel
               ? `${activeConnectionName} / ${activeTabLabel}`
               : "no active query tab"}
           </span>
           {activeEngine && (
-            <span className="rounded-[4px] border border-border-default px-1.5 py-px font-mono text-[9.5px] text-fg-3">
+            <span className="rounded-[4px] border border-border-default px-1.5 py-px font-mono text-[10.5px] text-fg-3">
               {activeEngine}
             </span>
           )}
@@ -955,13 +955,13 @@ function NoticesPanel({
         <div className="flex shrink-0 items-center gap-2">
           <div className="hidden items-center gap-1 sm:flex">
             {visibleCounts.length === 0 ? (
-              <span className="font-mono text-[10px] text-fg-3">0</span>
+              <span className="font-mono text-[11px] text-fg-3">0</span>
             ) : (
               visibleCounts.map(([severity, count]) => (
                 <span
                   key={severity}
                   className={
-                    "rounded-[4px] px-1.5 py-px font-mono text-[9.5px] " +
+                    "rounded-[4px] px-1.5 py-px font-mono text-[10.5px] " +
                     severityPillClass(toneForSeverity(severity))
                   }
                 >
@@ -970,7 +970,7 @@ function NoticesPanel({
               ))
             )}
           </div>
-          <label className="inline-flex items-center gap-1.5 text-[10.5px] text-fg-2">
+          <label className="inline-flex items-center gap-1.5 text-[11.5px] text-fg-2">
             <input
               type="checkbox"
               checked={entry.retain}
@@ -980,7 +980,7 @@ function NoticesPanel({
             <span>Retain</span>
           </label>
           <button
-            className="h-5 rounded-[4px] border border-border-default px-2 text-[10.5px] text-fg-2 hover:bg-bg-2 hover:text-fg-0 disabled:opacity-45"
+            className="h-5 rounded-[4px] border border-border-default px-2 text-sm text-fg-2 hover:bg-bg-2 hover:text-fg-0 disabled:opacity-45"
             disabled={notices.length === 0}
             onClick={onClear}
           >
@@ -1018,8 +1018,8 @@ function NoticesPanel({
 function NoticeState({ title, body }: { title: string; body: string }) {
   return (
     <div className="flex h-full flex-col items-center justify-center gap-1.5 p-6 text-center">
-      <div className="text-[12px] font-medium text-fg-1">{title}</div>
-      <div className="max-w-[520px] text-[10.5px] leading-[1.5] text-fg-3">
+      <div className="text-sm font-medium text-fg-1">{title}</div>
+      <div className="max-w-[520px] text-[11.5px] leading-[1.5] text-fg-3">
         {body}
       </div>
     </div>
@@ -1032,13 +1032,13 @@ function NoticeRows({ notices }: { notices: DatabaseNotice[] }) {
       {notices.map((notice, index) => (
         <div
           key={`${notice.timestamp}:${index}`}
-          className="grid grid-cols-[76px_84px_82px_minmax(0,1fr)] items-start border-b border-border-divider px-2 py-1.5 font-mono text-[10.5px] leading-[1.45]"
+          className="grid grid-cols-[76px_84px_82px_minmax(0,1fr)] items-start border-b border-border-divider px-2 py-1.5 font-mono text-sm leading-[1.45]"
         >
           <span className="text-fg-3">{formatNoticeTime(notice.timestamp)}</span>
           <span>
             <span
               className={
-                "rounded-[4px] px-1.5 py-px text-[9.5px] " +
+                "rounded-[4px] px-1.5 py-px text-[10.5px] " +
                 severityPillClass(toneForSeverity(notice.severity))
               }
             >

--- a/apps/desktop/src/components/BottomPlanPanel.tsx
+++ b/apps/desktop/src/components/BottomPlanPanel.tsx
@@ -106,11 +106,11 @@ export function PlanPanel({ activeTab }: { activeTab: WorkspaceTab | null }) {
           <span className="inline-flex text-accent">
             <Icon.tree size={13} />
           </span>
-          <span className="truncate font-mono text-[11px] text-fg-2">
+          <span className="truncate font-mono text-sm text-fg-2">
             {queryTab ? queryTab.title : "no SQL query selected"}
           </span>
           {stale && (
-            <span className="rounded-[3px] border border-warn/40 px-1.5 py-[1px] text-[10px] text-warn">
+            <span className="rounded-[3px] border border-warn/40 px-1.5 py-[1px] text-[11px] text-warn">
               stale
             </span>
           )}
@@ -134,7 +134,7 @@ export function PlanPanel({ activeTab }: { activeTab: WorkspaceTab | null }) {
             onClick={copyRawJson}
             disabled={!canCopyRawJson}
             title="Copy raw Postgres EXPLAIN JSON"
-            className="inline-flex h-[23px] items-center gap-1.5 rounded-[4px] border border-border-default bg-bg-2 px-2 text-[11px] text-fg-2 disabled:cursor-not-allowed disabled:opacity-50 hover:border-border-strong hover:bg-bg-3 hover:text-fg-0"
+            className="inline-flex h-[23px] items-center gap-1.5 rounded-[4px] border border-border-default bg-bg-2 px-2 text-sm text-fg-2 disabled:cursor-not-allowed disabled:opacity-50 hover:border-border-strong hover:bg-bg-3 hover:text-fg-0"
           >
             {copied ? <Icon.check size={10} /> : <Icon.copy size={10} />}
             {copied ? "Copied" : "JSON"}
@@ -148,7 +148,7 @@ export function PlanPanel({ activeTab }: { activeTab: WorkspaceTab | null }) {
                 ? "Run Postgres EXPLAIN ANALYZE"
                 : "Run Postgres EXPLAIN without executing the statement")
             }
-            className="inline-flex h-[23px] items-center gap-1.5 rounded-[4px] border border-border-default bg-bg-2 px-2 text-[11px] text-fg-1 disabled:cursor-not-allowed disabled:opacity-50 hover:border-border-strong hover:bg-bg-3"
+            className="inline-flex h-[23px] items-center gap-1.5 rounded-[4px] border border-border-default bg-bg-2 px-2 text-sm text-fg-1 disabled:cursor-not-allowed disabled:opacity-50 hover:border-border-strong hover:bg-bg-3"
           >
             <Icon.bolt size={10} />
             {loading ? "Explaining..." : "Run"}
@@ -211,7 +211,7 @@ function PlanModeButton({
       aria-pressed={active}
       onClick={onClick}
       className={
-        "rounded-[3px] px-2 text-[10.5px] leading-[19px] transition-colors " +
+        "rounded-[3px] px-2 text-[11.5px] leading-[19px] transition-colors " +
         (active
           ? "bg-bg-3 text-fg-0 shadow-sm"
           : "text-fg-3 hover:bg-bg-2 hover:text-fg-1")
@@ -224,7 +224,7 @@ function PlanModeButton({
 
 function AnalyzeWarning() {
   return (
-    <div className="flex items-start gap-2 rounded-[4px] border border-warn/30 bg-update-bg px-2.5 py-2 text-[10.5px] leading-[1.45] text-fg-2">
+    <div className="flex items-start gap-2 rounded-[4px] border border-warn/30 bg-update-bg px-2.5 py-2 text-[11.5px] leading-[1.45] text-fg-2">
       <Icon.warn size={13} className="mt-[1px] text-warn" />
       <div>
         <span className="font-medium text-warn">EXPLAIN ANALYZE executes SQL.</span>{" "}
@@ -266,7 +266,7 @@ function detailForUnavailable(reason: string): string {
 
 function PlanSummary({ plan, stale }: { plan: QueryPlan; stale: boolean }) {
   return (
-    <div className="grid grid-cols-2 gap-2 text-[10.5px] sm:grid-cols-4">
+    <div className="grid grid-cols-2 gap-2 text-[11.5px] sm:grid-cols-4">
       <Metric
         label="mode"
         value={plan.mode === "analyze" ? "analyze" : "estimate"}
@@ -290,12 +290,12 @@ function Metric({
 }) {
   return (
     <div className="rounded-[4px] border border-border-default bg-bg-1 px-2 py-1.5">
-      <div className="text-[9.5px] uppercase tracking-[0.08em] text-fg-3">
+      <div className="text-[10.5px] uppercase tracking-[0.08em] text-fg-3">
         {label}
       </div>
       <div
         className={
-          "font-mono text-[11px] " +
+          "font-mono text-[12px] " +
           (tone === "warn" ? "text-warn" : "text-fg-1")
         }
       >
@@ -313,21 +313,21 @@ function PlanNodeView({ node, maxCost }: { node: PlanNode; maxCost: number }) {
   return (
     <div className="rounded-[4px] border border-border-default bg-bg-1">
       <div className="flex flex-wrap items-center gap-x-2 gap-y-1 px-2 py-1.5">
-        <span className="font-mono text-[11.5px] font-medium text-fg-0">
+        <span className="font-mono text-sm font-medium text-fg-0">
           {node.node_type}
         </span>
         {node.relation_name && (
-          <span className="font-mono text-[10.5px] text-fg-2">
+          <span className="font-mono text-[11.5px] text-fg-2">
             {node.schema_name ? `${node.schema_name}.` : ""}
             {node.relation_name}
           </span>
         )}
         {node.index_name && (
-          <span className="font-mono text-[10.5px] text-accent">
+          <span className="font-mono text-[11.5px] text-accent">
             {node.index_name}
           </span>
         )}
-        <span className="ml-auto font-mono text-[10px] text-fg-3">
+        <span className="ml-auto font-mono text-[11px] text-fg-3">
           cost {formatRange(node.startup_cost, node.total_cost)} · rows{" "}
           {node.plan_rows ?? "?"}
         </span>
@@ -344,13 +344,13 @@ function PlanNodeView({ node, maxCost }: { node: PlanNode; maxCost: number }) {
               }}
             />
           </div>
-          <span className="w-[28px] text-right font-mono text-[9.5px] text-fg-3">
+          <span className="w-[28px] text-right font-mono text-[10.5px] text-fg-3">
             {heatPercent}%
           </span>
         </div>
       </div>
       {(node.actual_total_time_ms != null || node.details.length > 0) && (
-        <div className="border-t border-border-divider px-2 py-1.5 text-[10.5px] text-fg-2">
+        <div className="border-t border-border-divider px-2 py-1.5 text-[11.5px] text-fg-2">
           {node.actual_total_time_ms != null && (
             <div className="font-mono text-fg-2">
               actual {formatRange(node.actual_startup_time_ms, node.actual_total_time_ms)} ms · rows{" "}
@@ -390,11 +390,11 @@ function PlanEmpty({
   warn?: boolean;
 }) {
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-1.5 p-6 text-center text-[11.5px] text-fg-3">
-      <div className={"text-[12px] font-medium " + (warn ? "text-warn" : "text-fg-1")}>
+    <div className="flex h-full flex-col items-center justify-center gap-1.5 p-6 text-center text-sm text-fg-3">
+      <div className={"text-sm font-medium " + (warn ? "text-warn" : "text-fg-1")}>
         {title}
       </div>
-      <div className="max-w-[360px] text-[10.5px] leading-[1.5] text-fg-3">
+      <div className="max-w-[360px] text-[11.5px] leading-[1.5] text-fg-3">
         {detail}
       </div>
     </div>

--- a/apps/desktop/src/components/ContextMenu.tsx
+++ b/apps/desktop/src/components/ContextMenu.tsx
@@ -147,7 +147,7 @@ export function ContextMenu({
             item.onClick();
           }}
           className={
-            "flex w-full items-center gap-2 px-2.5 py-[5px] text-left text-[11.5px] transition-colors disabled:opacity-40 disabled:cursor-not-allowed " +
+            "flex w-full items-center gap-2 px-2.5 py-[5px] text-left text-sm transition-colors disabled:opacity-40 disabled:cursor-not-allowed " +
             (item.danger
               ? "text-warn hover:bg-warn/10"
               : "text-fg-1 hover:bg-accent-soft hover:text-accent")

--- a/apps/desktop/src/components/FindUsagesPanel.tsx
+++ b/apps/desktop/src/components/FindUsagesPanel.tsx
@@ -71,15 +71,15 @@ export function FindUsagesPanel() {
   }
 
   return (
-    <div className="flex h-full min-h-0 flex-col bg-bg-inset text-[11px]">
+    <div className="flex h-full min-h-0 flex-col bg-bg-inset text-[12px]">
       <div className="flex h-8 shrink-0 items-center justify-between gap-3 border-b border-border-divider px-2">
         <div className="flex min-w-0 items-center gap-2">
           <span className="shrink-0 font-medium text-fg-1">Find Usages</span>
-          <span className="min-w-0 truncate font-mono text-[10.5px] text-fg-2">
+          <span className="min-w-0 truncate font-mono text-[11.5px] text-fg-2">
             {targetLabel}
           </span>
           {target.column && (
-            <span className="shrink-0 rounded-[4px] bg-accent-soft px-1.5 py-px font-mono text-[9.5px] text-accent">
+            <span className="shrink-0 rounded-[4px] bg-accent-soft px-1.5 py-px font-mono text-[10.5px] text-accent">
               column
             </span>
           )}
@@ -136,7 +136,7 @@ export function FindUsagesPanel() {
       </div>
 
       {status === "ready" && results.length > 0 && (
-        <div className="flex h-6 shrink-0 items-center border-t border-border-divider px-2 font-mono text-[10px] text-fg-3">
+        <div className="flex h-6 shrink-0 items-center border-t border-border-divider px-2 font-mono text-[11px] text-fg-3">
           {results.length} {results.length === 1 ? "usage" : "usages"}
           {allSchemas ? " across all schemas" : ` in ${target.schema}`}
         </div>
@@ -159,7 +159,7 @@ function ScopeButton({
       type="button"
       onClick={onClick}
       className={
-        "h-[20px] px-2 text-[10px] " +
+        "h-[20px] px-2 text-[11px] " +
         (active
           ? "bg-accent-soft text-accent"
           : "text-fg-2 hover:bg-bg-2 hover:text-fg-0")
@@ -190,27 +190,27 @@ function UsageRow({
       </span>
       <div className="min-w-0 flex-1">
         <div className="flex min-w-0 items-center gap-1.5">
-          <span className="shrink-0 rounded-[3px] bg-bg-2 px-1 py-px font-mono text-[9px] text-fg-3">
+          <span className="shrink-0 rounded-[3px] bg-bg-2 px-1 py-px font-mono text-[10px] text-fg-3">
             {meta.pill}
           </span>
-          <span className="min-w-0 truncate font-mono text-[11px] text-fg-1">
+          <span className="min-w-0 truncate font-mono text-sm text-fg-1">
             {qualifiedName(usage.schema, usage.name)}
           </span>
           {usage.on_table && (
-            <span className="shrink-0 font-mono text-[10px] text-fg-3">
+            <span className="shrink-0 font-mono text-[11px] text-fg-3">
               on {usage.on_table}
             </span>
           )}
           {usage.matched_column && (
-            <span className="shrink-0 rounded-[3px] bg-accent-soft px-1 py-px font-mono text-[9px] text-accent">
+            <span className="shrink-0 rounded-[3px] bg-accent-soft px-1 py-px font-mono text-[10px] text-accent">
               {usage.matched_column}
             </span>
           )}
-          <span className="ml-auto shrink-0 font-mono text-[9.5px] text-fg-4">
+          <span className="ml-auto shrink-0 font-mono text-[10.5px] text-fg-4">
             L{usage.line}
           </span>
         </div>
-        <pre className="m-0 mt-1 max-h-[40px] overflow-hidden whitespace-pre-wrap break-words font-mono text-[10.5px] leading-[1.45] text-fg-2">
+        <pre className="m-0 mt-1 max-h-[40px] overflow-hidden whitespace-pre-wrap break-words font-mono text-[11.5px] leading-[1.45] text-fg-2">
           {usage.snippet}
         </pre>
       </div>
@@ -234,12 +234,12 @@ function EmptyState({
     <div className="flex h-full flex-col items-center justify-center gap-1.5 p-6 text-center">
       <div
         className={
-          "text-[12px] font-medium " + (tone === "warn" ? "text-warn" : "text-fg-1")
+          "text-sm font-medium " + (tone === "warn" ? "text-warn" : "text-fg-1")
         }
       >
         {title}
       </div>
-      <div className="max-w-[460px] text-[10.5px] leading-[1.5] text-fg-3">
+      <div className="max-w-[460px] text-[11.5px] leading-[1.5] text-fg-3">
         {detail}
       </div>
     </div>

--- a/apps/desktop/src/components/SchemaComparePane.tsx
+++ b/apps/desktop/src/components/SchemaComparePane.tsx
@@ -47,7 +47,7 @@ export function SchemaComparePane({ tab }: { tab: SchemaCompareTab }) {
           <span className="text-warn">{state.error ?? "Comparison failed."}</span>
           <button
             type="button"
-            className="inline-flex items-center gap-1.5 rounded-[4px] border border-border-default bg-bg-2 px-2.5 py-1 text-[11.5px] text-fg-1 hover:bg-bg-3"
+            className="inline-flex items-center gap-1.5 rounded-[4px] border border-border-default bg-bg-2 px-2.5 py-1 text-sm text-fg-1 hover:bg-bg-3"
             onClick={() => void recompare(tab.id)}
           >
             <Icon.history size={11} />
@@ -92,8 +92,8 @@ export function SchemaComparePane({ tab }: { tab: SchemaCompareTab }) {
     <div className="flex min-h-0 flex-1 flex-col bg-bg-0">
       <div className="flex h-[30px] shrink-0 items-center gap-2 border-b border-border-default bg-bg-1 px-3">
         <Icon.diff size={13} stroke="var(--accent)" />
-        <span className="text-[12px] font-semibold text-fg-0">Schema compare</span>
-        <span className="flex items-center gap-2 text-[11px] text-fg-3">
+        <span className="text-sm font-semibold text-fg-0">Schema compare</span>
+        <span className="flex items-center gap-2 text-sm text-fg-3">
           <SummaryPill n={s.tables_added + s.views_added} label="added" color="var(--insert)" />
           <SummaryPill n={s.tables_removed + s.views_removed} label="dropped" color="var(--delete)" />
           <SummaryPill n={s.tables_modified + s.views_modified} label="changed" color="var(--update)" />
@@ -102,7 +102,7 @@ export function SchemaComparePane({ tab }: { tab: SchemaCompareTab }) {
         <div className="flex-1" />
         <button
           type="button"
-          className="inline-flex items-center gap-1.5 rounded-[4px] border border-border-default bg-bg-2 px-2 py-1 text-[11px] text-fg-1 hover:bg-bg-3"
+          className="inline-flex items-center gap-1.5 rounded-[4px] border border-border-default bg-bg-2 px-2 py-1 text-sm text-fg-1 hover:bg-bg-3"
           onClick={() => void recompare(tab.id)}
           title="Re-run the comparison against the current live schema"
         >
@@ -146,7 +146,7 @@ function SummaryPill({
 
 function PaneMessage({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex flex-1 items-center justify-center bg-bg-inset text-[11.5px] text-fg-3">
+    <div className="flex flex-1 items-center justify-center bg-bg-inset text-sm text-fg-3">
       {children}
     </div>
   );

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -576,13 +576,13 @@ export function Sidebar({
 
   return (
     <div
-      className="flex h-full flex-col text-[11.5px]"
+      className="flex h-full flex-col text-[9px]"
       style={{ fontFamily: "var(--font-sans)" }}
     >
       <div className="flex shrink-0 items-center justify-between pt-[7px] pb-[5px] pl-2.5 pr-2">
-        <div className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.04em] text-fg-2">
+        <div className="flex items-center gap-1.5 text-[12px] font-semibold uppercase tracking-[0.04em] text-fg-2">
           <span>Connections</span>
-          <span className="rounded-[8px] bg-bg-2 px-1.5 py-px text-[10px] tabular-nums text-fg-3">
+          <span className="rounded-[8px] bg-bg-2 px-1.5 py-px text-[11px] tabular-nums text-fg-3">
             {connections.length}
           </span>
         </div>
@@ -612,7 +612,7 @@ export function Sidebar({
           placeholder="Filter…"
           value={filter}
           onChange={(e) => setFilter(e.target.value)}
-          className="flex-1 border-none bg-transparent py-0.5 text-[11.5px] leading-4 text-fg-0 outline-none placeholder:text-fg-3"
+          className="flex-1 border-none bg-transparent py-0.5 text-sm leading-4 text-fg-0 outline-none placeholder:text-fg-3"
         />
         <span className="kbd">⌘F</span>
       </div>
@@ -622,7 +622,7 @@ export function Sidebar({
           <button
             type="button"
             onClick={onNewConnection}
-            className="mx-2 mt-1 mb-3 flex w-[calc(100%-16px)] items-center gap-1.5 rounded-[4px] border border-dashed border-border-default px-2 py-1.5 text-[11.5px] text-fg-2 transition-[border-color,color,background] duration-150 hover:border-solid hover:border-accent-line hover:bg-accent-soft hover:text-accent"
+            className="mx-2 mt-1 mb-3 flex w-[calc(100%-16px)] items-center gap-1.5 rounded-[4px] border border-dashed border-border-default px-2 py-1.5 text-sm text-fg-2 transition-[border-color,color,background] duration-150 hover:border-solid hover:border-accent-line hover:bg-accent-soft hover:text-accent"
           >
             <Icon.plus size={11} />
             <span>New connection</span>
@@ -630,7 +630,7 @@ export function Sidebar({
         )}
 
         {matchCount === 0 && (
-          <div className="px-3 py-5 text-center text-[11px] text-fg-3">
+          <div className="px-3 py-5 text-center text-[12px] text-fg-3">
             {connections.length === 0 ? "no connections yet" : "no matches"}
           </div>
         )}
@@ -678,7 +678,7 @@ export function Sidebar({
           type="button"
           onClick={onOpenSettings}
           title="Settings (⌘,)"
-          className="flex items-center gap-1.5 rounded-[4px] px-1.5 py-1 text-[11.5px] text-fg-2 transition-colors duration-150 hover:bg-bg-2 hover:text-fg-0"
+          className="flex items-center gap-1.5 rounded-[4px] px-1.5 py-1 text-sm text-fg-2 transition-colors duration-150 hover:bg-bg-2 hover:text-fg-0"
         >
           <Icon.settings size={13} />
           <span>Settings</span>
@@ -754,10 +754,10 @@ function SchemaVisibilityManager({
       <div className="flex max-h-[70vh] w-[420px] flex-col overflow-hidden rounded-[8px] border border-border-default bg-bg-1 shadow-xl">
         <div className="flex h-10 shrink-0 items-center justify-between border-b border-border-default px-3">
           <div className="min-w-0">
-            <div className="text-[12.5px] font-semibold text-fg-0">
+            <div className="text-sm font-semibold text-fg-0">
               Visible schemas
             </div>
-            <div className="truncate text-[10.5px] text-fg-3">
+            <div className="truncate text-[11.5px] text-fg-3">
               {state.database}
             </div>
           </div>
@@ -773,7 +773,7 @@ function SchemaVisibilityManager({
               value={filter}
               onChange={(e) => setFilter(e.target.value)}
               placeholder="Filter schemas..."
-              className="min-w-0 flex-1 border-none bg-transparent py-1 text-[11.5px] text-fg-0 outline-none placeholder:text-fg-3"
+              className="min-w-0 flex-1 border-none bg-transparent py-1 text-sm text-fg-0 outline-none placeholder:text-fg-3"
             />
           </div>
           <div className="flex flex-wrap gap-1">
@@ -818,7 +818,7 @@ function SchemaVisibilityManager({
             return (
               <label
                 key={schema.name}
-                className="flex h-7 cursor-pointer items-center gap-2 px-3 text-[11.5px] text-fg-1 hover:bg-bg-2"
+                className="flex h-7 cursor-pointer items-center gap-2 px-3 text-sm text-fg-1 hover:bg-bg-2"
               >
                 <input
                   type="checkbox"
@@ -830,7 +830,7 @@ function SchemaVisibilityManager({
                 <span className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
                   {schema.name}
                 </span>
-                <span className="text-[10px] tabular-nums text-fg-3">
+                <span className="text-[11px] tabular-nums text-fg-3">
                   {count}
                 </span>
               </label>
@@ -839,11 +839,11 @@ function SchemaVisibilityManager({
         </div>
 
         <div className="flex h-9 shrink-0 items-center justify-between border-t border-border-default px-3">
-          <span className="text-[10.5px] tabular-nums text-fg-3">
+          <span className="text-[11.5px] tabular-nums text-fg-3">
             {visible.size}/{state.schemas.length} visible
           </span>
           <button
-            className="h-[24px] rounded-[4px] bg-accent px-2.5 text-[11px] font-medium text-accent-fg"
+            className="h-[24px] rounded-[4px] bg-accent px-2.5 text-sm font-medium text-accent-fg"
             onClick={onClose}
           >
             Done
@@ -864,7 +864,7 @@ function SchemaAction({
   return (
     <button
       type="button"
-      className="h-5 rounded-[3px] border border-border-default bg-bg-2 px-2 text-[10.5px] text-fg-1 hover:border-border-strong hover:text-fg-0"
+      className="h-5 rounded-[3px] border border-border-default bg-bg-2 px-2 text-sm text-fg-1 hover:border-border-strong hover:text-fg-0"
       onClick={onClick}
     >
       {label}

--- a/apps/desktop/src/components/SidebarConnectionList.tsx
+++ b/apps/desktop/src/components/SidebarConnectionList.tsx
@@ -287,7 +287,7 @@ export function SidebarConnectionList({
           {visibleChildren.length === 0 ? (
             <div
               className={
-                "mx-2 my-0.5 rounded-[4px] border border-dashed px-2 py-1 text-[10.5px] " +
+                "mx-2 my-0.5 rounded-[4px] border border-dashed px-2 py-1 text-[11.5px] " +
                 (isDropInto
                   ? "border-accent-line bg-accent-soft text-accent"
                   : "border-border-default text-fg-3")
@@ -479,7 +479,7 @@ function FolderRenameInput({
         }
       }}
       onBlur={(e) => commit(e.currentTarget.value)}
-      className="min-w-0 flex-1 rounded-[3px] border border-accent-line bg-bg-inset px-1 py-px text-[12px] text-fg-0 outline-none"
+      className="min-w-0 flex-1 rounded-[3px] border border-accent-line bg-bg-inset px-1 py-px text-[13px] text-fg-0 outline-none"
     />
   );
 }

--- a/apps/desktop/src/components/SidebarTree.tsx
+++ b/apps/desktop/src/components/SidebarTree.tsx
@@ -54,15 +54,15 @@ export const TWISTY =
   "inline-flex h-[14px] w-[14px] shrink-0 items-center justify-center text-fg-3 hover:text-fg-1";
 
 export const META =
-  "ml-auto shrink-0 whitespace-nowrap pr-1 text-[10px] font-medium tabular-nums text-fg-3";
+  "ml-auto shrink-0 whitespace-nowrap pr-1 text-[11px] font-medium tabular-nums text-fg-3";
 
-// Authored at 12px so labels render at exactly the Settings > Appearance font
-// size after the global --ui-scale zoom (FONT_SIZE_BASELINE = 12).
+// text-sm matches the body base size (--fs-sm) so sidebar labels render at
+// exactly the Settings > Appearance font size after the --ui-scale zoom.
 export const NODE_LABEL =
-  "min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[12px] leading-[18px]";
+  "min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-sm leading-[18px]";
 
 const PILL =
-  "ml-1 rounded-[3px] bg-bg-2 px-1 py-px text-[9px] font-medium tabular-nums text-fg-3";
+  "ml-1 rounded-[3px] bg-bg-2 px-1 py-px text-[10px] font-medium tabular-nums text-fg-3";
 
 /** Drag/drop wiring the sidebar list attaches to a connection header row. */
 export interface ConnectionDragHandles {
@@ -159,7 +159,7 @@ export function ConnectionRow({
         </span>
         {config.env_tag === "prod" && (
           <span
-            className="rounded-[3px] px-1 py-px text-[8.5px] font-semibold uppercase tracking-[0.04em]"
+            className="rounded-[3px] px-1 py-px text-[9.5px] font-semibold uppercase tracking-[0.04em]"
             style={{
               color: "var(--warn)",
               background: "color-mix(in oklab, var(--warn) 16%, transparent)",
@@ -198,12 +198,12 @@ export function ConnectionRow({
 
       {expanded && error && (
         <div
-          className="flex items-start gap-2 px-3 py-1 text-[10.5px] text-warn"
+          className="flex items-start gap-2 px-3 py-1 text-sm text-warn"
           style={{ paddingLeft: 32 }}
         >
           <span className="min-w-0 flex-1">{error}</span>
           <button
-            className="inline-flex h-[20px] shrink-0 items-center gap-1 rounded-[4px] border border-warn/40 px-1.5 text-[10px] text-warn hover:bg-bg-2"
+            className="inline-flex h-[20px] shrink-0 items-center gap-1 rounded-[4px] border border-warn/40 px-1.5 text-[11px] text-warn hover:bg-bg-2"
             title="Reconnect"
             onClick={(e) => {
               e.stopPropagation();
@@ -218,7 +218,7 @@ export function ConnectionRow({
 
       {expanded && loadingSchema && (
         <div
-          className="px-3 py-1 text-[10.5px] text-fg-3 animate-sb-pulse"
+          className="px-3 py-1 text-sm text-fg-3 animate-sb-pulse"
           style={{ paddingLeft: 32 }}
         >
           loading schemas…

--- a/apps/desktop/src/components/StatusBar.tsx
+++ b/apps/desktop/src/components/StatusBar.tsx
@@ -18,9 +18,9 @@ export function StatusBar() {
   const connected = activeState?.status === "connected";
 
   return (
-    <div className="flex h-[22px] shrink-0 items-center justify-between border-t border-border-default bg-bg-1 px-2.5 text-[11px] text-fg-2">
+    <div className="flex h-[22px] shrink-0 items-center justify-between border-t border-border-default bg-bg-1 px-2.5 text-[12px] text-fg-2">
       <div className="flex items-center gap-3.5">
-        <span className="inline-flex h-[18px] items-center gap-[5px] whitespace-nowrap text-[10.5px]">
+        <span className="inline-flex h-[18px] items-center gap-[5px] whitespace-nowrap text-[11.5px]">
           <span
             className="inline-block h-1.5 w-1.5 rounded-full"
             style={{
@@ -51,7 +51,7 @@ export function StatusBar() {
           )}
         </span>
         {activeConn && (
-          <span className="inline-flex h-[18px] items-center gap-[5px] whitespace-nowrap text-[10.5px]">
+          <span className="inline-flex h-[18px] items-center gap-[5px] whitespace-nowrap text-[11.5px]">
             <Icon.user size={10} />
             <span className="mono">
               {activeConn.user}@{activeConn.host}
@@ -59,7 +59,7 @@ export function StatusBar() {
           </span>
         )}
         {activeConn && activeConn.ssl_mode !== "disable" && (
-          <span className="inline-flex h-[18px] items-center gap-[5px] whitespace-nowrap text-[10.5px]">
+          <span className="inline-flex h-[18px] items-center gap-[5px] whitespace-nowrap text-[11.5px]">
             <Icon.lock size={10} />
             <span>SSL · {activeConn.ssl_mode}</span>
           </span>
@@ -67,7 +67,7 @@ export function StatusBar() {
       </div>
 
       <div className="flex items-center gap-3.5">
-        <span className="inline-flex h-[18px] items-center gap-[5px] whitespace-nowrap text-[10.5px]">
+        <span className="inline-flex h-[18px] items-center gap-[5px] whitespace-nowrap text-[11.5px]">
           {lastQuery ? (
             <>
               <Icon.check size={10} style={{ color: "var(--accent)" }} />
@@ -82,7 +82,7 @@ export function StatusBar() {
           )}
         </span>
         <span
-          className="inline-flex h-[18px] items-center gap-[5px] whitespace-nowrap font-mono text-[10.5px]"
+          className="inline-flex h-[18px] items-center gap-[5px] whitespace-nowrap font-mono text-[11.5px]"
           style={{ color: "var(--fg-2)" }}
         >
           UTF-8 · LF

--- a/apps/desktop/src/components/TabBar.tsx
+++ b/apps/desktop/src/components/TabBar.tsx
@@ -185,7 +185,7 @@ export function TabBar({ pane }: { pane?: PaneIndex } = {}) {
         }}
       >
         {tabs.length === 0 && (
-          <div className="inline-flex items-center px-3 text-[11px] text-fg-3">
+          <div className="inline-flex items-center px-3 text-[12px] text-fg-3">
             no tabs — double-click a table in the sidebar
           </div>
         )}
@@ -231,7 +231,7 @@ export function TabBar({ pane }: { pane?: PaneIndex } = {}) {
               onClick={() => setActive(t.id)}
               onContextMenu={(e) => openTabMenu(e, t)}
               className={
-                "group relative inline-flex items-center gap-1.5 h-full pl-2.5 pr-2 max-w-[260px] shrink-0 border-r border-border-default text-[11.5px] cursor-pointer transition-[background,color] duration-100 " +
+                "group relative inline-flex items-center gap-1.5 h-full pl-2.5 pr-2 max-w-[260px] shrink-0 border-r border-border-default text-sm cursor-pointer transition-[background,color] duration-100 " +
                 (isActive
                   ? "bg-bg-0 text-fg-0 border-b border-bg-0 -mb-px"
                   : "bg-bg-1 text-fg-2 hover:bg-bg-2 hover:text-fg-1") +

--- a/apps/desktop/src/components/TitleBar.tsx
+++ b/apps/desktop/src/components/TitleBar.tsx
@@ -101,7 +101,7 @@ export function TitleBar({
           <>
             <div className="mx-0.5 h-4 w-px bg-border-default" />
             <div className="flex items-center gap-0.5 max-[1080px]:[&_svg]:hidden">
-              <span className="inline-flex items-center gap-[5px] whitespace-nowrap rounded-[4px] px-1.5 py-[3px] text-[11.5px] text-fg-1">
+              <span className="inline-flex items-center gap-[5px] whitespace-nowrap rounded-[4px] px-1.5 py-[3px] text-sm text-fg-1">
                 <Icon.database size={12} />
                 <span>{activeConn?.name ?? activeTab.connectionId}</span>
               </span>
@@ -111,20 +111,20 @@ export function TitleBar({
                   type="button"
                   onClick={openDatabaseMenu}
                   title="Switch database"
-                  className="inline-flex items-center gap-[5px] whitespace-nowrap rounded-[4px] px-1.5 py-[3px] text-[11.5px] text-fg-1 transition-colors hover:bg-bg-2 max-[1080px]:hidden"
+                  className="inline-flex items-center gap-[5px] whitespace-nowrap rounded-[4px] px-1.5 py-[3px] text-sm text-fg-1 transition-colors hover:bg-bg-2 max-[1080px]:hidden"
                 >
                   <span style={{ color: engineColor }}>●</span>
                   <span>{activeTab.database}</span>
                   <Icon.chevronDown size={10} style={{ opacity: 0.5 }} />
                 </button>
               ) : (
-                <span className="inline-flex items-center gap-[5px] whitespace-nowrap rounded-[4px] px-1.5 py-[3px] text-[11.5px] text-fg-1 max-[1080px]:hidden">
+                <span className="inline-flex items-center gap-[5px] whitespace-nowrap rounded-[4px] px-1.5 py-[3px] text-sm text-fg-1 max-[1080px]:hidden">
                   <span style={{ color: engineColor }}>●</span>
                   <span>{activeTab.database}</span>
                 </span>
               )}
               <Icon.chevronRight size={11} style={{ opacity: 0.4 }} />
-              <span className="inline-flex items-center gap-[5px] whitespace-nowrap rounded-[4px] px-1.5 py-[3px] text-[11.5px] text-fg-1 max-[1080px]:hidden">
+              <span className="inline-flex items-center gap-[5px] whitespace-nowrap rounded-[4px] px-1.5 py-[3px] text-sm text-fg-1 max-[1080px]:hidden">
                 {activeTab.kind === "query" ? (
                   <Icon.terminal size={11} />
                 ) : activeTab.kind === "schema-compare" ? (
@@ -146,7 +146,7 @@ export function TitleBar({
       <button
         type="button"
         onClick={onOpenPalette}
-        className="absolute left-1/2 top-1/2 flex h-[24px] min-w-0 w-[320px] max-w-[320px] -translate-x-1/2 -translate-y-1/2 items-center gap-2 rounded-[5px] border border-border-default bg-bg-inset px-2 text-[11.5px] text-fg-3 transition-[border-color] duration-150 hover:border-border-strong"
+        className="absolute left-1/2 top-1/2 flex h-[24px] min-w-0 w-[320px] max-w-[320px] -translate-x-1/2 -translate-y-1/2 items-center gap-2 rounded-[5px] border border-border-default bg-bg-inset px-2 text-sm text-fg-3 transition-[border-color] duration-150 hover:border-border-strong"
       >
         <Icon.search size={12} />
         <span className="flex-1 text-left">

--- a/apps/desktop/src/components/UpdateToast.tsx
+++ b/apps/desktop/src/components/UpdateToast.tsx
@@ -19,8 +19,8 @@ export function UpdateToast({
       <div className="mb-2 flex items-start gap-2">
         <Icon.sparkles size={14} stroke="var(--accent)" />
         <div className="min-w-0 flex-1">
-          <div className="text-[12px] font-semibold text-fg-0">Update available</div>
-          <div className="text-[11px] text-fg-2">
+          <div className="text-sm font-semibold text-fg-0">Update available</div>
+          <div className="text-sm text-fg-2">
             Version {version} is ready to download.
           </div>
         </div>
@@ -36,7 +36,7 @@ export function UpdateToast({
       <button
         type="button"
         onClick={onUpdate}
-        className="inline-flex h-[26px] w-full items-center justify-center gap-1 rounded-[4px] bg-accent px-2 text-[11px] font-medium text-accent-fg hover:brightness-[1.07]"
+        className="inline-flex h-[26px] w-full items-center justify-center gap-1 rounded-[4px] bg-accent px-2 text-sm font-medium text-accent-fg hover:brightness-[1.07]"
       >
         <Icon.download size={11} />
         <span>Update</span>

--- a/apps/desktop/src/components/Workspace.tsx
+++ b/apps/desktop/src/components/Workspace.tsx
@@ -528,7 +528,7 @@ function TableTabPane({
 
 function PaneMessage({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex flex-1 items-center justify-center bg-bg-inset text-[11.5px] text-fg-3">
+    <div className="flex flex-1 items-center justify-center bg-bg-inset text-[12.5px] text-fg-3">
       {children}
     </div>
   );
@@ -536,7 +536,7 @@ function PaneMessage({ children }: { children: React.ReactNode }) {
 
 function EmptyWorkspace() {
   return (
-    <div className="flex flex-1 flex-col items-center justify-center gap-[14px] bg-bg-inset px-10 py-10 text-center text-[12.5px] text-fg-2">
+    <div className="flex flex-1 flex-col items-center justify-center gap-[14px] bg-bg-inset px-10 py-10 text-center text-sm text-fg-2">
       <span
         className="relative h-9 w-9 rounded-lg"
         style={{
@@ -554,16 +554,16 @@ function EmptyWorkspace() {
         />
       </span>
       <div>
-        <div className="text-[14px] font-semibold text-fg-0">
+        <div className="text-[15px] font-semibold text-fg-0">
           Open a table to begin
         </div>
-        <div className="max-w-[360px] text-[11.5px] leading-[1.5] text-fg-3">
+        <div className="max-w-[360px] text-[12.5px] leading-[1.5] text-fg-3">
           Add a Postgres connection in the sidebar, expand it, and click a table
           to load real rows — or hit <span className="font-mono">+</span> in the
           tab bar to open a SQL editor.
         </div>
       </div>
-      <div className="flex gap-3 text-[10.5px] text-fg-3">
+      <div className="flex gap-3 text-[11.5px] text-fg-3">
         <span className="inline-flex items-center gap-1">
           <kbd className="kbd">⌘</kbd>
           <kbd className="kbd">N</kbd>&nbsp;new connection

--- a/apps/desktop/src/components/er/ErDiagram.tsx
+++ b/apps/desktop/src/components/er/ErDiagram.tsx
@@ -604,11 +604,11 @@ function Toolbar(props: {
   onRefresh: () => void;
 }) {
   return (
-    <div className="relative flex h-7 shrink-0 items-center gap-1 border-b border-border-default bg-bg-1 px-2 text-[11px] text-fg-2">
+    <div className="relative flex h-7 shrink-0 items-center gap-1 border-b border-border-default bg-bg-1 px-2 text-sm text-fg-2">
       <button type="button" className="icon-btn" title="Zoom out" onClick={props.onZoomOut}>
         <Icon.minus size={12} />
       </button>
-      <span className="w-9 text-center font-mono text-[10px] text-fg-3">
+      <span className="w-9 text-center font-mono text-[11px] text-fg-3">
         {Math.round(props.zoom * 100)}%
       </span>
       <button type="button" className="icon-btn" title="Zoom in" onClick={props.onZoomIn}>
@@ -631,7 +631,7 @@ function Toolbar(props: {
       <button
         type="button"
         className={
-          "inline-flex h-[20px] items-center gap-1 rounded-[4px] border px-1.5 text-[10.5px] " +
+          "inline-flex h-[20px] items-center gap-1 rounded-[4px] border px-1.5 text-[11.5px] " +
           (props.compact
             ? "border-border-default bg-bg-2 text-fg-2 hover:text-fg-0"
             : "border-accent-line bg-accent-soft text-accent")
@@ -663,7 +663,7 @@ function Toolbar(props: {
         <Icon.history size={12} />
       </button>
 
-      <span className="ml-auto font-mono text-[10px] text-fg-3">
+      <span className="ml-auto font-mono text-[11px] text-fg-3">
         {props.nodeCount} tables · {props.edgeCount} refs
       </span>
 
@@ -674,7 +674,7 @@ function Toolbar(props: {
             return (
               <label
                 key={schema}
-                className="flex h-6 cursor-pointer items-center gap-2 px-2 text-[11px] text-fg-1 hover:bg-bg-2"
+                className="flex h-6 cursor-pointer items-center gap-2 px-2 text-sm text-fg-1 hover:bg-bg-2"
               >
                 <input
                   type="checkbox"
@@ -696,7 +696,7 @@ function Toolbar(props: {
 
 function Centered({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex h-full items-center justify-center text-[11.5px] text-fg-3">
+    <div className="flex h-full items-center justify-center text-sm text-fg-3">
       {children}
     </div>
   );

--- a/apps/desktop/src/components/modals/CommandPalette.tsx
+++ b/apps/desktop/src/components/modals/CommandPalette.tsx
@@ -398,7 +398,7 @@ export function CommandPalette({
               }
             }}
             autoFocus
-            className="flex-1 border-none bg-transparent text-[13px] text-fg-0 outline-none placeholder:text-fg-3"
+            className="flex-1 border-none bg-transparent text-sm text-fg-0 outline-none placeholder:text-fg-3"
           />
           <span className="kbd">esc</span>
         </div>
@@ -406,7 +406,7 @@ export function CommandPalette({
         <div className="max-h-[420px] overflow-y-auto pt-1 pb-2">
           {grouped.map(([grp, items]) => (
             <div key={grp} className="pt-1.5 pb-1">
-              <div className="px-3.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.06em] text-fg-3">
+              <div className="px-3.5 py-0.5 text-[11px] font-semibold uppercase tracking-[0.06em] text-fg-3">
                 {grp}
               </div>
               {items.map((entry) => {
@@ -419,7 +419,7 @@ export function CommandPalette({
                       setActive(filtered.findIndex((e) => e.id === entry.id))
                     }
                     className={
-                      "flex w-full items-center gap-2.5 px-3.5 py-1.5 text-left text-[12px] " +
+                      "flex w-full items-center gap-2.5 px-3.5 py-1.5 text-left text-sm " +
                       (isActive
                         ? "bg-accent-soft text-accent"
                         : "text-fg-1 hover:bg-bg-2 hover:text-fg-0")
@@ -432,7 +432,7 @@ export function CommandPalette({
                       {entry.label}
                     </span>
                     {entry.hint && (
-                      <span className="ml-auto min-w-0 overflow-hidden text-ellipsis whitespace-nowrap pr-1.5 text-[11px] text-fg-3">
+                      <span className="ml-auto min-w-0 overflow-hidden text-ellipsis whitespace-nowrap pr-1.5 text-[12px] text-fg-3">
                         {entry.hint}
                       </span>
                     )}
@@ -451,13 +451,13 @@ export function CommandPalette({
             </div>
           ))}
           {filtered.length === 0 && (
-            <div className="px-3.5 py-5 text-center text-[11.5px] text-fg-3">
+            <div className="px-3.5 py-5 text-center text-sm text-fg-3">
               No matches for &ldquo;{q}&rdquo;
             </div>
           )}
         </div>
 
-        <div className="flex items-center gap-3 border-t border-border-default bg-bg-2 px-3 py-1.5 text-[10.5px] text-fg-3">
+        <div className="flex items-center gap-3 border-t border-border-default bg-bg-2 px-3 py-1.5 text-[11.5px] text-fg-3">
           <span className="inline-flex items-center gap-1">
             <kbd className="kbd">↑↓</kbd>
             <span>navigate</span>

--- a/apps/desktop/src/components/modals/CommitModal.tsx
+++ b/apps/desktop/src/components/modals/CommitModal.tsx
@@ -24,7 +24,7 @@ type PreviewState =
 const EMPTY_CHANGES: PendingChanges = {};
 
 const ED_RUN_BASE =
-  "inline-flex h-[26px] items-center gap-[5px] whitespace-nowrap rounded-[4px] border border-transparent px-2.5 text-[11.5px] font-medium text-fg-1 transition-[background,color,border-color,filter] duration-[120ms]";
+  "inline-flex h-[26px] items-center gap-[5px] whitespace-nowrap rounded-[4px] border border-transparent px-2.5 text-[12.5px] font-medium text-fg-1 transition-[background,color,border-color,filter] duration-[120ms]";
 
 const ED_RUN_SUBTLE =
   ED_RUN_BASE +
@@ -154,10 +154,10 @@ export function CommitModal({ onClose }: { onClose: () => void }) {
           <span className="inline-flex text-accent">
             <Icon.commit size={14} />
           </span>
-          <span className="whitespace-nowrap text-[12.5px] font-semibold text-fg-0">
+          <span className="whitespace-nowrap text-sm font-semibold text-fg-0">
             Review &amp; commit
           </span>
-          <span className="ml-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap border-l border-border-divider pl-1.5 font-mono text-[11px] text-fg-2">
+          <span className="ml-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap border-l border-border-divider pl-1.5 font-mono text-[12px] text-fg-2">
             {activeTable ? `${activeTable.schema}.${activeTable.table}` : "no table"}{" "}
             <span style={{ color: "var(--fg-3)" }}>·</span>{" "}
             {activeConn?.name ?? "no connection"}
@@ -174,7 +174,7 @@ export function CommitModal({ onClose }: { onClose: () => void }) {
         <SummaryItem icon={<Icon.diff size={11} />} bg="var(--update-bg)" color="var(--update)" n={updates.length} label={`update${updates.length === 1 ? "" : "s"}`} />
         <SummaryItem icon={<Icon.close size={11} />} bg="var(--delete-bg)" color="var(--delete)" n={deletes.length} label={`delete${deletes.length === 1 ? "" : "s"}`} />
         <div className="flex-1" />
-        <span className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-[4px] bg-bg-inset px-2 py-1 font-mono text-[10.5px] text-fg-2">
+        <span className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-[4px] bg-bg-inset px-2 py-1 font-mono text-[11.5px] text-fg-2">
           <Icon.bracket size={10} />
           <span>BEGIN ... COMMIT - atomic</span>
         </span>
@@ -182,15 +182,15 @@ export function CommitModal({ onClose }: { onClose: () => void }) {
 
       <div className="grid min-h-0 flex-1 overflow-hidden grid-cols-[320px_1fr]">
         <div className="flex min-h-0 flex-col border-r border-border-default">
-          <div className="flex h-[26px] shrink-0 items-center gap-1.5 border-b border-border-divider px-3 text-[10px] font-semibold uppercase tracking-[0.05em] text-fg-3">
+          <div className="flex h-[26px] shrink-0 items-center gap-1.5 border-b border-border-divider px-3 text-[11px] font-semibold uppercase tracking-[0.05em] text-fg-3">
             <span>Changes</span>
-            <span className="rounded-[8px] bg-bg-2 px-1.5 py-px font-mono text-[10px] text-fg-2">
+            <span className="rounded-[8px] bg-bg-2 px-1.5 py-px font-mono text-[11px] text-fg-2">
               {entries.length}
             </span>
           </div>
           <div className="flex-1 overflow-y-auto py-1.5">
             {entries.length === 0 ? (
-              <div className="px-3 py-3 text-[11px] text-fg-3">
+              <div className="px-3 py-3 text-[12px] text-fg-3">
                 No pending changes on the active table.
               </div>
             ) : (
@@ -202,29 +202,29 @@ export function CommitModal({ onClose }: { onClose: () => void }) {
         </div>
 
         <div className="flex min-h-0 flex-col bg-bg-inset">
-          <div className="flex h-[26px] shrink-0 items-center justify-between border-b border-border-divider bg-bg-1 px-3 text-[10px] font-semibold uppercase tracking-[0.05em] text-fg-3">
+          <div className="flex h-[26px] shrink-0 items-center justify-between border-b border-border-divider bg-bg-1 px-3 text-[11px] font-semibold uppercase tracking-[0.05em] text-fg-3">
             <span>Generated SQL</span>
             <button
               type="button"
               disabled={!preview}
               onClick={() => void navigator.clipboard?.writeText(sqlText)}
-              className="inline-flex h-[26px] items-center gap-1 rounded-[4px] border border-border-default bg-bg-2 px-2 text-[11px] text-fg-1 hover:bg-bg-3 disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex h-[26px] items-center gap-1 rounded-[4px] border border-border-default bg-bg-2 px-2 text-[12px] text-fg-1 hover:bg-bg-3 disabled:cursor-not-allowed disabled:opacity-60"
             >
               <Icon.copy size={11} />
               <span>Copy</span>
             </button>
           </div>
-          <div className="flex-1 overflow-auto py-2 font-mono text-[11.5px] leading-[1.55]">
+          <div className="flex-1 overflow-auto py-2 font-mono text-sm leading-[1.55]">
             {blockers.length > 0 ? (
               <MessageList messages={blockers} tone="warn" />
             ) : previewState.kind === "loading" ? (
-              <div className="px-3 text-[11px] text-fg-3">Generating preview...</div>
+              <div className="px-3 text-[12px] text-fg-3">Generating preview...</div>
             ) : previewState.kind === "error" ? (
               <MessageList messages={[previewState.error]} tone="warn" />
             ) : (
               lines.map((toks, i) => (
                 <div key={i} className="flex px-3">
-                  <span className="inline-flex w-7 shrink-0 select-none items-center justify-end pr-2.5 font-variant-numeric-tabular text-[10px] text-fg-3 font-mono">
+                  <span className="inline-flex w-7 shrink-0 select-none items-center justify-end pr-2.5 font-variant-numeric-tabular text-[11px] text-fg-3 font-mono">
                     {i + 1}
                   </span>
                   <span className="whitespace-pre font-mono">
@@ -238,7 +238,7 @@ export function CommitModal({ onClose }: { onClose: () => void }) {
       </div>
 
       <div className="flex min-h-11 shrink-0 items-center justify-between gap-3 border-t border-border-default bg-bg-2 px-3 py-2">
-        <div className="flex min-w-0 items-center gap-2 text-[10.5px]">
+        <div className="flex min-w-0 items-center gap-2 text-[11.5px]">
           <Icon.warn size={10} stroke={activeConn?.env_tag === "prod" ? "var(--warn)" : "var(--fg-3)"} />
           <span className={activeConn?.env_tag === "prod" ? "text-warn" : "text-fg-2"}>
             {activeConn?.env_tag === "prod" ? "prod" : "transaction"}
@@ -313,13 +313,13 @@ function ChangePreview({
 
   return (
     <ChangeRow tag={tag} tagBg={tagBg} tagColor={tagColor}>
-      <div className="flex items-center gap-1.5 text-[11px]">
+      <div className="flex items-center gap-1.5 text-sm">
         <span className="font-mono font-medium text-fg-0">{label}</span>
       </div>
       {Object.entries(change.edits).map(([col, e]) => (
         <div
           key={col}
-          className="grid items-center gap-[5px] pl-1 font-mono text-[10.5px] grid-cols-[90px_auto_auto_auto]"
+          className="grid items-center gap-[5px] pl-1 font-mono text-sm grid-cols-[90px_auto_auto_auto]"
         >
           <span className="overflow-hidden text-ellipsis text-fg-2">{col}</span>
           <span
@@ -458,7 +458,7 @@ function MessageList({
   tone: "warn" | "muted";
 }) {
   return (
-    <div className={tone === "warn" ? "px-3 text-[11px] text-warn" : "px-3 text-[11px] text-fg-3"}>
+    <div className={tone === "warn" ? "px-3 text-[12px] text-warn" : "px-3 text-[12px] text-fg-3"}>
       {messages.map((message) => (
         <div key={message}>{message}</div>
       ))}
@@ -487,10 +487,10 @@ function SummaryItem({
       >
         {icon}
       </span>
-      <span className="font-mono text-[14px] font-semibold text-fg-0 tabular-nums">
+      <span className="font-mono text-[15px] font-semibold text-fg-0 tabular-nums">
         {n}
       </span>
-      <span className="text-[11px] text-fg-2">{label}</span>
+      <span className="text-sm text-fg-2">{label}</span>
     </div>
   );
 }
@@ -509,7 +509,7 @@ function ChangeRow({
   return (
     <div className="flex gap-2 border-b border-dashed border-border-divider px-3 py-1.5">
       <span
-        className="mt-px inline-flex h-[14px] items-center self-start rounded-[3px] px-1 py-px font-mono text-[9.5px] font-semibold tracking-[0.04em]"
+        className="mt-px inline-flex h-[14px] items-center self-start rounded-[3px] px-1 py-px font-mono text-[10.5px] font-semibold tracking-[0.04em]"
         style={{ background: tagBg, color: tagColor }}
       >
         {tag}

--- a/apps/desktop/src/components/modals/ConfirmDialog.tsx
+++ b/apps/desktop/src/components/modals/ConfirmDialog.tsx
@@ -2,7 +2,7 @@ import { useConfirm } from "../../state/confirm";
 import { Modal } from "./Modal";
 
 const BTN_BASE =
-  "inline-flex h-[26px] items-center gap-[5px] whitespace-nowrap rounded-[4px] border px-3 text-[11.5px] font-medium transition-[background,color,border-color,filter] duration-[120ms]";
+  "inline-flex h-[26px] items-center gap-[5px] whitespace-nowrap rounded-[4px] border px-3 text-sm font-medium transition-[background,color,border-color,filter] duration-[120ms]";
 const BTN_SUBTLE =
   BTN_BASE +
   " text-fg-1 bg-transparent border-border-default hover:bg-bg-3 hover:border-border-strong hover:text-fg-0";
@@ -21,10 +21,10 @@ export function ConfirmDialog() {
   return (
     <Modal onClose={() => resolve(false)} width={420}>
       <div className="flex flex-col gap-3 p-4">
-        <span className="text-[12.5px] font-semibold text-fg-0">
+        <span className="text-sm font-semibold text-fg-0">
           {request.title}
         </span>
-        <span className="whitespace-pre-line text-[11.5px] leading-relaxed text-fg-2">
+        <span className="whitespace-pre-line text-sm leading-relaxed text-fg-2">
           {request.message}
         </span>
         <div className="mt-1 flex justify-end gap-2">

--- a/apps/desktop/src/components/modals/ConnectionDialog.tsx
+++ b/apps/desktop/src/components/modals/ConnectionDialog.tsx
@@ -59,7 +59,7 @@ const SSL_MODES: SslMode[] = [
 ];
 
 const ED_RUN_BASE =
-  "inline-flex h-[26px] items-center gap-[5px] whitespace-nowrap rounded-[4px] border border-transparent px-2.5 text-[11.5px] font-medium transition-[background,color,border-color,filter] duration-[120ms]";
+  "inline-flex h-[26px] items-center gap-[5px] whitespace-nowrap rounded-[4px] border border-transparent px-2.5 text-sm font-medium transition-[background,color,border-color,filter] duration-[120ms]";
 
 const ED_RUN_SUBTLE =
   ED_RUN_BASE +
@@ -70,7 +70,7 @@ const ED_RUN_PRIMARY =
   " bg-accent text-accent-fg hover:brightness-[1.07] disabled:opacity-40 disabled:cursor-not-allowed";
 
 const CD_INPUT =
-  "h-[26px] min-w-0 flex-1 rounded-[4px] border border-border-default bg-bg-inset px-2 text-[11.5px] text-fg-0 outline-none font-sans focus:border-accent-line focus:bg-bg-2";
+  "h-[26px] min-w-0 flex-1 rounded-[4px] border border-border-default bg-bg-inset px-2 text-sm text-fg-0 outline-none font-sans focus:border-accent-line focus:bg-bg-2";
 
 interface ConnectionDialogProps {
   onClose: () => void;
@@ -208,7 +208,7 @@ export function ConnectionDialog({
           <span className="inline-flex text-accent">
             <Icon.database size={14} />
           </span>
-          <span className="whitespace-nowrap text-[12.5px] font-semibold text-fg-0">
+          <span className="whitespace-nowrap text-sm font-semibold text-fg-0">
             {isEdit ? "Edit connection" : "New connection"}
           </span>
         </div>
@@ -245,7 +245,7 @@ export function ConnectionDialog({
                 }
               >
                 <span
-                  className="inline-flex h-7 w-7 items-center justify-center rounded-[6px] border font-mono text-[13px] font-semibold"
+                  className="inline-flex h-7 w-7 items-center justify-center rounded-[6px] border font-mono text-[14px] font-semibold"
                   style={{
                     color: hex,
                     background: `color-mix(in oklab, ${hex} 14%, transparent)`,
@@ -256,7 +256,7 @@ export function ConnectionDialog({
                 </span>
                 <span
                   className={
-                    "text-[10.5px] " +
+                    "text-[11.5px] " +
                     (active ? "font-medium text-fg-0" : "text-fg-1")
                   }
                 >
@@ -275,7 +275,7 @@ export function ConnectionDialog({
                 key={t}
                 onClick={() => setTab(t)}
                 className={
-                  "relative -mb-px inline-flex h-[26px] items-center gap-1.5 px-2.5 text-[11.5px] capitalize border-b-[1.5px] " +
+                  "relative -mb-px inline-flex h-[26px] items-center gap-1.5 px-2.5 text-sm capitalize border-b-[1.5px] " +
                   (isActive
                     ? "border-accent text-accent"
                     : "border-transparent text-fg-2 hover:text-fg-0")
@@ -404,7 +404,7 @@ export function ConnectionDialog({
                 ))}
               </Segment>
               {envTag === "prod" && (
-                <span className="ml-2 inline-flex items-center gap-1 text-[10.5px] text-warn">
+                <span className="ml-2 inline-flex items-center gap-1 text-[11.5px] text-warn">
                   <Icon.warn size={10} />
                   <span>prod will ask you to confirm before changing data (insert / update / delete)</span>
                 </span>
@@ -418,7 +418,7 @@ export function ConnectionDialog({
             <FormRow label="Use SSH tunnel">
               <Toggle on={ssh} onChange={setSsh} />
             </FormRow>
-            <div className="text-[11px] text-fg-3">
+            <div className="text-[12px] text-fg-3">
               SSH tunneling lands in a follow-up slice. Connect directly for now.
             </div>
           </div>
@@ -474,7 +474,7 @@ export function ConnectionDialog({
         </div>
         <div className="flex items-center gap-2">
           {savingError && (
-            <span className="text-[11px] text-warn">{savingError}</span>
+            <span className="text-sm text-warn">{savingError}</span>
           )}
           <button className={ED_RUN_SUBTLE} onClick={onClose}>
             Cancel
@@ -500,7 +500,7 @@ function TestPill({ status }: { status: TestStatus }) {
   if (status.kind === "idle") return null;
   if (status.kind === "running") {
     return (
-      <span className="inline-flex items-center gap-1 text-[11px] text-fg-3">
+      <span className="inline-flex items-center gap-1 text-[12px] text-fg-3">
         <span className="h-1.5 w-1.5 animate-sb-pulse rounded-full bg-accent" />
         contacting…
       </span>
@@ -508,7 +508,7 @@ function TestPill({ status }: { status: TestStatus }) {
   }
   if (status.kind === "ok") {
     return (
-      <span className="inline-flex items-center gap-1.5 text-[11px]">
+      <span className="inline-flex items-center gap-1.5 text-[12px]">
         <span
           className="inline-flex h-[15px] items-center gap-1 rounded-[3px] px-1.5 font-medium"
           style={{
@@ -534,7 +534,7 @@ function TestPill({ status }: { status: TestStatus }) {
     );
   }
   return (
-    <span className="inline-flex max-w-[420px] items-center gap-1 truncate text-[11px] text-warn">
+    <span className="inline-flex max-w-[420px] items-center gap-1 truncate text-sm text-warn">
       <Icon.warn size={10} />
       <span title={status.message}>{truncate(status.message, 80)}</span>
     </span>
@@ -572,13 +572,13 @@ function FormRow({
 }) {
   return (
     <div className="grid min-h-6 items-center gap-3 grid-cols-[110px_1fr]">
-      <div className="flex flex-col gap-px pt-0.5 text-[11.5px] font-medium text-fg-1">
+      <div className="flex flex-col gap-px pt-0.5 text-sm font-medium text-fg-1">
         <span>{label}</span>
         {hint && (
-          <span className="text-[10px] font-normal text-fg-3">{hint}</span>
+          <span className="text-[11px] font-normal text-fg-3">{hint}</span>
         )}
       </div>
-      <div className="flex min-w-0 items-center gap-1.5 text-[11.5px]">
+      <div className="flex min-w-0 items-center gap-1.5 text-sm">
         {children}
       </div>
     </div>
@@ -632,7 +632,7 @@ function Seg({
     <button
       onClick={onClick}
       className={
-        "h-5 rounded-[3px] px-2.5 text-[11px] " +
+        "h-5 rounded-[3px] px-2.5 text-[12px] " +
         (active
           ? "bg-bg-3 font-medium text-fg-0"
           : "text-fg-2 hover:text-fg-0")

--- a/apps/desktop/src/components/modals/EmptyState.tsx
+++ b/apps/desktop/src/components/modals/EmptyState.tsx
@@ -50,11 +50,11 @@ export function EmptyState({ onNew }: { onNew: () => void }) {
             />
           </span>
         </div>
-        <h1 className="m-0 mb-1 text-[20px] font-semibold tracking-[-0.01em] text-fg-0">
+        <h1 className="m-0 mb-1 text-[21px] font-semibold tracking-[-0.01em] text-fg-0">
           Welcome to Cellar
         </h1>
         <p
-          className="m-0 mb-[22px] text-[12.5px] text-fg-2"
+          className="m-0 mb-[22px] text-sm text-fg-2"
           style={{ textWrap: "pretty" }}
         >
           Connect to Postgres, inspect schemas, run SQL, and browse table data.
@@ -63,7 +63,7 @@ export function EmptyState({ onNew }: { onNew: () => void }) {
         <div className="mb-[22px] flex flex-col gap-1.5">
           <button
             onClick={onNew}
-            className="flex h-8 items-center justify-center gap-2 whitespace-nowrap rounded-[6px] border px-3 text-xs font-medium text-accent-fg transition-[filter] duration-[120ms] hover:brightness-[1.07]"
+            className="flex h-8 items-center justify-center gap-2 whitespace-nowrap rounded-[6px] border px-3 text-sm font-medium text-accent-fg transition-[filter] duration-[120ms] hover:brightness-[1.07]"
             style={{
               background: "var(--accent)",
               borderColor: "color-mix(in oklab, var(--accent) 40%, black)",
@@ -75,7 +75,7 @@ export function EmptyState({ onNew }: { onNew: () => void }) {
           <button
             disabled
             title="Connection import is not wired yet"
-            className="flex h-8 cursor-not-allowed items-center justify-center gap-2 whitespace-nowrap rounded-[6px] border border-border-default bg-bg-2 px-3 text-xs text-fg-2 opacity-55"
+            className="flex h-8 cursor-not-allowed items-center justify-center gap-2 whitespace-nowrap rounded-[6px] border border-border-default bg-bg-2 px-3 text-sm text-fg-2 opacity-55"
           >
             <Icon.fileText size={12} />
             <span>Import from DataGrip / DBeaver</span>
@@ -83,14 +83,14 @@ export function EmptyState({ onNew }: { onNew: () => void }) {
           <button
             disabled
             title="Demo database provisioning is not wired yet"
-            className="flex h-8 cursor-not-allowed items-center justify-center gap-2 whitespace-nowrap rounded-[6px] border border-border-default bg-bg-2 px-3 text-xs text-fg-2 opacity-55"
+            className="flex h-8 cursor-not-allowed items-center justify-center gap-2 whitespace-nowrap rounded-[6px] border border-border-default bg-bg-2 px-3 text-sm text-fg-2 opacity-55"
           >
             <Icon.cloud size={12} />
             <span>Connect to demo database</span>
           </button>
         </div>
 
-        <div className="mb-2 text-[10px] uppercase tracking-[0.06em] text-fg-3">
+        <div className="mb-2 text-[11px] uppercase tracking-[0.06em] text-fg-3">
           or pick an engine to start
         </div>
         <div className="mb-[22px] grid grid-cols-5 gap-1.5">
@@ -125,7 +125,7 @@ export function EmptyState({ onNew }: { onNew: () => void }) {
                 >
                   {m.letter}
                 </span>
-                <span className="whitespace-nowrap text-[10px] text-fg-1">
+                <span className="whitespace-nowrap text-sm text-fg-1">
                   {SHORT[e]}
                 </span>
               </button>
@@ -134,30 +134,30 @@ export function EmptyState({ onNew }: { onNew: () => void }) {
         </div>
 
         <div className="mb-[18px] flex justify-center gap-4">
-          <span className="inline-flex items-center gap-1 whitespace-nowrap text-[10.5px] text-fg-3">
+          <span className="inline-flex items-center gap-1 whitespace-nowrap text-[11.5px] text-fg-3">
             <kbd className="kbd">⌘</kbd>
             <kbd className="kbd">K</kbd>
             <span>command palette</span>
           </span>
-          <span className="inline-flex items-center gap-1 whitespace-nowrap text-[10.5px] text-fg-3">
+          <span className="inline-flex items-center gap-1 whitespace-nowrap text-[11.5px] text-fg-3">
             <kbd className="kbd">⌘</kbd>
             <kbd className="kbd">N</kbd>
             <span>new connection</span>
           </span>
-          <span className="inline-flex items-center gap-1 whitespace-nowrap text-[10.5px] text-fg-3">
+          <span className="inline-flex items-center gap-1 whitespace-nowrap text-[11.5px] text-fg-3">
             <kbd className="kbd">⌘</kbd>
             <kbd className="kbd">,</kbd>
             <span>settings</span>
           </span>
         </div>
 
-        <div className="border-t border-border-divider pt-4 text-[10.5px] text-fg-3">
+        <div className="border-t border-border-divider pt-4 text-[11.5px] text-fg-3">
           <span>
             v0.1.0 · MIT licensed ·{" "}
             <button
               disabled
               title="Documentation links are not wired in the desktop shell yet"
-              className="cursor-not-allowed bg-transparent text-[10.5px] text-fg-3 underline underline-offset-2 opacity-70"
+              className="cursor-not-allowed bg-transparent text-[11.5px] text-fg-3 underline underline-offset-2 opacity-70"
             >
               docs
             </button>{" "}
@@ -165,7 +165,7 @@ export function EmptyState({ onNew }: { onNew: () => void }) {
             <button
               disabled
               title="External links are not wired in the desktop shell yet"
-              className="cursor-not-allowed bg-transparent text-[10.5px] text-fg-3 underline underline-offset-2 opacity-70"
+              className="cursor-not-allowed bg-transparent text-[11.5px] text-fg-3 underline underline-offset-2 opacity-70"
             >
               github
             </button>

--- a/apps/desktop/src/components/modals/ExportSetupModal.tsx
+++ b/apps/desktop/src/components/modals/ExportSetupModal.tsx
@@ -113,7 +113,7 @@ export function ExportSetupModal({ onClose }: { onClose: () => void }) {
           <span className="inline-flex text-accent">
             <Icon.download size={14} />
           </span>
-          <span className="whitespace-nowrap text-[12.5px] font-semibold text-fg-0">
+          <span className="whitespace-nowrap text-sm font-semibold text-fg-0">
             Export setup
           </span>
         </div>
@@ -123,7 +123,7 @@ export function ExportSetupModal({ onClose }: { onClose: () => void }) {
       </div>
 
       <div className="flex-1 overflow-y-auto px-4 py-3.5">
-        <p className="m-0 mb-3 max-w-[52ch] text-[11.5px] text-fg-2 text-pretty">
+        <p className="m-0 mb-3 max-w-[52ch] text-sm text-fg-2 text-pretty">
           Pick what to include, then download a <code>.json</code> file you can
           share or move to another machine.
         </p>
@@ -159,13 +159,13 @@ export function ExportSetupModal({ onClose }: { onClose: () => void }) {
                   {on && !empty && <Icon.check size={10} />}
                 </span>
                 <span className="min-w-0">
-                  <span className="flex items-center gap-1.5 text-[12px] font-medium text-fg-0">
+                  <span className="flex items-center gap-1.5 text-sm font-medium text-fg-0">
                     {section.label}
-                    <span className="font-mono text-[10px] text-fg-3">
+                    <span className="font-mono text-[11px] text-fg-3">
                       {empty ? "none saved" : `×${count}`}
                     </span>
                   </span>
-                  <span className="block text-[10.5px] text-fg-3">
+                  <span className="block text-[11.5px] text-fg-3">
                     {section.describe(count)}
                   </span>
                 </span>
@@ -174,7 +174,7 @@ export function ExportSetupModal({ onClose }: { onClose: () => void }) {
           })}
         </div>
 
-        <div className="mt-3 flex items-center gap-1.5 rounded-[4px] border border-dashed border-border-default bg-bg-inset px-3 py-2 text-[11px] text-fg-2">
+        <div className="mt-3 flex items-center gap-1.5 rounded-[4px] border border-dashed border-border-default bg-bg-inset px-3 py-2 text-sm text-fg-2">
           <Icon.lock size={12} stroke="var(--fg-3)" />
           <span>
             Passwords and API keys are never exported — recipients re-enter their
@@ -184,7 +184,7 @@ export function ExportSetupModal({ onClose }: { onClose: () => void }) {
       </div>
 
       <div className="flex h-11 shrink-0 items-center justify-between gap-3 border-t border-border-default bg-bg-2 px-3">
-        <span className="font-mono text-[10.5px] text-fg-3">
+        <span className="font-mono text-[11.5px] text-fg-3">
           {anySelected ? `${json.length.toLocaleString()} bytes` : "nothing selected"}
         </span>
         <div className="flex items-center gap-2">

--- a/apps/desktop/src/components/modals/ImportDataModal.tsx
+++ b/apps/desktop/src/components/modals/ImportDataModal.tsx
@@ -73,7 +73,7 @@ export function ImportDataModal({ onClose }: { onClose: () => void }) {
   if (!tab) {
     return (
       <Modal onClose={onClose} width={420}>
-        <div className="flex items-center gap-2 px-4 py-5 text-[12px] text-fg-1">
+        <div className="flex items-center gap-2 px-4 py-5 text-sm text-fg-1">
           <Icon.warn size={13} stroke="var(--fg-3)" />
           <span>Open a table before importing data.</span>
         </div>
@@ -198,10 +198,10 @@ export function ImportDataModal({ onClose }: { onClose: () => void }) {
           <span className="inline-flex text-accent">
             <Icon.upload size={14} />
           </span>
-          <span className="whitespace-nowrap text-[12.5px] font-semibold text-fg-0">
+          <span className="whitespace-nowrap text-sm font-semibold text-fg-0">
             Import data
           </span>
-          <span className="ml-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap border-l border-border-divider pl-1.5 font-mono text-[11px] text-fg-2">
+          <span className="ml-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap border-l border-border-divider pl-1.5 font-mono text-sm text-fg-2">
             {tab.schema}.{tab.table}{" "}
             <span style={{ color: "var(--fg-3)" }}>·</span>{" "}
             {conn?.name ?? "no connection"}
@@ -216,7 +216,7 @@ export function ImportDataModal({ onClose }: { onClose: () => void }) {
       {result ? (
         <ResultView result={result} />
       ) : !table ? (
-        <div className="flex-1 px-4 py-4 text-[11.5px] text-warn">
+        <div className="flex-1 px-4 py-4 text-sm text-warn">
           Schema metadata for this table isn't loaded yet — open the table once,
           then try again.
         </div>
@@ -262,7 +262,7 @@ export function ImportDataModal({ onClose }: { onClose: () => void }) {
 
       {!result && table && (
         <div className="flex h-11 shrink-0 items-center justify-between gap-3 border-t border-border-default bg-bg-2 px-3">
-          <span className="min-w-0 truncate text-[10.5px] text-fg-2">
+          <span className="min-w-0 truncate text-[11.5px] text-fg-2">
             {commitError ? (
               <span className="text-delete">{commitError}</span>
             ) : step === "source" ? (
@@ -340,7 +340,7 @@ function SourceView({
 }) {
   return (
     <div className="flex-1 overflow-y-auto px-4 py-3.5">
-      <p className="m-0 mb-3 max-w-[60ch] text-[11.5px] text-fg-2 text-pretty">
+      <p className="m-0 mb-3 max-w-[60ch] text-sm text-fg-2 text-pretty">
         Load a CSV file to update or insert rows in this table. Its first row is
         treated as the header. You'll map columns, choose a match key, and review
         the generated SQL before anything is committed.
@@ -355,13 +355,13 @@ function SourceView({
       <button
         type="button"
         onClick={() => fileRef.current?.click()}
-        className="flex w-full items-center justify-center gap-2 rounded-[6px] border border-dashed border-border-strong bg-bg-2 px-3 py-6 text-[12px] text-fg-1 hover:border-accent-line hover:bg-accent-soft"
+        className="flex w-full items-center justify-center gap-2 rounded-[6px] border border-dashed border-border-strong bg-bg-2 px-3 py-6 text-sm text-fg-1 hover:border-accent-line hover:bg-accent-soft"
       >
         <Icon.fileText size={14} stroke="var(--fg-2)" />
         <span>{fileName ? `Loaded ${fileName} — choose another` : "Choose a .csv file"}</span>
       </button>
       {error && (
-        <div className="mt-2.5 flex items-start gap-1.5 rounded-[4px] border border-[color-mix(in_oklab,var(--delete)_30%,var(--border-default))] bg-delete-bg px-3 py-2 text-[11px] text-delete">
+        <div className="mt-2.5 flex items-start gap-1.5 rounded-[4px] border border-[color-mix(in_oklab,var(--delete)_30%,var(--border-default))] bg-delete-bg px-3 py-2 text-sm text-delete">
           <Icon.warn size={12} />
           <span>{error}</span>
         </div>
@@ -426,8 +426,8 @@ function ConfigureView({
                 {mode === m.value && <Icon.check size={8} />}
               </span>
               <span>
-                <span className="block text-[12px] font-medium text-fg-0">{m.label}</span>
-                <span className="block text-[10.5px] text-fg-3">{m.hint}</span>
+                <span className="block text-sm font-medium text-fg-0">{m.label}</span>
+                <span className="block text-[11.5px] text-fg-3">{m.hint}</span>
               </span>
             </button>
           ))}
@@ -438,7 +438,7 @@ function ConfigureView({
         title="Columns"
         sub="Map each table column to a CSV column. Pick the match key (PK is unique-constraint backed for upsert/insert) and which fields to write."
       >
-        <div className="grid grid-cols-[1fr_140px_auto] items-center gap-x-2 px-1 pb-1 text-[9.5px] font-semibold uppercase tracking-[0.05em] text-fg-3">
+        <div className="grid grid-cols-[1fr_140px_auto] items-center gap-x-2 px-1 pb-1 text-[10.5px] font-semibold uppercase tracking-[0.05em] text-fg-3">
           <span>Table column</span>
           <span>From CSV</span>
           <span className="text-right">Role</span>
@@ -453,12 +453,12 @@ function ConfigureView({
                 className="grid grid-cols-[1fr_140px_auto] items-center gap-x-2 rounded-[4px] border border-border-default bg-bg-2 px-2 py-1"
               >
                 <span className="flex min-w-0 items-center gap-1.5">
-                  <span className="truncate font-mono text-[11.5px] text-fg-0">
+                  <span className="truncate font-mono text-sm text-fg-0">
                     {col.name}
                   </span>
                   {col.is_primary_key && <Tag tone="accent">PK</Tag>}
                   {!col.nullable && <Tag tone="warn">NOT NULL</Tag>}
-                  <span className="truncate font-mono text-[10px] text-fg-3">
+                  <span className="truncate font-mono text-[11px] text-fg-3">
                     {col.data_type}
                   </span>
                 </span>
@@ -467,7 +467,7 @@ function ConfigureView({
                   onChange={(e) =>
                     remap(col.name, e.target.value === "" ? null : Number(e.target.value))
                   }
-                  className="h-[24px] w-full rounded-[4px] border border-border-default bg-bg-inset px-1.5 text-[11px] text-fg-0 outline-none focus:border-accent-line"
+                  className="h-[24px] w-full rounded-[4px] border border-border-default bg-bg-inset px-1.5 text-sm text-fg-0 outline-none focus:border-accent-line"
                 >
                   <option value="">(skip)</option>
                   {csv.headers.map((h, i) => (
@@ -501,7 +501,7 @@ function ConfigureView({
       </Section>
 
       {blockers.length > 0 && (
-        <div className="mx-4 mt-1 flex flex-col gap-0.5 rounded-[4px] border border-[color-mix(in_oklab,var(--warn)_30%,var(--border-default))] bg-warn-bg px-3 py-2 text-[11px] text-warn">
+        <div className="mx-4 mt-1 flex flex-col gap-0.5 rounded-[4px] border border-[color-mix(in_oklab,var(--warn)_30%,var(--border-default))] bg-warn-bg px-3 py-2 text-sm text-warn">
           {blockers.map((b) => (
             <div key={b} className="flex items-start gap-1.5">
               <Icon.warn size={11} />
@@ -541,25 +541,25 @@ function PreviewView({
           <Stat n={counts.skipped} label="skipped (no match key)" color="var(--fg-3)" />
         )}
         <div className="flex-1" />
-        <span className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-[4px] bg-bg-inset px-2 py-1 font-mono text-[10.5px] text-fg-2">
+        <span className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-[4px] bg-bg-inset px-2 py-1 font-mono text-[11.5px] text-fg-2">
           <Icon.bracket size={10} />
           <span>BEGIN … COMMIT · atomic</span>
         </span>
       </div>
-      <div className="flex h-[24px] shrink-0 items-center justify-between border-b border-border-divider bg-bg-1 px-3 text-[10px] font-semibold uppercase tracking-[0.05em] text-fg-3">
+      <div className="flex h-[24px] shrink-0 items-center justify-between border-b border-border-divider bg-bg-1 px-3 text-[11px] font-semibold uppercase tracking-[0.05em] text-fg-3">
         <span>
           Generated SQL{totalRows > 25 ? " (first 25 rows shown)" : ""}
         </span>
       </div>
-      <div className="flex-1 overflow-auto bg-bg-inset py-2 font-mono text-[11.5px] leading-[1.55]">
+      <div className="flex-1 overflow-auto bg-bg-inset py-2 font-mono text-sm leading-[1.55]">
         {previewError ? (
-          <div className="px-3 text-[11px] text-delete">{previewError}</div>
+          <div className="px-3 text-sm text-delete">{previewError}</div>
         ) : sqlLines.length === 0 ? (
-          <div className="px-3 text-[11px] text-fg-3">Generating preview…</div>
+          <div className="px-3 text-sm text-fg-3">Generating preview…</div>
         ) : (
           sqlLines.map((toks, i) => (
             <div key={i} className="flex px-3">
-              <span className="inline-flex w-7 shrink-0 select-none items-center justify-end pr-2.5 font-mono text-[10px] text-fg-3">
+              <span className="inline-flex w-7 shrink-0 select-none items-center justify-end pr-2.5 font-mono text-[11px] text-fg-3">
                 {i + 1}
               </span>
               <span className="whitespace-pre font-mono">{renderTokens(toks)}</span>
@@ -578,9 +578,9 @@ function ResultView({ result }: { result: { rows: number; ms: number } }) {
         <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-accent-soft text-accent">
           <Icon.check size={13} />
         </span>
-        <span className="text-[13px] font-semibold text-fg-0">Import committed</span>
+        <span className="text-sm font-semibold text-fg-0">Import committed</span>
       </div>
-      <p className="m-0 text-[11.5px] text-fg-2">
+      <p className="m-0 text-sm text-fg-2">
         {result.rows} row{result.rows === 1 ? "" : "s"} affected in {result.ms} ms.
         The table has been refreshed.
       </p>
@@ -596,7 +596,7 @@ function Tag({ tone, children }: { tone: "accent" | "warn"; children: React.Reac
   return (
     <span
       className={
-        "shrink-0 rounded-[3px] px-1 py-px font-mono text-[8.5px] uppercase tracking-[0.04em] " +
+        "shrink-0 rounded-[3px] px-1 py-px font-mono text-[9.5px] uppercase tracking-[0.04em] " +
         (tone === "accent" ? "bg-accent-soft text-accent" : "bg-warn-bg text-warn")
       }
     >
@@ -626,7 +626,7 @@ function RoleToggle({
       title={title}
       aria-pressed={active}
       className={
-        "h-[20px] rounded-[3px] border px-1.5 text-[10px] " +
+        "h-[20px] rounded-[3px] border px-1.5 text-[11px] " +
         (active
           ? "border-accent bg-accent text-accent-fg"
           : "border-border-default bg-bg-inset text-fg-2 hover:text-fg-0") +
@@ -641,10 +641,10 @@ function RoleToggle({
 function Stat({ n, label, color }: { n: number; label: string; color: string }) {
   return (
     <div className="flex items-center gap-1.5">
-      <span className="font-mono text-[14px] font-semibold tabular-nums" style={{ color }}>
+      <span className="font-mono text-[15px] font-semibold tabular-nums" style={{ color }}>
         {n}
       </span>
-      <span className="text-[11px] text-fg-2">{label}</span>
+      <span className="text-sm text-fg-2">{label}</span>
     </div>
   );
 }

--- a/apps/desktop/src/components/modals/ImportDatagripDialog.tsx
+++ b/apps/desktop/src/components/modals/ImportDatagripDialog.tsx
@@ -8,10 +8,10 @@ import { Modal } from "./Modal";
 import { useConnections } from "../../state/connections";
 
 const ROW_INPUT =
-  "h-[24px] rounded-[4px] border border-border-default bg-bg-inset px-2 text-[11px] font-mono text-fg-0 outline-none focus:border-accent-line focus:bg-bg-2 disabled:opacity-40";
+  "h-[24px] rounded-[4px] border border-border-default bg-bg-inset px-2 text-sm font-mono text-fg-0 outline-none focus:border-accent-line focus:bg-bg-2 disabled:opacity-40";
 
 const BTN_BASE =
-  "inline-flex h-[26px] items-center gap-[5px] whitespace-nowrap rounded-[4px] border px-2.5 text-[11.5px] font-medium transition-[background,color,border-color,filter] duration-[120ms]";
+  "inline-flex h-[26px] items-center gap-[5px] whitespace-nowrap rounded-[4px] border px-2.5 text-sm font-medium transition-[background,color,border-color,filter] duration-[120ms]";
 const BTN_SUBTLE =
   BTN_BASE +
   " text-fg-1 bg-transparent border-border-default hover:bg-bg-3 hover:border-border-strong hover:text-fg-0";
@@ -104,7 +104,7 @@ export function ImportDatagripDialog({ onClose }: { onClose: () => void }) {
           <span className="inline-flex text-accent">
             <Icon.database size={14} />
           </span>
-          <span className="whitespace-nowrap text-[12.5px] font-semibold text-fg-0">
+          <span className="whitespace-nowrap text-sm font-semibold text-fg-0">
             Import from DataGrip
           </span>
         </div>
@@ -121,19 +121,19 @@ export function ImportDatagripDialog({ onClose }: { onClose: () => void }) {
           includes the strip behind it). NB: calc needs spaces → underscores. */}
       <div className="max-h-[calc(90vh_-_200px)] min-h-0 flex-1 overflow-y-auto px-4 pt-3 pb-4">
         {load.kind === "loading" && (
-          <div className="px-2 py-8 text-center text-[11.5px] text-fg-3">
+          <div className="px-2 py-8 text-center text-sm text-fg-3">
             Scanning DataGrip…
           </div>
         )}
 
         {load.kind === "error" && (
-          <div className="px-2 py-8 text-center text-[11.5px] text-warn">
+          <div className="px-2 py-8 text-center text-sm text-warn">
             {load.message}
           </div>
         )}
 
         {load.kind === "ready" && conns.length === 0 && (
-          <div className="px-2 py-8 text-center text-[11.5px] text-fg-3">
+          <div className="px-2 py-8 text-center text-sm text-fg-3">
             No importable DataGrip connections found.
           </div>
         )}
@@ -141,14 +141,14 @@ export function ImportDatagripDialog({ onClose }: { onClose: () => void }) {
         {load.kind === "ready" && conns.length > 0 && (
           <div className="flex flex-col gap-1.5">
             <div className="mb-1 flex items-center justify-between gap-3">
-              <span className="text-[11px] text-fg-3">
+              <span className="text-[12px] text-fg-3">
                 Passwords aren&apos;t stored by DataGrip — add them now or on
                 first connect.
               </span>
               <button
                 type="button"
                 onClick={toggleAll}
-                className="shrink-0 text-[11px] font-medium text-accent hover:underline"
+                className="shrink-0 text-sm font-medium text-accent hover:underline"
               >
                 {allSelected ? "Unselect all" : "Select all"}
               </button>
@@ -170,15 +170,15 @@ export function ImportDatagripDialog({ onClose }: { onClose: () => void }) {
                   />
                   <EngineBadge engine={c.engine as Engine} size={16} />
                   <div className="flex min-w-0 flex-1 flex-col">
-                    <span className="truncate text-[11.5px] font-medium text-fg-0">
+                    <span className="truncate text-sm font-medium text-fg-0">
                       {c.name}
                       {exists && (
-                        <span className="ml-2 text-[10px] font-normal text-warn">
+                        <span className="ml-2 text-[11px] font-normal text-warn">
                           overwrites existing
                         </span>
                       )}
                     </span>
-                    <span className="truncate font-mono text-[10px] text-fg-3">
+                    <span className="truncate font-mono text-[11px] text-fg-3">
                       {c.user ? `${c.user}@` : ""}
                       {c.host}:{c.port}
                     </span>
@@ -209,7 +209,7 @@ export function ImportDatagripDialog({ onClose }: { onClose: () => void }) {
             })}
 
             {skipped.length > 0 && (
-              <div className="mt-2 rounded-[5px] border border-border-default bg-bg-inset px-2.5 py-2 text-[10.5px] text-fg-3">
+              <div className="mt-2 rounded-[5px] border border-border-default bg-bg-inset px-2.5 py-2 text-[11.5px] text-fg-3">
                 <div className="mb-1 font-medium text-fg-2">
                   Skipped {skipped.length}
                 </div>
@@ -225,14 +225,14 @@ export function ImportDatagripDialog({ onClose }: { onClose: () => void }) {
       </div>
 
       <div className="flex h-11 shrink-0 items-center justify-between gap-3 border-t border-border-default bg-bg-2 px-3">
-        <span className="text-[11px] text-fg-3">
+        <span className="text-[12px] text-fg-3">
           {load.kind === "ready" && conns.length > 0
             ? `${chosen.length} of ${conns.length} selected`
             : ""}
         </span>
         <div className="flex items-center gap-2">
           {importError && (
-            <span className="text-[11px] text-warn">{importError}</span>
+            <span className="text-[12px] text-warn">{importError}</span>
           )}
           <button className={BTN_SUBTLE} onClick={onClose}>
             Cancel

--- a/apps/desktop/src/components/modals/ImportSetupModal.tsx
+++ b/apps/desktop/src/components/modals/ImportSetupModal.tsx
@@ -135,7 +135,7 @@ export function ImportSetupModal({ onClose }: { onClose: () => void }) {
           <span className="inline-flex text-accent">
             <Icon.upload size={14} />
           </span>
-          <span className="whitespace-nowrap text-[12.5px] font-semibold text-fg-0">
+          <span className="whitespace-nowrap text-sm font-semibold text-fg-0">
             Import setup
           </span>
         </div>
@@ -170,7 +170,7 @@ export function ImportSetupModal({ onClose }: { onClose: () => void }) {
       <div className="flex h-11 shrink-0 items-center justify-between gap-3 border-t border-border-default bg-bg-2 px-3">
         {result ? (
           <>
-            <span className="text-[11px] text-fg-2">Import complete.</span>
+            <span className="text-sm text-fg-2">Import complete.</span>
             <button className={ED_RUN_PRIMARY} onClick={onClose}>
               <Icon.check size={11} />
               <span>Done</span>
@@ -199,7 +199,7 @@ export function ImportSetupModal({ onClose }: { onClose: () => void }) {
           </>
         ) : (
           <>
-            <span className="font-mono text-[10.5px] text-fg-3">
+            <span className="font-mono text-[11.5px] text-fg-3">
               {fileName ?? "no file selected"}
             </span>
             <button
@@ -240,7 +240,7 @@ function SourceView({
 }) {
   return (
     <div className="flex-1 overflow-y-auto px-4 py-3.5">
-      <p className="m-0 mb-3 max-w-[56ch] text-[11.5px] text-fg-2 text-pretty">
+      <p className="m-0 mb-3 max-w-[56ch] text-sm text-fg-2 text-pretty">
         Load a Cellar setup file someone shared with you. You'll review each item
         before anything changes.
       </p>
@@ -255,13 +255,13 @@ function SourceView({
       <button
         type="button"
         onClick={() => fileRef.current?.click()}
-        className="flex w-full items-center justify-center gap-2 rounded-[6px] border border-dashed border-border-strong bg-bg-2 px-3 py-5 text-[12px] text-fg-1 hover:border-accent-line hover:bg-accent-soft"
+        className="flex w-full items-center justify-center gap-2 rounded-[6px] border border-dashed border-border-strong bg-bg-2 px-3 py-5 text-sm text-fg-1 hover:border-accent-line hover:bg-accent-soft"
       >
         <Icon.fileText size={14} stroke="var(--fg-2)" />
         <span>{fileName ? `Loaded ${fileName} — choose another` : "Choose a .json file"}</span>
       </button>
 
-      <div className="my-3 flex items-center gap-2 text-[10.5px] text-fg-3">
+      <div className="my-3 flex items-center gap-2 text-[11.5px] text-fg-3">
         <span className="h-px flex-1 bg-border-divider" />
         <span>or paste JSON</span>
         <span className="h-px flex-1 bg-border-divider" />
@@ -273,11 +273,11 @@ function SourceView({
         onBlur={() => raw.trim() && onReview()}
         spellCheck={false}
         placeholder={'{\n  "format": "cellar.setup",\n  ...\n}'}
-        className="h-[180px] w-full resize-none rounded-[5px] border border-border-default bg-bg-inset px-2.5 py-2 font-mono text-[11px] text-fg-0 outline-none focus:border-accent-line"
+        className="h-[180px] w-full resize-none rounded-[5px] border border-border-default bg-bg-inset px-2.5 py-2 font-mono text-sm text-fg-0 outline-none focus:border-accent-line"
       />
 
       {error && (
-        <div className="mt-2.5 flex items-start gap-1.5 rounded-[4px] border border-[color-mix(in_oklab,var(--delete)_30%,var(--border-default))] bg-delete-bg px-3 py-2 text-[11px] text-delete">
+        <div className="mt-2.5 flex items-start gap-1.5 rounded-[4px] border border-[color-mix(in_oklab,var(--delete)_30%,var(--border-default))] bg-delete-bg px-3 py-2 text-sm text-delete">
           <Icon.warn size={12} />
           <span>{error}</span>
         </div>
@@ -330,10 +330,10 @@ function ReviewView({
               {plan.settings.apply && <Icon.check size={10} />}
             </span>
             <span className="min-w-0">
-              <span className="block text-[12px] font-medium text-fg-0">
+              <span className="block text-sm font-medium text-fg-0">
                 Apply imported appearance & settings
               </span>
-              <span className="flex items-center gap-1.5 text-[10.5px] text-fg-3">
+              <span className="flex items-center gap-1.5 text-[11.5px] text-fg-3">
                 <span
                   className="inline-block h-2.5 w-2.5 rounded-full border border-white/15"
                   style={{ background: plan.settings.settings.accent }}
@@ -423,7 +423,7 @@ function ConnRow({
     <div className="flex items-center gap-2.5 rounded-[4px] border border-border-default bg-bg-2 px-2.5 py-1.5">
       <span className="min-w-0 flex-1">
         <span className="flex items-center gap-1.5">
-          <span className="truncate text-[11.5px] font-medium text-fg-0">
+          <span className="truncate text-sm font-medium text-fg-0">
             {item.incoming.name}
           </span>
           <StatusBadge
@@ -431,7 +431,7 @@ function ConnRow({
             label={dup ? `dup of ${item.duplicateOfName}` : "new"}
           />
         </span>
-        <span className="block truncate font-mono text-[10px] text-fg-3">
+        <span className="block truncate font-mono text-[11px] text-fg-3">
           {connHint(item.incoming)}
         </span>
       </span>
@@ -460,7 +460,7 @@ function LayoutRow({
     <div className="flex items-center gap-2.5 rounded-[4px] border border-border-default bg-bg-2 px-2.5 py-1.5">
       <span className="min-w-0 flex-1">
         <span className="flex items-center gap-1.5">
-          <span className="truncate font-mono text-[11px] text-fg-0">
+          <span className="truncate font-mono text-sm text-fg-0">
             {item.tablePath}
           </span>
           <StatusBadge
@@ -468,7 +468,7 @@ function LayoutRow({
             label={item.exists ? "exists" : "new"}
           />
         </span>
-        <span className="block truncate font-mono text-[10px] text-fg-3">
+        <span className="block truncate font-mono text-[11px] text-fg-3">
           {item.connectionId || "—"} · {item.layout.order.length} cols
         </span>
       </span>
@@ -500,22 +500,22 @@ function ResultView({ result }: { result: ImportResult }) {
         <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-accent-soft text-accent">
           <Icon.check size={13} />
         </span>
-        <span className="text-[13px] font-semibold text-fg-0">Setup imported</span>
+        <span className="text-sm font-semibold text-fg-0">Setup imported</span>
       </div>
       <ul className="m-0 flex list-none flex-col gap-1 p-0">
         {lines.length ? (
           lines.map((line) => (
-            <li key={line} className="flex items-center gap-1.5 text-[11.5px] text-fg-1">
+            <li key={line} className="flex items-center gap-1.5 text-sm text-fg-1">
               <span className="h-1 w-1 rounded-full bg-fg-3" />
               {line}
             </li>
           ))
         ) : (
-          <li className="text-[11.5px] text-fg-2">Nothing was changed.</li>
+          <li className="text-sm text-fg-2">Nothing was changed.</li>
         )}
       </ul>
       {importedConns > 0 && (
-        <div className="mt-3 flex items-start gap-1.5 rounded-[4px] border border-dashed border-border-default bg-bg-inset px-3 py-2 text-[11px] text-fg-2">
+        <div className="mt-3 flex items-start gap-1.5 rounded-[4px] border border-dashed border-border-default bg-bg-inset px-3 py-2 text-sm text-fg-2">
           <Icon.lock size={12} stroke="var(--fg-3)" />
           <span>
             Imported connections have no password yet — open each one and set its
@@ -535,7 +535,7 @@ function StatusBadge({ tone, label }: { tone: "ok" | "warn"; label: string }) {
   return (
     <span
       className={
-        "shrink-0 rounded-[3px] px-1.5 py-px font-mono text-[9px] uppercase tracking-[0.04em] " +
+        "shrink-0 rounded-[3px] px-1.5 py-px font-mono text-[10px] uppercase tracking-[0.04em] " +
         (tone === "warn"
           ? "bg-warn-bg text-warn"
           : "bg-insert-bg text-insert")
@@ -564,7 +564,7 @@ function MiniSegment<T extends string>({
           onClick={() => onChange(o.value)}
           aria-pressed={value === o.value}
           className={
-            "h-5 rounded-[3px] px-2 text-[10.5px] " +
+            "h-5 rounded-[3px] px-2 text-[11.5px] " +
             (value === o.value
               ? "bg-bg-3 font-medium text-fg-0"
               : "text-fg-2 hover:text-fg-0")
@@ -580,7 +580,7 @@ function MiniSegment<T extends string>({
 function BulkBar({ children }: { children: React.ReactNode }) {
   return (
     <div className="mb-1 flex items-center gap-1.5">
-      <span className="text-[10px] uppercase tracking-[0.06em] text-fg-3">Bulk</span>
+      <span className="text-[11px] uppercase tracking-[0.06em] text-fg-3">Bulk</span>
       {children}
     </div>
   );
@@ -597,7 +597,7 @@ function BulkBtn({
     <button
       type="button"
       onClick={onClick}
-      className="rounded-[3px] border border-border-default bg-bg-2 px-2 py-0.5 text-[10.5px] text-fg-2 hover:border-border-strong hover:text-fg-0"
+      className="rounded-[3px] border border-border-default bg-bg-2 px-2 py-0.5 text-[11.5px] text-fg-2 hover:border-border-strong hover:text-fg-0"
     >
       {children}
     </button>

--- a/apps/desktop/src/components/modals/SaveTemplateModal.tsx
+++ b/apps/desktop/src/components/modals/SaveTemplateModal.tsx
@@ -51,7 +51,7 @@ export function SaveTemplateModal({
           <span className="inline-flex text-accent">
             <Icon.star size={14} />
           </span>
-          <span className="whitespace-nowrap text-[12.5px] font-semibold text-fg-0">
+          <span className="whitespace-nowrap text-sm font-semibold text-fg-0">
             Save query template
           </span>
         </div>
@@ -61,9 +61,9 @@ export function SaveTemplateModal({
       </div>
 
       <div className="flex-1 overflow-y-auto px-4 py-3.5">
-        <label className="mb-1 block text-[11px] font-medium text-fg-1">Name</label>
+        <label className="mb-1 block text-sm font-medium text-fg-1">Name</label>
         <input
-          className="mb-3 w-full rounded-[5px] border border-border-default bg-bg-inset px-2.5 py-1.5 text-[12px] text-fg-0 outline-none focus:border-accent"
+          className="mb-3 w-full rounded-[5px] border border-border-default bg-bg-inset px-2.5 py-1.5 text-sm text-fg-0 outline-none focus:border-accent"
           value={name}
           autoFocus
           spellCheck={false}
@@ -74,24 +74,24 @@ export function SaveTemplateModal({
           placeholder="Recent orders by region"
         />
 
-        <label className="mb-1 block text-[11px] font-medium text-fg-1">
+        <label className="mb-1 block text-sm font-medium text-fg-1">
           Description <span className="text-fg-3">(optional)</span>
         </label>
         <textarea
-          className="mb-3 h-16 w-full resize-none rounded-[5px] border border-border-default bg-bg-inset px-2.5 py-1.5 text-[12px] text-fg-0 outline-none focus:border-accent"
+          className="mb-3 h-16 w-full resize-none rounded-[5px] border border-border-default bg-bg-inset px-2.5 py-1.5 text-sm text-fg-0 outline-none focus:border-accent"
           value={description}
           spellCheck={false}
           onChange={(e) => setDescription(e.target.value)}
           placeholder="What this query is for…"
         />
 
-        <label className="mb-1 block text-[11px] font-medium text-fg-1">SQL</label>
-        <pre className="m-0 max-h-32 overflow-auto rounded-[5px] border border-border-default bg-bg-inset px-2.5 py-1.5 font-mono text-[11px] leading-[1.5] text-fg-2 whitespace-pre-wrap">
+        <label className="mb-1 block text-sm font-medium text-fg-1">SQL</label>
+        <pre className="m-0 max-h-32 overflow-auto rounded-[5px] border border-border-default bg-bg-inset px-2.5 py-1.5 font-mono text-sm leading-[1.5] text-fg-2 whitespace-pre-wrap">
           {sql.trim()}
         </pre>
 
         {error && (
-          <p className="mt-2 mb-0 text-[11px] text-delete">{error}</p>
+          <p className="mt-2 mb-0 text-sm text-delete">{error}</p>
         )}
       </div>
 

--- a/apps/desktop/src/components/modals/SchemaCompareDialog.tsx
+++ b/apps/desktop/src/components/modals/SchemaCompareDialog.tsx
@@ -88,7 +88,7 @@ export function SchemaCompareDialog({
       <div className="flex h-[38px] shrink-0 items-center justify-between border-b border-border-default pl-3.5 pr-2">
         <div className="flex items-center gap-2">
           <Icon.diff size={14} stroke="var(--accent)" />
-          <span className="text-[12.5px] font-semibold text-fg-0">
+          <span className="text-sm font-semibold text-fg-0">
             Compare schemas
           </span>
         </div>
@@ -127,18 +127,18 @@ export function SchemaCompareDialog({
           onError={setError}
         />
 
-        {error && <div className="text-[11px] text-warn">{error}</div>}
+        {error && <div className="text-sm text-warn">{error}</div>}
       </div>
 
       <div className="flex min-h-11 shrink-0 items-center justify-between gap-3 border-t border-border-default bg-bg-2 px-3 py-2">
-        <span className="text-[10.5px] text-fg-3">
+        <span className="text-[11.5px] text-fg-3">
           The migration transforms the source into the target. Generated SQL is
           reviewed before it runs.
         </span>
         <div className="flex items-center gap-2">
           <button
             type="button"
-            className="inline-flex h-[26px] items-center rounded-[4px] border border-border-default bg-transparent px-2.5 text-[11.5px] text-fg-1 hover:bg-bg-3"
+            className="inline-flex h-[26px] items-center rounded-[4px] border border-border-default bg-transparent px-2.5 text-sm text-fg-1 hover:bg-bg-3"
             onClick={onClose}
           >
             Cancel
@@ -147,7 +147,7 @@ export function SchemaCompareDialog({
             type="button"
             disabled={!canCompare}
             onClick={handleCompare}
-            className="inline-flex h-[26px] items-center gap-1.5 rounded-[4px] border border-transparent bg-accent px-2.5 text-[11.5px] font-medium text-white hover:brightness-[1.07] disabled:cursor-not-allowed disabled:opacity-60"
+            className="inline-flex h-[26px] items-center gap-1.5 rounded-[4px] border border-transparent bg-accent px-2.5 text-sm font-medium text-white hover:brightness-[1.07] disabled:cursor-not-allowed disabled:opacity-60"
           >
             <Icon.diff size={11} />
             Compare
@@ -208,8 +208,8 @@ function SidePicker({
   return (
     <div className="flex flex-col gap-2 rounded-[6px] border border-border-default bg-bg-2 p-2.5">
       <div className="flex items-baseline justify-between">
-        <span className="text-[11.5px] font-semibold text-fg-0">{heading}</span>
-        <span className="text-[10px] text-fg-3">{subtitle}</span>
+        <span className="text-sm font-semibold text-fg-0">{heading}</span>
+        <span className="text-[11px] text-fg-3">{subtitle}</span>
       </div>
 
       <div className="flex gap-1">
@@ -331,7 +331,7 @@ function SnapshotManager({
 
   return (
     <div className="flex flex-col gap-2 rounded-[6px] border border-border-default bg-bg-2 p-2.5">
-      <span className="text-[11.5px] font-semibold text-fg-0">Snapshots</span>
+      <span className="text-sm font-semibold text-fg-0">Snapshots</span>
       <div className="flex items-end gap-2">
         <Field label="Connection" className="flex-1">
           <Select
@@ -356,7 +356,7 @@ function SnapshotManager({
           type="button"
           disabled={!canSave}
           onClick={() => void save()}
-          className="inline-flex h-[26px] items-center gap-1.5 rounded-[4px] border border-border-default bg-bg-1 px-2.5 text-[11.5px] text-fg-1 hover:bg-bg-3 disabled:cursor-not-allowed disabled:opacity-60"
+          className="inline-flex h-[26px] items-center gap-1.5 rounded-[4px] border border-border-default bg-bg-1 px-2.5 text-sm text-fg-1 hover:bg-bg-3 disabled:cursor-not-allowed disabled:opacity-60"
         >
           <Icon.download size={11} />
           {saving ? "Saving…" : "Save snapshot"}
@@ -367,10 +367,10 @@ function SnapshotManager({
           {snapshots.map((s) => (
             <div
               key={s.id}
-              className="flex items-center gap-2 border-b border-border-divider px-2 py-1 text-[11px] last:border-b-0"
+              className="flex items-center gap-2 border-b border-border-divider px-2 py-1 text-sm last:border-b-0"
             >
               <span className="min-w-0 flex-1 truncate text-fg-1">{s.label}</span>
-              <span className="shrink-0 text-[10px] text-fg-3">
+              <span className="shrink-0 text-[11px] text-fg-3">
                 {s.table_count} tables · {formatWhen(s.created_at_ms)}
               </span>
               <button
@@ -403,7 +403,7 @@ function ModeTab({
       type="button"
       onClick={onClick}
       className={
-        "rounded-[4px] px-2 py-0.5 text-[11px] " +
+        "rounded-[4px] px-2 py-0.5 text-sm " +
         (active
           ? "bg-accent-soft text-accent"
           : "text-fg-2 hover:bg-bg-3 hover:text-fg-0")
@@ -425,7 +425,7 @@ function Field({
 }) {
   return (
     <label className={"flex flex-col gap-0.5 " + className}>
-      <span className="text-[10px] uppercase tracking-[0.05em] text-fg-3">
+      <span className="text-[11px] uppercase tracking-[0.05em] text-fg-3">
         {label}
       </span>
       {children}
@@ -448,7 +448,7 @@ function Select({
     <select
       value={value}
       onChange={(e) => onChange(e.target.value)}
-      className="h-[26px] rounded-[4px] border border-border-default bg-bg-1 px-1.5 text-[11.5px] text-fg-1 outline-none focus:border-accent-line"
+      className="h-[26px] rounded-[4px] border border-border-default bg-bg-1 px-1.5 text-sm text-fg-1 outline-none focus:border-accent-line"
     >
       <option value="">{placeholder}</option>
       {options.map((o) => (

--- a/apps/desktop/src/components/modals/Settings.tsx
+++ b/apps/desktop/src/components/modals/Settings.tsx
@@ -118,11 +118,11 @@ export function SettingsModal({
         <span className="inline-flex text-accent">
           <Icon.settings size={14} />
         </span>
-        <span className="whitespace-nowrap text-[12.5px] font-semibold text-fg-0">
+        <span className="whitespace-nowrap text-sm font-semibold text-fg-0">
           Settings
         </span>
         <span className="h-[14px] w-px bg-border-divider" />
-        <span className="font-mono text-[11px] text-fg-2">{currentLabel}</span>
+        <span className="font-mono text-[12px] text-fg-2">{currentLabel}</span>
 
         <div className="ml-auto inline-flex h-[24px] max-w-[260px] flex-1 items-center gap-1.5 rounded-[4px] border border-border-default bg-bg-inset px-[7px]">
           <Icon.search size={11} stroke="var(--fg-3)" />
@@ -131,7 +131,7 @@ export function SettingsModal({
             placeholder="Search settings…"
             value={q}
             onChange={(e) => setQ(e.target.value)}
-            className="min-w-0 flex-1 bg-transparent text-[11.5px] text-fg-0 outline-none placeholder:text-fg-3"
+            className="min-w-0 flex-1 bg-transparent text-sm text-fg-0 outline-none placeholder:text-fg-3"
           />
           <span className="inline-flex gap-0.5">
             <kbd className="kbd">⌘F</kbd>
@@ -185,7 +185,7 @@ export function SettingsModal({
       </div>
 
       <div className="flex h-11 shrink-0 items-center justify-between gap-3 border-t border-border-default bg-bg-2 px-3">
-        <span className="inline-flex items-center gap-1.5 text-[11px]">
+        <span className="inline-flex items-center gap-1.5 text-[12px]">
           <span
             className="h-1.5 w-1.5 rounded-full"
             style={{ background: "var(--insert)" }}
@@ -196,7 +196,7 @@ export function SettingsModal({
           <button
             type="button"
             disabled
-            className="cursor-not-allowed text-[11px] text-fg-3 underline underline-offset-2"
+            className="cursor-not-allowed text-[12px] text-fg-3 underline underline-offset-2"
             title="Raw settings editing is not wired yet"
           >
             edit raw
@@ -264,7 +264,7 @@ function SettingsNav({
         if (!items.length) return null;
         return (
           <div key={g.group} className="py-1">
-            <div className="px-[14px] py-1 text-[9.5px] font-semibold uppercase tracking-[0.08em] text-fg-3">
+            <div className="px-[14px] py-1 text-[10.5px] font-semibold uppercase tracking-[0.08em] text-fg-3">
               {g.group}
             </div>
             {items.map((i) => {
@@ -276,7 +276,7 @@ function SettingsNav({
                   key={i.id}
                   onClick={() => setCat(i.id)}
                   className={
-                    "flex h-[26px] w-full items-center gap-2 border-l-2 px-[10px] pl-[14px] text-left text-[11.5px] " +
+                    "flex h-[26px] w-full items-center gap-2 border-l-2 px-[10px] pl-[14px] text-left text-sm " +
                     (active
                       ? "bg-accent-soft border-l-accent text-accent font-medium"
                       : "border-l-transparent text-fg-1 hover:bg-bg-2 hover:text-fg-0")
@@ -294,7 +294,7 @@ function SettingsNav({
                   {filter && counts[i.id] ? (
                     <span
                       className={
-                        "font-mono text-[10px] " +
+                        "font-mono text-[11px] " +
                         (active ? "text-accent" : "text-fg-3")
                       }
                     >
@@ -303,7 +303,7 @@ function SettingsNav({
                   ) : i.badge ? (
                     <span
                       className={
-                        "rounded-[3px] border px-1 py-[1px] font-mono text-[9px] uppercase tracking-[0.04em] " +
+                        "rounded-[3px] border px-1 py-[1px] font-mono text-[10px] uppercase tracking-[0.04em] " +
                         (active
                           ? "border-accent-line bg-bg-1 text-accent"
                           : "border-accent-line bg-accent-soft text-accent")
@@ -318,13 +318,13 @@ function SettingsNav({
           </div>
         );
       })}
-      <div className="mt-auto flex items-center gap-1.5 border-t border-border-divider px-[14px] py-2.5 text-[10px]">
+      <div className="mt-auto flex items-center gap-1.5 border-t border-border-divider px-[14px] py-2.5 text-[11px]">
         {appVersion && <span className="font-mono text-fg-3">{`v${appVersion}`}</span>}
         {appVersion && <span className="text-fg-3">·</span>}
         <button
           type="button"
           disabled
-          className="cursor-not-allowed text-[10px] text-fg-3 underline underline-offset-2 opacity-70"
+          className="cursor-not-allowed text-[11px] text-fg-3 underline underline-offset-2 opacity-70"
           title="Documentation links are not wired in the desktop shell yet"
         >
           docs
@@ -348,16 +348,16 @@ function SettingsSearchResults({
       <section className="px-6 pb-1 pt-[18px]">
         <header className="mb-3 flex items-end justify-between gap-3">
           <div>
-            <h2 className="m-0 text-[13px] font-semibold tracking-[-0.005em] text-fg-0">
+            <h2 className="m-0 text-sm font-semibold tracking-[-0.005em] text-fg-0">
               Search results
             </h2>
-            <p className="m-0 mt-px max-w-[60ch] text-[11.5px] text-fg-2 text-pretty">
+            <p className="m-0 mt-px max-w-[60ch] text-sm text-fg-2 text-pretty">
               {results.length
                 ? `${results.length} match${results.length === 1 ? "" : "es"} for "${q.trim()}"`
                 : `No settings match "${q.trim()}"`}
             </p>
           </div>
-          <span className="font-mono text-[10.5px] text-fg-3">
+          <span className="font-mono text-[11.5px] text-fg-3">
             labels, sections, values
           </span>
         </header>
@@ -377,17 +377,17 @@ function SettingsSearchResults({
                 }
               >
                 <span className="min-w-0">
-                  <span className="block truncate text-[11.5px] font-medium text-fg-0">
+                  <span className="block truncate text-sm font-medium text-fg-0">
                     {result.label}
                   </span>
-                  <span className="block truncate text-[10.5px] text-fg-3">
+                  <span className="block truncate text-[11.5px] text-fg-3">
                     {result.section}
                   </span>
                 </span>
-                <span className="min-w-0 truncate font-mono text-[11px] text-fg-2">
+                <span className="min-w-0 truncate font-mono text-sm text-fg-2">
                   {result.category}
                 </span>
-                <span className="inline-flex items-center gap-1 text-[10.5px] text-fg-3">
+                <span className="inline-flex items-center gap-1 text-[11.5px] text-fg-3">
                   <span>open</span>
                   <Icon.chevronRight size={10} />
                 </span>
@@ -396,10 +396,10 @@ function SettingsSearchResults({
           </div>
         ) : (
           <div className="rounded-[5px] border border-dashed border-border-default bg-bg-inset px-3 py-6 text-center">
-            <div className="text-[12px] font-medium text-fg-1">
+            <div className="text-sm font-medium text-fg-1">
               No matching settings
             </div>
-            <div className="mt-1 text-[11px] text-fg-3">
+            <div className="mt-1 text-[12px] text-fg-3">
               Try a label, category, provider, shortcut, or stored value.
             </div>
           </div>

--- a/apps/desktop/src/components/modals/settingsAIPanel.tsx
+++ b/apps/desktop/src/components/modals/settingsAIPanel.tsx
@@ -55,10 +55,10 @@ export function SettingsAI() {
             <Icon.sparkles size={12} stroke="var(--accent)" />
           </span>
           <div className="text-pretty">
-            <div className="mb-0.5 text-[12px] font-semibold text-fg-0">
+            <div className="mb-0.5 text-sm font-semibold text-fg-0">
               Bring-your-own-key, by design
             </div>
-            <div className="text-[11.5px] leading-[1.45] text-fg-1">
+            <div className="text-sm leading-[1.45] text-fg-1">
               All AI requests go directly from your machine to the provider. We
               see nothing. Cellar is open-source; verify the network path in the
               AI package before enabling providers.
@@ -89,19 +89,19 @@ export function SettingsAI() {
                         : "border-border-default bg-bg-2 hover:border-border-strong")
                   }
                 >
-                  <span className="text-[11.5px] font-medium text-fg-0">
+                  <span className="text-sm font-medium text-fg-0">
                     {p.label}
                   </span>
                   <span
                     className={
-                      "font-mono text-[9.5px] " +
+                      "font-mono text-[10.5px] " +
                       (active ? "text-accent opacity-85" : "text-fg-3")
                     }
                   >
                     {p.sub}
                   </span>
                   {disabled && (
-                    <span className="absolute right-[5px] top-[5px] rounded-[3px] bg-bg-3 px-1 py-px text-[8.5px] uppercase tracking-[0.04em] text-fg-3">
+                    <span className="absolute right-[5px] top-[5px] rounded-[3px] bg-bg-3 px-1 py-px text-[9.5px] uppercase tracking-[0.04em] text-fg-3">
                       soon
                     </span>
                   )}
@@ -119,11 +119,11 @@ export function SettingsAI() {
         <Row label="API key" hint="stored in OS keychain, never written to disk">
           <div className="flex min-w-0 flex-1 flex-col gap-1.5">
             <div className="inline-flex min-w-0 items-center gap-1">
-              <span className="inline-flex h-[26px] items-center rounded-l-[4px] border border-r-0 border-border-default bg-bg-inset px-1.5 font-mono text-[11px] text-fg-2">
+              <span className="inline-flex h-[26px] items-center rounded-l-[4px] border border-r-0 border-border-default bg-bg-inset px-1.5 font-mono text-sm text-fg-2">
                 {current.keyPrefix}
               </span>
               <input
-                className="-ml-px h-[26px] min-w-0 flex-1 border border-border-default bg-bg-inset px-2 font-mono text-[11.5px] text-fg-0 outline-none focus:border-accent-line focus:bg-bg-2"
+                className="-ml-px h-[26px] min-w-0 flex-1 border border-border-default bg-bg-inset px-2 font-mono text-sm text-fg-0 outline-none focus:border-accent-line focus:bg-bg-2"
                 type={reveal ? "text" : "password"}
                 value={keyDraft}
                 onChange={(e) => setKeyDraft(e.target.value)}
@@ -139,7 +139,7 @@ export function SettingsAI() {
               <button
                 type="button"
                 onClick={() => setReveal((v) => !v)}
-                className="inline-flex h-[26px] items-center gap-1 rounded-[4px] border border-border-default bg-bg-2 px-2 text-[10.5px] text-fg-1 hover:bg-bg-3"
+                className="inline-flex h-[26px] items-center gap-1 rounded-[4px] border border-border-default bg-bg-2 px-2 text-sm text-fg-1 hover:bg-bg-3"
               >
                 {reveal ? "hide" : "reveal"}
               </button>
@@ -147,12 +147,12 @@ export function SettingsAI() {
                 type="button"
                 disabled={!keyDraft.trim() || saving}
                 onClick={() => void onSaveKey()}
-                className="inline-flex h-[26px] items-center gap-1 rounded-[4px] bg-accent px-2.5 text-[11px] font-medium text-accent-fg hover:brightness-[1.07] disabled:opacity-40"
+                className="inline-flex h-[26px] items-center gap-1 rounded-[4px] bg-accent px-2.5 text-sm font-medium text-accent-fg hover:brightness-[1.07] disabled:opacity-40"
               >
                 {saving ? "saving…" : "save"}
               </button>
             </div>
-            <div className="flex items-center gap-1.5 text-[10.5px]">
+            <div className="flex items-center gap-1.5 text-[11.5px]">
               {keyConfigured ? (
                 <span className="inline-flex items-center gap-1 text-insert">
                   <Icon.check size={10} />
@@ -168,7 +168,7 @@ export function SettingsAI() {
         <Row label="Model" hint="discovered from your API key">
           <div className="flex w-full flex-col gap-[3px]">
             <div className="mb-1 flex items-center justify-between">
-              <span className="text-[10.5px] text-fg-3">
+              <span className="text-[11.5px] text-fg-3">
                 {modelsLoading
                   ? "loading models…"
                   : modelsError
@@ -179,7 +179,7 @@ export function SettingsAI() {
                 type="button"
                 disabled={!keyConfigured || modelsLoading}
                 onClick={() => void refreshModels()}
-                className="inline-flex h-[22px] items-center gap-1 rounded-[4px] border border-border-default bg-bg-2 px-2 text-[10.5px] text-fg-1 hover:bg-bg-3 disabled:opacity-40"
+                className="inline-flex h-[22px] items-center gap-1 rounded-[4px] border border-border-default bg-bg-2 px-2 text-[11.5px] text-fg-1 hover:bg-bg-3 disabled:opacity-40"
               >
                 <Icon.undo size={10} />
                 <span>refresh</span>
@@ -187,18 +187,18 @@ export function SettingsAI() {
             </div>
 
             {modelsError && (
-              <div className="mb-1 flex items-start gap-1.5 rounded-[4px] border border-delete-line bg-delete-bg px-2 py-1.5 text-[10.5px] text-delete">
+              <div className="mb-1 flex items-start gap-1.5 rounded-[4px] border border-delete-line bg-delete-bg px-2 py-1.5 text-[11.5px] text-delete">
                 <Icon.warn size={11} />
                 <span>{modelsError}</span>
               </div>
             )}
 
             {!keyConfigured ? (
-              <div className="rounded-[4px] border border-dashed border-border-default px-2.5 py-2 text-[10.5px] text-fg-3">
+              <div className="rounded-[4px] border border-dashed border-border-default px-2.5 py-2 text-[11.5px] text-fg-3">
                 Add an API key above to discover available models.
               </div>
             ) : models.length === 0 && !modelsLoading && !modelsError ? (
-              <div className="rounded-[4px] border border-dashed border-border-default px-2.5 py-2 text-[10.5px] text-fg-3">
+              <div className="rounded-[4px] border border-dashed border-border-default px-2.5 py-2 text-[11.5px] text-fg-3">
                 No chat-capable models found for this key.
               </div>
             ) : (
@@ -233,11 +233,11 @@ export function SettingsAI() {
                       checked={active}
                       onChange={() => setModel(m.id)}
                     />
-                    <span className="min-w-0 truncate font-mono text-[11.5px] text-fg-0">
+                    <span className="min-w-0 truncate font-mono text-sm text-fg-0">
                       {m.id}
                     </span>
                     {m.ctx && (
-                      <span className="font-mono text-[10px] text-fg-3">
+                      <span className="font-mono text-[11px] text-fg-3">
                         {m.ctx} ctx
                       </span>
                     )}

--- a/apps/desktop/src/components/modals/settingsDataPanels.tsx
+++ b/apps/desktop/src/components/modals/settingsDataPanels.tsx
@@ -25,7 +25,7 @@ export function SettingsConnections() {
             defaultValue="10"
             style={{ width: 70, flex: "none" }}
           />
-          <span className="text-[11px] text-fg-2">seconds</span>
+          <span className="text-sm text-fg-2">seconds</span>
         </Row>
         <Row label="Keep-alive interval">
           <input
@@ -34,7 +34,7 @@ export function SettingsConnections() {
             defaultValue="30"
             style={{ width: 70, flex: "none" }}
           />
-          <span className="text-[11px] text-fg-2">seconds</span>
+          <span className="text-sm text-fg-2">seconds</span>
         </Row>
         <Row label="Application name">
           <input
@@ -68,7 +68,7 @@ export function SettingsConnections() {
             defaultValue="100"
             style={{ width: 70, flex: "none" }}
           />
-          <span className="text-[11px] text-fg-2">rows</span>
+          <span className="text-sm text-fg-2">rows</span>
         </Row>
       </Section>
     </div>
@@ -148,7 +148,7 @@ export function SettingsBackups({
             type="button"
             disabled
             title="Snapshot location browsing is not wired yet"
-            className="inline-flex h-[26px] cursor-not-allowed items-center gap-1 rounded-[4px] border border-border-default bg-bg-2 px-2 text-[11px] text-fg-2 opacity-70"
+            className="inline-flex h-[26px] cursor-not-allowed items-center gap-1 rounded-[4px] border border-border-default bg-bg-2 px-2 text-sm text-fg-2 opacity-70"
           >
             <Icon.fileText size={11} />
             <span>Browse</span>
@@ -161,7 +161,7 @@ export function SettingsBackups({
             defaultValue="30"
             style={{ width: 70, flex: "none" }}
           />
-          <span className="text-[11px] text-fg-2">days</span>
+          <span className="text-sm text-fg-2">days</span>
         </Row>
       </Section>
       <Section title="Export defaults">

--- a/apps/desktop/src/components/modals/settingsPrimitives.tsx
+++ b/apps/desktop/src/components/modals/settingsPrimitives.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 import { Icon } from "../icons";
 
 export const ED_RUN_BASE =
-  "inline-flex h-[26px] items-center gap-[5px] whitespace-nowrap rounded-[4px] border border-transparent px-2.5 text-[11.5px] font-medium transition-[background,color,border-color,filter] duration-[120ms]";
+  "inline-flex h-[26px] items-center gap-[5px] whitespace-nowrap rounded-[4px] border border-transparent px-2.5 text-sm font-medium transition-[background,color,border-color,filter] duration-[120ms]";
 export const ED_RUN_SUBTLE =
   ED_RUN_BASE +
   " text-fg-1 bg-transparent border-border-default hover:bg-bg-3 hover:border-border-strong hover:text-fg-0";
@@ -13,7 +13,7 @@ export const ED_RUN_DANGER =
   " bg-transparent border-[color-mix(in_oklab,var(--delete)_30%,var(--border-default))] text-delete hover:bg-delete-bg hover:border-delete";
 
 export const CD_INPUT =
-  "h-[26px] min-w-0 flex-1 rounded-[4px] border border-border-default bg-bg-inset px-2 text-[11.5px] text-fg-0 outline-none focus:border-accent-line focus:bg-bg-2";
+  "h-[26px] min-w-0 flex-1 rounded-[4px] border border-border-default bg-bg-inset px-2 text-sm text-fg-0 outline-none focus:border-accent-line focus:bg-bg-2";
 
 export function Section({
   title,
@@ -27,11 +27,11 @@ export function Section({
   return (
     <section className="px-6 pb-1 pt-[18px] [&+section]:mt-1.5 [&+section]:border-t [&+section]:border-border-divider">
       <header className="mb-3">
-        <h2 className="m-0 text-[13px] font-semibold tracking-[-0.005em] text-fg-0">
+        <h2 className="m-0 text-sm font-semibold tracking-[-0.005em] text-fg-0">
           {title}
         </h2>
         {sub && (
-          <p className="m-0 mt-px max-w-[60ch] text-[11.5px] text-fg-2 text-pretty">
+          <p className="m-0 mt-px max-w-[60ch] text-sm text-fg-2 text-pretty">
             {sub}
           </p>
         )}
@@ -59,17 +59,17 @@ export function Row({
         (stack ? "items-start" : "items-center")
       }
     >
-      <div className="flex flex-col gap-[2px] text-[11.5px] font-medium text-fg-1">
+      <div className="flex flex-col gap-[2px] text-sm font-medium text-fg-1">
         <span>{label}</span>
         {hint && (
-          <span className="text-[10.5px] font-normal text-fg-3 text-pretty">
+          <span className="text-[11.5px] font-normal text-fg-3 text-pretty">
             {hint}
           </span>
         )}
       </div>
       <div
         className={
-          "min-w-0 text-[11.5px] " +
+          "min-w-0 text-sm " +
           (stack ? "block" : "flex flex-wrap items-center gap-2")
         }
       >
@@ -135,7 +135,7 @@ export function Segment<T extends string>({
           aria-pressed={value === o.value}
           onClick={() => onChange?.(o.value)}
           className={
-            "h-5 rounded-[3px] px-2.5 text-[11px] " +
+            "h-5 rounded-[3px] px-2.5 text-[12px] " +
             (value === o.value
               ? "bg-bg-3 font-medium text-fg-0"
               : "text-fg-2 " + (onChange ? "hover:text-fg-0" : ""))
@@ -164,7 +164,7 @@ export function StaticSegment({
           disabled
           aria-pressed={i === activeIdx}
           className={
-            "h-5 cursor-not-allowed rounded-[3px] px-2.5 text-[11px] " +
+            "h-5 cursor-not-allowed rounded-[3px] px-2.5 text-[12px] " +
             (i === activeIdx
               ? "bg-bg-3 font-medium text-fg-0"
               : "text-fg-2")
@@ -179,7 +179,7 @@ export function StaticSegment({
 
 export function StubBanner({ children }: { children: ReactNode }) {
   return (
-    <div className="mx-6 my-2 flex items-center gap-1.5 rounded-[4px] border border-dashed border-border-default bg-bg-inset px-3 py-2 text-[11px] text-fg-2">
+    <div className="mx-6 my-2 flex items-center gap-1.5 rounded-[4px] border border-dashed border-border-default bg-bg-inset px-3 py-2 text-[12px] text-fg-2">
       <Icon.info size={12} stroke="var(--fg-3)" />
       <span>{children}</span>
     </div>

--- a/apps/desktop/src/components/modals/settingsSystemPanels.tsx
+++ b/apps/desktop/src/components/modals/settingsSystemPanels.tsx
@@ -23,7 +23,7 @@ function renderInline(text: string, keyBase: string) {
 function Changelog({ source }: { source: string }) {
   const lines = source.replace(/\r\n/g, "\n").split("\n");
   return (
-    <div className="max-h-[260px] overflow-y-auto rounded-[5px] border border-border-default bg-bg-inset px-3 py-2.5 text-[11.5px] leading-[1.55] text-fg-2">
+    <div className="max-h-[260px] overflow-y-auto rounded-[5px] border border-border-default bg-bg-inset px-3 py-2.5 text-[12.5px] leading-[1.55] text-fg-2">
       {lines.map((raw, i) => {
         const line = raw.trimEnd();
         if (!line.trim()) return <div key={i} className="h-1.5" />;
@@ -35,7 +35,7 @@ function Changelog({ source }: { source: string }) {
               key={i}
               className={
                 "mt-2 mb-1 font-semibold text-fg-0 " +
-                (top ? "text-[13px]" : "text-[12px]")
+                (top ? "text-sm" : "text-sm")
               }
             >
               {renderInline(h[2]!, `h${i}`)}
@@ -88,13 +88,13 @@ export function SettingsPrivacy() {
             <div
               key={x.k}
               className={
-                "grid grid-cols-[160px_1fr_auto_22px] items-center gap-2.5 bg-bg-2 px-2.5 py-1.5 text-[11px] hover:bg-bg-3 " +
+                "grid grid-cols-[160px_1fr_auto_22px] items-center gap-2.5 bg-bg-2 px-2.5 py-1.5 text-sm hover:bg-bg-3 " +
                 (i !== arr.length - 1 ? "border-b border-border-divider" : "")
               }
             >
               <span className="font-medium text-fg-0">{x.k}</span>
               <span className="text-fg-2">{x.v}</span>
-              <span className="font-mono text-[10.5px] text-fg-3">
+              <span className="font-mono text-[11.5px] text-fg-3">
                 ~/.cellar/{x.path}
               </span>
               <button
@@ -152,14 +152,14 @@ export function SettingsUpdates() {
       <Section title="Updates">
         <div className="mb-2 flex items-center justify-between rounded-[5px] border border-border-default bg-bg-inset px-3 py-2.5">
           <div className="flex items-center gap-2.5">
-            <span className="font-mono text-[13px] font-semibold text-fg-0">
+            <span className="font-mono text-sm font-semibold text-fg-0">
               {versionLabel}
             </span>
-            <span className="inline-flex items-center gap-1 text-[11px]">
+            <span className="inline-flex items-center gap-1 text-[12px]">
               <Icon.info size={11} stroke="var(--fg-2)" />
               <span className="text-fg-2">{statusText}</span>
             </span>
-            <span className="text-[11px] text-fg-3">{lastCheckedLabel}</span>
+            <span className="text-sm text-fg-3">{lastCheckedLabel}</span>
           </div>
           <div className="flex items-center gap-1.5">
             {canInstall && (
@@ -167,7 +167,7 @@ export function SettingsUpdates() {
                 type="button"
                 onClick={downloadAndInstall}
                 disabled={isBusy}
-                className="inline-flex h-[26px] items-center gap-1 rounded-[4px] border border-accent-line bg-accent-soft px-2 text-[11px] font-medium text-accent hover:bg-accent/20"
+                className="inline-flex h-[26px] items-center gap-1 rounded-[4px] border border-accent-line bg-accent-soft px-2 text-[12px] font-medium text-accent hover:bg-accent/20"
               >
                 <Icon.download size={11} />
                 <span>Download &amp; install</span>
@@ -180,8 +180,8 @@ export function SettingsUpdates() {
               title={canCheck ? "Check for updates" : "Update check in progress"}
               className={
                 canCheck
-                  ? "inline-flex h-[26px] items-center gap-1 rounded-[4px] border border-border-default bg-bg-2 px-2 text-[11px] text-fg-1 hover:bg-bg-3"
-                  : "inline-flex h-[26px] cursor-not-allowed items-center gap-1 rounded-[4px] border border-border-default bg-bg-2 px-2 text-[11px] text-fg-2 opacity-70"
+                  ? "inline-flex h-[26px] items-center gap-1 rounded-[4px] border border-border-default bg-bg-2 px-2 text-[12px] text-fg-1 hover:bg-bg-3"
+                  : "inline-flex h-[26px] cursor-not-allowed items-center gap-1 rounded-[4px] border border-border-default bg-bg-2 px-2 text-[12px] text-fg-2 opacity-70"
               }
             >
               <Icon.power size={11} />
@@ -238,13 +238,13 @@ export function SettingsAbout() {
             />
           </span>
           <div>
-            <div className="text-[18px] font-semibold tracking-[-0.01em] text-fg-0">
+            <div className="text-[19px] font-semibold tracking-[-0.01em] text-fg-0">
               Cellar
             </div>
-            <div className="mb-2 text-[12px] text-fg-2">
+            <div className="mb-2 text-sm text-fg-2">
               A fast, native database client with AI built in.
             </div>
-            <div className="mb-2.5 flex gap-1.5 font-mono text-[10.5px] text-fg-2">
+            <div className="mb-2.5 flex gap-1.5 font-mono text-[11.5px] text-fg-2">
               <span>
                 {versionLabel}
                 {import.meta.env.DEV ? " · development build" : ""}
@@ -254,7 +254,7 @@ export function SettingsAbout() {
               <span className="text-fg-3">·</span>
               <span>commit unavailable</span>
             </div>
-            <div className="mb-2.5 text-[11px] text-fg-2">
+            <div className="mb-2.5 text-sm text-fg-2">
               built by{" "}
               <button
                 type="button"
@@ -264,7 +264,7 @@ export function SettingsAbout() {
                 Matt List
               </button>
             </div>
-            <div className="flex gap-1.5 text-[11px]">
+            <div className="flex gap-1.5 text-[12px]">
               <button
                 type="button"
                 disabled

--- a/apps/desktop/src/components/modals/settingsWorkspacePanels.tsx
+++ b/apps/desktop/src/components/modals/settingsWorkspacePanels.tsx
@@ -152,15 +152,15 @@ export function SettingsAppearance() {
               }
             }}
           />
-          <span className="text-[11px] text-fg-2">px</span>
+          <span className="text-sm text-fg-2">px</span>
           <div className="relative ml-2 w-[220px] pt-[14px]">
-            <span className="absolute top-0 left-0 -translate-x-1/2 whitespace-nowrap text-[9.5px] text-fg-3">
+            <span className="absolute top-0 left-0 -translate-x-1/2 whitespace-nowrap text-[10.5px] text-fg-3">
               {FONT_SIZE_MIN}
             </span>
-            <span className="absolute top-0 left-1/2 -translate-x-1/2 whitespace-nowrap text-[9.5px] text-fg-3">
+            <span className="absolute top-0 left-1/2 -translate-x-1/2 whitespace-nowrap text-[10.5px] text-fg-3">
               13.5
             </span>
-            <span className="absolute top-0 right-0 translate-x-1/2 whitespace-nowrap text-[9.5px] text-fg-3">
+            <span className="absolute top-0 right-0 translate-x-1/2 whitespace-nowrap text-[10.5px] text-fg-3">
               {FONT_SIZE_MAX}
             </span>
             <input
@@ -204,7 +204,7 @@ export function SettingsAppearance() {
 export function SettingsGeneral() {
   return (
     <div className="flex-1 overflow-y-auto pb-6 pt-1">
-      <p className="px-5 pt-4 text-[11.5px] text-fg-3">
+      <p className="px-5 pt-4 text-sm text-fg-3">
         General settings and more config coming soon.
       </p>
     </div>
@@ -342,7 +342,7 @@ export function SettingsKeymap() {
                 key={s.k}
                 className="grid grid-cols-[1fr_auto_auto] items-center gap-3 border-b border-dashed border-border-divider py-1.5 last:border-b-0"
               >
-                <span className="text-[11.5px] text-fg-1">{s.k}</span>
+                <span className="text-sm text-fg-1">{s.k}</span>
                 <span className="inline-flex gap-0.5">
                   {[...s.kbd].map((k, i) => (
                     <kbd key={i} className="kbd">

--- a/apps/desktop/src/components/schema-compare/DiffTree.tsx
+++ b/apps/desktop/src/components/schema-compare/DiffTree.tsx
@@ -39,7 +39,7 @@ export function DiffTree({ diff }: { diff: SchemaDiff }) {
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <div className="flex h-[26px] shrink-0 items-center gap-2 border-b border-border-divider bg-bg-1 px-3 text-[10px] font-semibold uppercase tracking-[0.05em] text-fg-3">
+      <div className="flex h-[26px] shrink-0 items-center gap-2 border-b border-border-divider bg-bg-1 px-3 text-[11px] font-semibold uppercase tracking-[0.05em] text-fg-3">
         <span className="flex-1 truncate" title={diff.source_label}>
           source · {diff.source_label}
         </span>
@@ -60,7 +60,7 @@ export function DiffTree({ diff }: { diff: SchemaDiff }) {
 
       <div className="flex-1 overflow-auto py-1">
         {tables.length === 0 && views.length === 0 ? (
-          <div className="px-3 py-3 text-[11px] text-fg-3">
+          <div className="px-3 py-3 text-[12px] text-fg-3">
             No differences between these schemas.
           </div>
         ) : (
@@ -101,14 +101,14 @@ function TableRow({ table }: { table: TableDiff }) {
         </span>
         <StatusBadge status={table.status} />
         <Icon.table size={11} stroke="var(--fg-3)" />
-        <span className="font-mono text-[11.5px] text-fg-1">{table.name}</span>
+        <span className="font-mono text-sm text-fg-1">{table.name}</span>
         {table.status === "modified" && changedCols.length > 0 && (
-          <span className="ml-1 text-[10px] text-fg-3">
+          <span className="ml-1 text-[11px] text-fg-3">
             {changedCols.length} column{changedCols.length === 1 ? "" : "s"}
           </span>
         )}
         {table.primary_key.status !== "unchanged" && (
-          <span className="ml-1 rounded-[3px] bg-bg-2 px-1 text-[9.5px] text-fg-3">
+          <span className="ml-1 rounded-[3px] bg-bg-2 px-1 text-[10.5px] text-fg-3">
             pk changed
           </span>
         )}
@@ -126,7 +126,7 @@ function TableRow({ table }: { table: TableDiff }) {
 
 function ColumnRow({ col }: { col: ColumnDiff }) {
   return (
-    <div className="grid grid-cols-2 gap-2 px-2 pl-7 text-[10.5px]">
+    <div className="grid grid-cols-2 gap-2 px-2 pl-7 text-[11.5px]">
       <ColumnCell side="source" status={col.status} column={col.source} />
       <ColumnCell
         side="target"
@@ -168,7 +168,7 @@ function ColumnCell({
       <span className="truncate text-fg-3">{column.data_type}</span>
       {!column.nullable && <span className="text-fg-4">NOT NULL</span>}
       {side === "target" && changes && changes.length > 0 && (
-        <span className="truncate text-[10px]" style={{ color: "var(--update)" }}>
+        <span className="truncate text-[11px]" style={{ color: "var(--update)" }}>
           {changes.join(", ")}
         </span>
       )}
@@ -181,8 +181,8 @@ function ViewRow({ view }: { view: ViewDiff }) {
     <div className="flex items-center gap-1.5 border-b border-dashed border-border-divider px-2 py-1 pl-5">
       <StatusBadge status={view.status} />
       <Icon.tree size={11} stroke="var(--fg-3)" />
-      <span className="font-mono text-[11.5px] text-fg-1">{view.name}</span>
-      <span className="text-[10px] text-fg-3">view</span>
+      <span className="font-mono text-sm text-fg-1">{view.name}</span>
+      <span className="text-[11px] text-fg-3">view</span>
     </div>
   );
 }
@@ -191,7 +191,7 @@ function StatusBadge({ status }: { status: ChangeStatus }) {
   const { label, color, bg } = statusStyle(status);
   return (
     <span
-      className="inline-flex h-[14px] shrink-0 items-center rounded-[3px] px-1 font-mono text-[9px] font-semibold uppercase tracking-[0.04em]"
+      className="inline-flex h-[14px] shrink-0 items-center rounded-[3px] px-1 font-mono text-[10px] font-semibold uppercase tracking-[0.04em]"
       style={{ background: bg, color }}
     >
       {label}

--- a/apps/desktop/src/components/schema-compare/MigrationPanel.tsx
+++ b/apps/desktop/src/components/schema-compare/MigrationPanel.tsx
@@ -32,9 +32,9 @@ function confirmMessage(
 }
 
 const ED_BTN =
-  "inline-flex h-[26px] items-center gap-[5px] whitespace-nowrap rounded-[4px] border border-border-default bg-bg-2 px-2.5 text-[11.5px] font-medium text-fg-1 transition-colors duration-100 hover:bg-bg-3 hover:text-fg-0 disabled:cursor-not-allowed disabled:opacity-60";
+  "inline-flex h-[26px] items-center gap-[5px] whitespace-nowrap rounded-[4px] border border-border-default bg-bg-2 px-2.5 text-sm font-medium text-fg-1 transition-colors duration-100 hover:bg-bg-3 hover:text-fg-0 disabled:cursor-not-allowed disabled:opacity-60";
 const ED_DANGER =
-  "inline-flex h-[26px] items-center gap-[5px] whitespace-nowrap rounded-[4px] border px-2.5 text-[11.5px] font-medium text-white bg-delete transition-[filter] duration-100 hover:brightness-[1.07] disabled:cursor-not-allowed disabled:opacity-60";
+  "inline-flex h-[26px] items-center gap-[5px] whitespace-nowrap rounded-[4px] border px-2.5 text-sm font-medium text-white bg-delete transition-[filter] duration-100 hover:brightness-[1.07] disabled:cursor-not-allowed disabled:opacity-60";
 
 /**
  * Right-hand panel of the schema-compare view: pick which generated DDL
@@ -104,7 +104,7 @@ export function MigrationPanel({
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       {/* Statement checklist */}
-      <div className="flex h-[26px] shrink-0 items-center justify-between border-b border-border-divider bg-bg-1 px-3 text-[10px] font-semibold uppercase tracking-[0.05em] text-fg-3">
+      <div className="flex h-[26px] shrink-0 items-center justify-between border-b border-border-divider bg-bg-1 px-3 text-[11px] font-semibold uppercase tracking-[0.05em] text-fg-3">
         <span>
           Include in migration · {selectedIds.length}/{statements.length}
         </span>
@@ -128,7 +128,7 @@ export function MigrationPanel({
 
       <div className="max-h-[34%] min-h-[60px] overflow-y-auto py-1">
         {statements.length === 0 ? (
-          <div className="px-3 py-3 text-[11px] text-fg-3">
+          <div className="px-3 py-3 text-[12px] text-fg-3">
             No DDL to generate — the schemas already match.
           </div>
         ) : (
@@ -144,7 +144,7 @@ export function MigrationPanel({
       </div>
 
       {/* Generated SQL */}
-      <div className="flex h-[26px] shrink-0 items-center justify-between border-y border-border-divider bg-bg-1 px-3 text-[10px] font-semibold uppercase tracking-[0.05em] text-fg-3">
+      <div className="flex h-[26px] shrink-0 items-center justify-between border-y border-border-divider bg-bg-1 px-3 text-[11px] font-semibold uppercase tracking-[0.05em] text-fg-3">
         <span>Migration script{state.sqlDirty ? " · edited" : ""}</span>
         <div className="flex items-center gap-2">
           <label className="flex cursor-pointer items-center gap-1 normal-case tracking-normal text-fg-2">
@@ -186,7 +186,7 @@ export function MigrationPanel({
 
       {/* Apply bar */}
       <div className="flex min-h-11 shrink-0 items-center justify-between gap-3 border-t border-border-default bg-bg-2 px-3 py-2">
-        <div className="flex min-w-0 items-center gap-2 text-[10.5px]">
+        <div className="flex min-w-0 items-center gap-2 text-[11.5px]">
           <Icon.warn
             size={10}
             stroke={requiresConfirm ? "var(--warn)" : "var(--fg-3)"}
@@ -255,10 +255,10 @@ function StatementRow({
     <label className="flex cursor-pointer items-center gap-2 px-3 py-1 hover:bg-bg-2">
       <input type="checkbox" checked={checked} onChange={onToggle} />
       <KindChip kind={statement.kind} destructive={statement.destructive} />
-      <span className="min-w-0 flex-1 truncate font-mono text-[11px] text-fg-1">
+      <span className="min-w-0 flex-1 truncate font-mono text-sm text-fg-1">
         {statement.object}
       </span>
-      <span className="shrink-0 text-[10px] text-fg-3">
+      <span className="shrink-0 text-[11px] text-fg-3">
         {statement.description}
       </span>
     </label>
@@ -276,7 +276,7 @@ function KindChip({
   const bg = destructive ? "var(--delete-bg)" : "var(--insert-bg)";
   return (
     <span
-      className="inline-flex h-[14px] shrink-0 items-center rounded-[3px] px-1 font-mono text-[9px] font-semibold uppercase tracking-[0.03em]"
+      className="inline-flex h-[14px] shrink-0 items-center rounded-[3px] px-1 font-mono text-[10px] font-semibold uppercase tracking-[0.03em]"
       style={{ background: bg, color }}
     >
       {kind.replace(/-/g, " ")}

--- a/apps/desktop/src/lib/settings.tsx
+++ b/apps/desktop/src/lib/settings.tsx
@@ -73,10 +73,10 @@ export const DEFAULTS: Settings = {
 };
 
 const STORAGE_KEY = "cellar.settings.v1";
-// The interface is authored compact and zoomed up for comfort: the font-size
-// setting divided by this baseline gives the global UI scale, so the default
-// 13.5px setting renders at ~1.125× rather than being a no-op.
-const FONT_SIZE_BASELINE = 12;
+// Primary text is authored at --fs-sm (13px, Tailwind text-sm). The font-size
+// setting divided by this baseline gives the global UI zoom, so primary text
+// renders at exactly the selected size (e.g. setting 13 → zoom 1 → 13px).
+const FONT_SIZE_BASELINE = 13;
 export const FONT_SIZE_MIN = 10;
 export const FONT_SIZE_MAX = 22;
 

--- a/apps/desktop/src/styles/base.css
+++ b/apps/desktop/src/styles/base.css
@@ -67,7 +67,7 @@
   height: 16px;
   padding: 0 4px;
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: 11px;
   color: var(--fg-2);
   background: var(--bg-3);
   border: 1px solid var(--border-default);

--- a/apps/desktop/src/styles/editor.css
+++ b/apps/desktop/src/styles/editor.css
@@ -12,7 +12,7 @@
   width: 100%;
   height: 100%;
   background: var(--bg-inset);
-  font-size: var(--fs-md);
+  font-size: var(--fs-sm);
 }
 
 .ed-toolbar {
@@ -41,7 +41,7 @@
   height: 22px;
   padding: 0 8px;
   border-radius: 4px;
-  font-size: 11.5px;
+  font-size: var(--fs-sm);
   font-weight: 500;
   color: var(--fg-1);
   white-space: nowrap;
@@ -88,7 +88,7 @@
 .ed-stmt-note {
   display: inline-flex;
   gap: 6px;
-  font-size: 10.5px;
+  font-size: 11.5px;
   color: var(--fg-2);
   max-width: 360px;
 }
@@ -102,7 +102,7 @@
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  font-size: 10.5px;
+  font-size: 11.5px;
   color: var(--fg-2);
   padding: 0 6px;
 }
@@ -147,7 +147,7 @@
 }
 .cellar-cm .cm-scroller {
   font-family: var(--font-mono);
-  font-size: 12.5px;
+  font-size: var(--fs-sm);
   line-height: 1.55;
 }
 .cellar-cm .cm-content {
@@ -164,7 +164,7 @@
   background: var(--bg-inset);
   border-right: none;
   color: var(--fg-3);
-  font-size: 10.5px;
+  font-size: 11.5px;
 }
 .cellar-cm .cm-lineNumbers .cm-gutterElement {
   min-width: 48px;
@@ -225,7 +225,7 @@
 .cm-tooltip.cm-tooltip-autocomplete ul li {
   min-height: 24px;
   padding: 2px 8px 2px 6px;
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 .cm-tooltip.cm-tooltip-autocomplete ul li[aria-selected] {
   background: var(--accent-soft);
@@ -237,7 +237,7 @@
 .cm-tooltip-autocomplete .cm-completionDetail {
   color: var(--fg-3);
   font-family: var(--font-mono);
-  font-size: 10.5px;
+  font-size: 11.5px;
 }
 .cm-tooltip-autocomplete li[aria-selected] .cm-completionDetail {
   color: var(--fg-2);
@@ -258,7 +258,7 @@
 .cm-tooltip-autocomplete .cm-completionSection {
   background: var(--bg-2);
   color: var(--fg-3);
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 600;
   letter-spacing: 0;
   padding: 4px 8px;
@@ -300,7 +300,7 @@
   flex-direction: column;
   padding: 6px 0 60px;
   font-family: var(--font-mono);
-  font-size: 12.5px;
+  font-size: var(--fs-sm);
   line-height: 1.55;
   pointer-events: none;
   position: relative;
@@ -319,7 +319,7 @@
   flex: none;
   padding: 0 8px 0 4px;
   color: var(--fg-3);
-  font-size: 10.5px;
+  font-size: 11.5px;
   user-select: none;
   position: relative;
 }
@@ -385,7 +385,7 @@
   -webkit-text-fill-color: transparent;
   caret-color: var(--fg-0);
   font-family: var(--font-mono);
-  font-size: 12.5px;
+  font-size: var(--fs-sm);
   line-height: 1.55;
   white-space: pre;
   overflow: hidden;
@@ -429,7 +429,7 @@
   border: 1px dashed var(--border-default);
   border-radius: 5px;
   font-family: var(--font-sans);
-  font-size: 11.5px;
+  font-size: 12.5px;
   color: var(--fg-3);
   pointer-events: none;
 }
@@ -464,13 +464,13 @@
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  font-size: 11.5px;
+  font-size: 12.5px;
   font-weight: 600;
   color: var(--fg-1);
 }
 .param-panel-hint {
   flex: 1;
-  font-size: 11px;
+  font-size: 12px;
   color: var(--fg-3);
 }
 .param-panel-grid {
@@ -492,13 +492,13 @@
 }
 .param-placeholder {
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   color: var(--accent);
   white-space: nowrap;
 }
 .param-col-hint {
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: 11px;
   color: var(--fg-3);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -512,7 +512,7 @@
   border: 1px solid var(--border-default);
   background: var(--bg-inset);
   color: var(--fg-0);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   font-family: var(--font-mono);
   outline: none;
 }
@@ -531,12 +531,12 @@
   align-items: center;
   height: 24px;
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   color: var(--fg-3);
 }
 .param-error {
   grid-column: 3;
-  font-size: 10.5px;
+  font-size: 11.5px;
   color: var(--delete);
 }
 .param-panel-foot {

--- a/apps/desktop/src/styles/grid-renderers.css
+++ b/apps/desktop/src/styles/grid-renderers.css
@@ -32,7 +32,7 @@
   background: transparent;
   color: var(--fg-3);
   cursor: pointer;
-  font-size: 11px;
+  font-size: 12px;
   line-height: 1;
   opacity: 0;
   transition: opacity 0.1s, color 0.1s, background 0.1s;
@@ -57,7 +57,7 @@
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-lg);
-  font-size: 11px;
+  font-size: 12px;
   color: var(--fg-1);
   overflow: hidden;
 }
@@ -70,7 +70,7 @@
   border-bottom: 1px solid var(--border-divider);
   background: var(--bg-2);
   color: var(--fg-2);
-  font-size: 10px;
+  font-size: 11px;
   text-transform: lowercase;
 }
 .cell-popover-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -80,7 +80,7 @@
   background: transparent;
   color: var(--fg-3);
   cursor: pointer;
-  font-size: 11px;
+  font-size: 12px;
   padding: 0 2px;
 }
 .cell-popover-close:hover { color: var(--fg-0); }
@@ -99,7 +99,7 @@
   background: var(--bg-2);
   color: var(--fg-1);
   cursor: pointer;
-  font-size: 10px;
+  font-size: 11px;
   padding: 2px 7px;
 }
 .cell-rich-action:hover { background: var(--bg-3); color: var(--fg-0); }
@@ -115,7 +115,7 @@
   border-radius: var(--radius-sm);
   background: var(--bg-3);
   color: var(--fg-2);
-  font-size: 10px;
+  font-size: 11px;
   padding: 2px 6px;
 }
 .cell-rich-pre {
@@ -125,13 +125,13 @@
   font-family: var(--font-mono);
   color: var(--fg-1);
 }
-.cell-rich-error { color: var(--warn); font-size: 11px; }
+.cell-rich-error { color: var(--warn); font-size: 12px; }
 
 /* ── JSON ─────────────────────────────────────────────────── */
 .cell-json-inline { color: var(--fg-2); font-style: italic; }
 .cell-json-tree {
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   line-height: 1.55;
   white-space: nowrap;
 }
@@ -159,7 +159,7 @@
 /* ── arrays ───────────────────────────────────────────────── */
 .cell-array-inline { display: inline-flex; align-items: center; gap: 3px; min-width: 0; }
 .cell-array-empty { color: var(--fg-3); }
-.cell-array-more { color: var(--fg-3); font-size: 10px; flex-shrink: 0; }
+.cell-array-more { color: var(--fg-3); font-size: 11px; flex-shrink: 0; }
 .cell-array-chip {
   display: inline-flex;
   align-items: center;
@@ -167,7 +167,7 @@
   background: var(--bg-3);
   border: 1px solid var(--border-subtle);
   padding: 0 5px;
-  font-size: 10px;
+  font-size: 11px;
   max-width: 140px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -179,17 +179,17 @@
 .cell-array-chip.kind-string { color: var(--fg-1); }
 .cell-array-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 3px; }
 .cell-array-list li { display: flex; align-items: center; gap: 6px; }
-.cell-array-index { color: var(--fg-4); font-size: 10px; min-width: 24px; text-align: right; }
+.cell-array-index { color: var(--fg-4); font-size: 11px; min-width: 24px; text-align: right; }
 
 /* ── bytea / blob ─────────────────────────────────────────── */
 .cell-bytes-inline { display: inline-flex; align-items: center; gap: 5px; min-width: 0; }
 .cell-bytes-imgdot { width: 6px; height: 6px; border-radius: 50%; background: var(--info); flex-shrink: 0; }
 .cell-bytes-hexpeek { color: var(--fg-2); overflow: hidden; text-overflow: ellipsis; }
-.cell-bytes-size { color: var(--fg-3); font-size: 10px; flex-shrink: 0; }
+.cell-bytes-size { color: var(--fg-3); font-size: 11px; flex-shrink: 0; }
 .cell-bytes-dump {
   margin: 0;
   font-family: var(--font-mono);
-  font-size: 10.5px;
+  font-size: 11.5px;
   line-height: 1.5;
   color: var(--fg-1);
   white-space: pre;
@@ -212,7 +212,7 @@
 /* ── geometry (stub) ──────────────────────────────────────── */
 .cell-geometry-inline { display: inline-flex; align-items: center; gap: 5px; }
 .cell-geometry-glyph { color: var(--info); }
-.cell-geometry-kind { color: var(--fg-2); font-size: 10px; text-transform: uppercase; }
+.cell-geometry-kind { color: var(--fg-2); font-size: 11px; text-transform: uppercase; }
 .cell-geometry-map {
   display: flex;
   align-items: center;
@@ -223,5 +223,5 @@
   border-radius: var(--radius-sm);
   background: var(--bg-inset);
   color: var(--fg-3);
-  font-size: 10px;
+  font-size: 11px;
 }

--- a/apps/desktop/src/styles/grid.css
+++ b/apps/desktop/src/styles/grid.css
@@ -9,9 +9,8 @@
      `min-width: 0` a flex item's min-width defaults to its intrinsic content
      width (~1850px here), so `.grid-scroll` never sees overflow to scroll. */
   min-width: 0;
-  /* Match the 13px base used by the body / sidebar so grid data and the rest of
-     the UI read at the same size. */
-  font-size: var(--fs-sm);
+  /* Keep dense result data one step below the interface font. */
+  font-size: var(--fs-xs);
   /* bg-1 rather than bg-inset: near-black under bright mono text read too
      harsh; a lighter base + fg-1 data text keeps contrast comfortable. */
   background: var(--bg-1);
@@ -28,7 +27,7 @@
   border-bottom: 1px solid var(--border-default);
   flex-shrink: 0;
   font-family: var(--font-sans);
-  font-size: var(--fs-sm);
+  font-size: var(--fs-xs);
 }
 .grid-filterbar-label {
   display: inline-flex;
@@ -57,7 +56,7 @@
   padding: 0 3px;
   border-radius: 3px;
   font-family: var(--font-mono);
-  font-size: 9.5px;
+  font-size: 10.5px;
   color: var(--fg-3);
   text-transform: uppercase;
 }
@@ -70,7 +69,7 @@
   background: var(--accent-soft);
   border: 1px solid var(--accent-line);
   border-radius: 4px;
-  font-size: var(--fs-sm);
+  font-size: var(--fs-xs);
   color: var(--fg-0);
   overflow: hidden;
 }
@@ -121,7 +120,7 @@
   padding: 0 6px;
   border: 1px dashed var(--border-default);
   border-radius: 4px;
-  font-size: var(--fs-sm);
+  font-size: var(--fs-xs);
   color: var(--fg-2);
 }
 .grid-filter-add:hover { color: var(--fg-0); border-color: var(--border-strong); }
@@ -151,7 +150,7 @@
   border-radius: 3px;
   background: var(--bg-inset);
   color: var(--fg-0);
-  font-size: var(--fs-sm);
+  font-size: var(--fs-xs);
   outline: none;
 }
 .grid-filter-select {
@@ -180,7 +179,7 @@
   border-radius: 3px;
   background: var(--accent-soft);
   color: var(--accent);
-  font-size: var(--fs-sm);
+  font-size: var(--fs-xs);
   font-weight: 600;
 }
 .grid-filter-apply:hover:not(:disabled) {
@@ -196,7 +195,7 @@
   padding: 0 5px;
   border-radius: 3px;
   color: var(--fg-3);
-  font-size: var(--fs-sm);
+  font-size: var(--fs-xs);
   flex-shrink: 0;
 }
 .grid-filter-clear:hover { background: var(--bg-3); color: var(--fg-1); }
@@ -206,7 +205,7 @@
   align-items: center;
   gap: 3px;
   margin-left: auto;
-  font-size: 10.5px;
+  font-size: 11.5px;
 }
 
 /* ── order by (pinned before the row summary) ─────────────── */
@@ -236,20 +235,20 @@
   border-radius: 3px;
   background: var(--bg-inset);
   color: var(--fg-0);
-  font-size: var(--fs-sm);
+  font-size: var(--fs-xs);
   outline: none;
 }
 .grid-quickfilter-input:focus {
   border-color: var(--accent);
   box-shadow: 0 0 0 1px var(--accent-line);
 }
-.grid-quickfilter-column { height: 22px; max-width: 120px; font-size: var(--fs-sm); }
+.grid-quickfilter-column { height: 22px; max-width: 120px; font-size: var(--fs-xs); }
 .grid-filter-active-count {
   padding: 0 5px;
   border-radius: 8px;
   background: var(--accent-soft);
   color: var(--accent);
-  font-size: 9.5px;
+  font-size: 10.5px;
   font-weight: 600;
 }
 
@@ -263,7 +262,7 @@
   flex-direction: column;
   font-family: var(--font-mono);
   font-feature-settings: "calt", "ss01";
-  font-size: var(--fs-sm);
+  font-size: var(--fs-xs);
   line-height: 1;
   color: var(--fg-1);
 }
@@ -337,7 +336,7 @@
   color: var(--fg-3);
   background: var(--bg-1);
   border-right: 1px solid var(--grid-column-line);
-  font-size: 10px;
+  font-size: 11px;
   position: sticky;
   left: 0;
   z-index: 2;
@@ -384,7 +383,7 @@
 }
 .grid-header-cell {
   height: 100%;
-  font-size: 11px;
+  font-size: var(--fs-xs);
   font-weight: 500;
   color: var(--fg-0);
   text-transform: none;
@@ -420,7 +419,7 @@
   font-family: var(--font-mono);
 }
 .grid-header-type {
-  font-size: 9.5px;
+  font-size: 10.5px;
   color: var(--fg-3);
   font-family: var(--font-mono);
   margin-left: auto;
@@ -503,7 +502,7 @@
 .cell-null {
   color: var(--fg-3);
   font-style: italic;
-  font-size: 10px;
+  font-size: var(--fs-xs);
   letter-spacing: 0.04em;
 }
 .cell-enum {
@@ -511,7 +510,7 @@
   align-items: center;
   gap: 5px;
   font-family: var(--font-sans);
-  font-size: 11px;
+  font-size: var(--fs-xs);
 }
 .cell-enum .dot {
   width: 6px;
@@ -547,7 +546,7 @@
   border: none;
   outline: none;
   color: var(--fg-0);
-  font-size: 11.5px;
+  font-size: var(--fs-xs);
 }
 .cell-edit-input[aria-invalid="true"] {
   background: color-mix(in oklab, var(--delete-bg) 82%, var(--bg-2));
@@ -571,7 +570,7 @@
   padding: 0 6px;
   background: var(--bg-3);
   border-radius: 3px;
-  font-size: 10px;
+  font-size: 11px;
   font-family: var(--font-sans);
   color: var(--fg-1);
   flex-shrink: 0;
@@ -591,7 +590,7 @@
   right: 4px;
   top: 50%;
   transform: translateY(-50%);
-  font-size: 9.5px;
+  font-size: 10.5px;
   color: var(--fg-3);
   pointer-events: none;
   max-width: 50%;
@@ -626,7 +625,7 @@
   background: var(--bg-1);
   border-top: 1px solid var(--border-default);
   font-family: var(--font-sans);
-  font-size: 11px;
+  font-size: 12px;
   color: var(--fg-2);
   flex-shrink: 0;
 }
@@ -651,7 +650,7 @@
   border-radius: 4px;
   background: var(--bg-inset);
   color: var(--fg-0);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   outline: none;
 }
 .grid-pagination-size select:focus {
@@ -690,7 +689,7 @@
   background: var(--bg-1);
   border-top: 1px solid var(--border-default);
   font-family: var(--font-sans);
-  font-size: 11.5px;
+  font-size: var(--fs-xs);
   flex-shrink: 0;
 }
 .grid-pending.empty { background: var(--bg-1); }
@@ -713,7 +712,7 @@
   height: 18px;
   padding: 0 6px;
   border-radius: 3px;
-  font-size: 10.5px;
+  font-size: 11.5px;
   font-weight: 500;
 }
 .grid-pending-chip .dot {
@@ -733,7 +732,7 @@
   height: 22px;
   padding: 0 9px;
   border-radius: 4px;
-  font-size: 11px;
+  font-size: var(--fs-xs);
   font-weight: 500;
   border: 1px solid var(--border-default);
   color: var(--fg-1);

--- a/apps/desktop/src/styles/tokens.css
+++ b/apps/desktop/src/styles/tokens.css
@@ -100,14 +100,14 @@
   --font-mono: "JetBrains Mono", "Geist Mono", ui-monospace, "SF Mono", "Menlo", "Consolas", monospace;
   --font-interface: var(--font-sans);
   --font-data: var(--font-mono);
-  /* Size scale: 12, 13 (base), 14, 16, 18, 24. Base lives on --fs-sm, which the
+  /* Size scale: 13, 14 (base), 15, 17, 19, 25. Base lives on --fs-sm, which the
      body uses (see base.css). */
-  --fs-xs: 12px;
-  --fs-sm: 13px;
-  --fs-md: 14px;
-  --fs-lg: 16px;
-  --fs-xl: 18px;
-  --fs-2xl: 24px;
+  --fs-xs: 13px;
+  --fs-sm: 14px;
+  --fs-md: 15px;
+  --fs-lg: 17px;
+  --fs-xl: 19px;
+  --fs-2xl: 25px;
 }
 
 [data-theme="light"] {


### PR DESCRIPTION
Bumps Cellar desktop font pixels up by 1 across shared type tokens, CSS font-size rules, Tailwind arbitrary text classes, and inline fontSize usages. Keeps the dense result grid one token step below the 14px interface base while preserving latest main's grid surface contrast changes. This updates the existing workspace font-size changes across desktop panels, modals, sidebar, status bar, grid, editor, and renderers. Validated with pnpm typecheck, git diff --check, and a merge-tree conflict check against origin/main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Double-clicking the window title bar now toggles maximize/restore more reliably.

* **UI Improvements**
  * Increased and standardized text sizes across the desktop app for better readability.
  * Updated panels, dialogs, tabs, sidebars, status bars, and message views to use more consistent typography.
  * Refreshed editor, grid, and code-block styling for a clearer appearance.

* **Bug Fixes**
  * Improved visual consistency across empty states, labels, badges, and action buttons throughout the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->