### PR TITLE
Add saved filter presets to the table grid toolbar

### DIFF
--- a/apps/desktop/src/components/Workspace.tsx
+++ b/apps/desktop/src/components/Workspace.tsx
@@ -28,6 +28,7 @@ import {
   type WorkspaceTab,
 } from "../state/tabs";
 import { useFindUsages } from "../state/findUsages";
+import { useFilterPresets } from "../state/filterPresets";
 import { useTableData } from "../hooks/useTableData";
 import { useSettings } from "../lib/settings";
 import { toCsv, toJson, toSqlInserts, toTsv } from "../lib/export";
@@ -259,6 +260,64 @@ function TableTabPane({
   // pauses — keystrokes never re-render the grid.
   const [quickFilter, setQuickFilter] = useState("");
   const [quickColumn, setQuickColumn] = useState<string | null>(null);
+  // Saved presets snapshot the whole toolbar (quick filter, chips, order by)
+  // per table, persisted to localStorage so they survive restarts.
+  const presets = useFilterPresets((s) => s.presets[tab.id]);
+  const savePreset = useFilterPresets((s) => s.savePreset);
+  const deletePreset = useFilterPresets((s) => s.deletePreset);
+  const savedFilters = useMemo(
+    () => ({
+      names: (presets ?? []).map((preset) => preset.name),
+      // Derived, not tracked: the dropdown names whichever preset the toolbar
+      // currently matches, and clears itself the moment anything is edited.
+      activeName:
+        (presets ?? []).find(
+          (preset) =>
+            JSON.stringify([
+              preset.filters,
+              preset.sort,
+              preset.quickFilter,
+              preset.quickColumn,
+            ]) ===
+            JSON.stringify([grid.filters, grid.sort, quickFilter, quickColumn]),
+        )?.name ?? null,
+      onSave: (name: string) =>
+        savePreset(tab.id, {
+          name,
+          filters: grid.filters,
+          sort: grid.sort,
+          quickFilter,
+          quickColumn,
+        }),
+      onApply: (name: string) => {
+        const preset = (presets ?? []).find((item) => item.name === name);
+        if (!preset) return;
+        grid.setFilters(preset.filters);
+        grid.setSort(preset.sort);
+        setQuickFilter(preset.quickFilter);
+        setQuickColumn(preset.quickColumn);
+      },
+      onDelete: (name: string) => deletePreset(tab.id, name),
+      onClear: () => {
+        grid.setFilters([]);
+        grid.setSort(null);
+        setQuickFilter("");
+        setQuickColumn(null);
+      },
+    }),
+    [
+      presets,
+      savePreset,
+      deletePreset,
+      tab.id,
+      grid.filters,
+      grid.sort,
+      grid.setFilters,
+      grid.setSort,
+      quickFilter,
+      quickColumn,
+    ],
+  );
   const data = useTableData(
     tab.connectionId,
     tab.database,
@@ -421,6 +480,7 @@ function TableTabPane({
         onQuickFilterColumnChange={setQuickColumn}
         sort={grid.sort}
         onSortChange={grid.setSort}
+        savedFilters={savedFilters}
         columnLayout={columnLayout}
         onColumnLayoutChange={(next) => setTableLayout(tab.id, next)}
         onCommit={onCommit}

--- a/apps/desktop/src/state/filterPresets.test.ts
+++ b/apps/desktop/src/state/filterPresets.test.ts
@@ -22,11 +22,11 @@ describe("useFilterPresets", () => {
       useFilterPresets.getState().presets["t1"]?.map((p) => p.name),
     ).toEqual(["active users", "recent"]);
 
-    // Same name overwrites in place rather than duplicating.
-    savePreset("t1", preset("recent", { quickFilter: "now" }));
+    // Same name overwrites in place — no duplicate, and list order is kept.
+    savePreset("t1", preset("active users", { quickFilter: "now" }));
     const t1 = useFilterPresets.getState().presets["t1"] ?? [];
-    expect(t1.filter((p) => p.name === "recent")).toHaveLength(1);
-    expect(t1.find((p) => p.name === "recent")?.quickFilter).toBe("now");
+    expect(t1.map((p) => p.name)).toEqual(["active users", "recent"]);
+    expect(t1.find((p) => p.name === "active users")?.quickFilter).toBe("now");
 
     deletePreset("t1", "active users");
     deletePreset("t1", "recent");

--- a/apps/desktop/src/state/filterPresets.test.ts
+++ b/apps/desktop/src/state/filterPresets.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { useFilterPresets, type FilterPreset } from "./filterPresets";
+
+const preset = (name: string, extra?: Partial<FilterPreset>): FilterPreset => ({
+  name,
+  filters: [],
+  sort: null,
+  quickFilter: "",
+  quickColumn: null,
+  ...extra,
+});
+
+describe("useFilterPresets", () => {
+  it("saves, overwrites by name, and deletes per table", () => {
+    const { savePreset, deletePreset } = useFilterPresets.getState();
+
+    savePreset("t1", preset("active users", { quickFilter: "active" }));
+    savePreset("t2", preset("other table"));
+    savePreset("t1", preset("recent"));
+    expect(
+      useFilterPresets.getState().presets["t1"]?.map((p) => p.name),
+    ).toEqual(["active users", "recent"]);
+
+    // Same name overwrites in place rather than duplicating.
+    savePreset("t1", preset("recent", { quickFilter: "now" }));
+    const t1 = useFilterPresets.getState().presets["t1"] ?? [];
+    expect(t1.filter((p) => p.name === "recent")).toHaveLength(1);
+    expect(t1.find((p) => p.name === "recent")?.quickFilter).toBe("now");
+
+    deletePreset("t1", "active users");
+    deletePreset("t1", "recent");
+    expect(useFilterPresets.getState().presets["t1"]).toBeUndefined();
+    expect(useFilterPresets.getState().presets["t2"]).toHaveLength(1);
+  });
+});

--- a/apps/desktop/src/state/filterPresets.ts
+++ b/apps/desktop/src/state/filterPresets.ts
@@ -32,13 +32,22 @@ function loadPresets(): FilterPresets {
     const presets: FilterPresets = {};
     for (const [key, value] of Object.entries(parsed)) {
       if (!Array.isArray(value)) continue;
-      const items = value.filter(
-        (item): item is FilterPreset =>
-          !!item &&
-          typeof item === "object" &&
-          typeof (item as FilterPreset).name === "string" &&
-          Array.isArray((item as FilterPreset).filters),
-      );
+      const items = value.filter((item): item is FilterPreset => {
+        if (!item || typeof item !== "object") return false;
+        const preset = item as FilterPreset;
+        return (
+          typeof preset.name === "string" &&
+          Array.isArray(preset.filters) &&
+          (preset.sort === null ||
+            (typeof preset.sort === "object" &&
+              typeof preset.sort.columnKey === "string" &&
+              (preset.sort.direction === "asc" ||
+                preset.sort.direction === "desc"))) &&
+          typeof preset.quickFilter === "string" &&
+          (preset.quickColumn === null ||
+            typeof preset.quickColumn === "string")
+        );
+      });
       if (items.length > 0) presets[key] = items;
     }
     return presets;
@@ -49,7 +58,11 @@ function loadPresets(): FilterPresets {
 
 function savePresets(presets: FilterPresets) {
   if (typeof localStorage === "undefined") return;
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(presets));
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(presets));
+  } catch {
+    // Persistence failed (quota, private mode) — keep the in-memory update.
+  }
 }
 
 export const useFilterPresets = create<FilterPresetsStore>((set) => ({
@@ -58,10 +71,12 @@ export const useFilterPresets = create<FilterPresetsStore>((set) => ({
   savePreset(tableId, preset) {
     set((s) => {
       const existing = s.presets[tableId] ?? [];
-      const next = [
-        ...existing.filter((item) => item.name !== preset.name),
-        preset,
-      ];
+      // Overwrite in place so saving over a preset keeps its list position.
+      const index = existing.findIndex((item) => item.name === preset.name);
+      const next =
+        index === -1
+          ? [...existing, preset]
+          : existing.map((item, i) => (i === index ? preset : item));
       const presets = { ...s.presets, [tableId]: next };
       savePresets(presets);
       return { presets };

--- a/apps/desktop/src/state/filterPresets.ts
+++ b/apps/desktop/src/state/filterPresets.ts
@@ -1,0 +1,83 @@
+import { create } from "zustand";
+import type { ColumnFilters, SortState } from "@cellar/data-grid";
+
+const STORAGE_KEY = "cellar.filterPresets.v1";
+
+/** Snapshot of the whole toolbar: quick filter, advanced chips, and order by. */
+export interface FilterPreset {
+  name: string;
+  filters: ColumnFilters;
+  sort: SortState;
+  quickFilter: string;
+  quickColumn: string | null;
+}
+
+/** Presets keyed by table id (`tableKey` from tabs.ts). */
+export type FilterPresets = Record<string, FilterPreset[]>;
+
+interface FilterPresetsStore {
+  presets: FilterPresets;
+  /** Save (or overwrite, matched by name) a preset for a table. */
+  savePreset: (tableId: string, preset: FilterPreset) => void;
+  deletePreset: (tableId: string, name: string) => void;
+}
+
+function loadPresets(): FilterPresets {
+  if (typeof localStorage === "undefined") return {};
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return {};
+    const presets: FilterPresets = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (!Array.isArray(value)) continue;
+      const items = value.filter(
+        (item): item is FilterPreset =>
+          !!item &&
+          typeof item === "object" &&
+          typeof (item as FilterPreset).name === "string" &&
+          Array.isArray((item as FilterPreset).filters),
+      );
+      if (items.length > 0) presets[key] = items;
+    }
+    return presets;
+  } catch {
+    return {};
+  }
+}
+
+function savePresets(presets: FilterPresets) {
+  if (typeof localStorage === "undefined") return;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(presets));
+}
+
+export const useFilterPresets = create<FilterPresetsStore>((set) => ({
+  presets: loadPresets(),
+
+  savePreset(tableId, preset) {
+    set((s) => {
+      const existing = s.presets[tableId] ?? [];
+      const next = [
+        ...existing.filter((item) => item.name !== preset.name),
+        preset,
+      ];
+      const presets = { ...s.presets, [tableId]: next };
+      savePresets(presets);
+      return { presets };
+    });
+  },
+
+  deletePreset(tableId, name) {
+    set((s) => {
+      const next = (s.presets[tableId] ?? []).filter(
+        (item) => item.name !== name,
+      );
+      const presets = { ...s.presets };
+      if (next.length > 0) presets[tableId] = next;
+      else delete presets[tableId];
+      savePresets(presets);
+      return { presets };
+    });
+  },
+}));

--- a/apps/desktop/src/styles/grid.css
+++ b/apps/desktop/src/styles/grid.css
@@ -244,25 +244,40 @@
   box-shadow: 0 6px 20px rgba(0, 0, 0, 0.3);
   font-size: var(--fs-sm);
 }
+/* Row wrapper: apply/clear and delete are sibling buttons inside it, so the
+   delete “×” stays keyboard-focusable instead of nesting inside a button. */
 .grid-menu-item {
   display: flex;
   width: 100%;
   align-items: center;
-  gap: 7px;
-  padding: 4px 8px 4px 6px;
-  border: 0;
+  gap: 4px;
+  padding: 0 4px 0 0;
   border-radius: 4px;
-  background: none;
   color: var(--fg-1);
   font-size: var(--fs-sm);
-  text-align: left;
   white-space: nowrap;
   cursor: default;
 }
+.grid-menu-item-main {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  align-items: center;
+  gap: 7px;
+  padding: 4px 4px 4px 6px;
+  border: 0;
+  background: none;
+  color: inherit;
+  font-size: inherit;
+  text-align: left;
+  cursor: default;
+}
 .grid-menu-item:hover,
-.grid-menu-item:focus-visible {
+.grid-menu-item:focus-within {
   background: var(--bg-3);
   color: var(--fg-0);
+}
+.grid-menu-item-main:focus-visible {
   outline: none;
 }
 .grid-menu-item.is-selected {
@@ -286,7 +301,8 @@
 .grid-menu-delete {
   visibility: hidden;
 }
-.grid-menu-item:hover .grid-menu-delete {
+.grid-menu-item:hover .grid-menu-delete,
+.grid-menu-item:focus-within .grid-menu-delete {
   visibility: visible;
 }
 .grid-menu-separator {

--- a/apps/desktop/src/styles/grid.css
+++ b/apps/desktop/src/styles/grid.css
@@ -184,11 +184,115 @@
   font-size: var(--fs-sm);
 }
 .grid-select-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   padding: 3px 8px;
   border-radius: 3px;
   color: var(--fg-1);
   white-space: nowrap;
   cursor: default;
+}
+/* Saved filter presets — dropdown-menu trigger + panel. */
+.grid-preset-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 22px;
+  max-width: 190px;
+  padding: 0 8px;
+  border: 1px solid var(--border-default);
+  border-radius: 4px;
+  background: var(--bg-inset);
+  color: var(--fg-2);
+  font-size: var(--fs-xs);
+  cursor: default;
+}
+.grid-preset-trigger:hover {
+  background: var(--bg-3);
+  color: var(--fg-0);
+  border-color: var(--border-strong);
+}
+.grid-preset-trigger:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent-line);
+}
+.grid-preset-trigger.is-active {
+  color: var(--accent);
+  border-color: var(--accent-line);
+}
+.grid-preset-trigger > svg {
+  flex-shrink: 0;
+}
+.grid-preset-trigger-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.grid-menu {
+  position: fixed;
+  z-index: 1000;
+  min-width: 180px;
+  max-height: 300px;
+  overflow-y: auto;
+  padding: 4px;
+  border: 1px solid var(--border-strong);
+  border-radius: 6px;
+  background: var(--bg-2);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.3);
+  font-size: var(--fs-sm);
+}
+.grid-menu-item {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 7px;
+  padding: 4px 8px 4px 6px;
+  border: 0;
+  border-radius: 4px;
+  background: none;
+  color: var(--fg-1);
+  font-size: var(--fs-sm);
+  text-align: left;
+  white-space: nowrap;
+  cursor: default;
+}
+.grid-menu-item:hover,
+.grid-menu-item:focus-visible {
+  background: var(--bg-3);
+  color: var(--fg-0);
+  outline: none;
+}
+.grid-menu-item.is-selected {
+  color: var(--accent);
+}
+.grid-menu-check {
+  display: inline-flex;
+  width: 12px;
+  flex-shrink: 0;
+  justify-content: center;
+  color: var(--fg-3);
+}
+.grid-menu-item.is-selected .grid-menu-check {
+  color: var(--accent);
+}
+.grid-menu-item-label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.grid-menu-delete {
+  visibility: hidden;
+}
+.grid-menu-item:hover .grid-menu-delete {
+  visibility: visible;
+}
+.grid-menu-separator {
+  height: 1px;
+  margin: 4px 2px;
+  background: var(--border-default);
 }
 .grid-select-option.is-active {
   background: var(--bg-3);

--- a/packages/data-grid/src/DataGrid.tsx
+++ b/packages/data-grid/src/DataGrid.tsx
@@ -95,6 +95,7 @@ export function DataGrid({
   onQuickFilterColumnChange,
   sort,
   onSortChange,
+  savedFilters,
   columnLayout,
   onColumnLayoutChange,
   frozenCount = 0,
@@ -616,6 +617,7 @@ export function DataGrid({
         serverRows={pagination?.totalRows ?? undefined}
         sort={activeSort}
         onSortChange={applySort}
+        savedFilters={savedFilters}
       />
 
       <div

--- a/packages/data-grid/src/DataGridProps.tsx
+++ b/packages/data-grid/src/DataGridProps.tsx
@@ -3,6 +3,7 @@ import type {
   ReactNode,
 } from "react";
 import type { CellEditorProps } from "./Cell";
+import type { SavedFilterControls } from "./FilterBar";
 import type { RendererRegistry, SaveBlob } from "./renderers/types";
 import type {
   CellAddress,
@@ -50,6 +51,9 @@ export type DataGridProps = {
 
   sort?: SortState;
   onSortChange?: (next: SortState) => void;
+
+  /** Saved filter presets shown in the toolbar. Hidden when omitted. */
+  savedFilters?: SavedFilterControls;
 
   columnLayout?: GridColumnLayout;
   onColumnLayoutChange?: (next: GridColumnLayout) => void;

--- a/packages/data-grid/src/FilterBar.tsx
+++ b/packages/data-grid/src/FilterBar.tsx
@@ -9,6 +9,7 @@ import {
 } from "./filters";
 import { GridIcon } from "./icons";
 import { GridSelect } from "./GridSelect";
+import { PresetMenu } from "./PresetMenu";
 import type {
   ColumnFilters,
   FilterClause,
@@ -24,6 +25,23 @@ type ComposerDraft = {
   operator: FilterOperator;
   value: string;
   logic: FilterLogic;
+};
+
+export type SavedFilterControls = {
+  /** Preset names for this table, in display order. */
+  names: readonly string[];
+  /**
+   * Name of the preset the current toolbar state matches, if any. Shown on the
+   * dropdown trigger; hosts typically derive it by comparing state to the
+   * saved snapshots, so it clears itself as soon as the user edits anything.
+   */
+  activeName?: string | null;
+  /** Snapshot the current quick filter + chips + sort under `name`. */
+  onSave: (name: string) => void;
+  onApply: (name: string) => void;
+  onDelete: (name: string) => void;
+  /** Reset the whole toolbar (quick filter, chips, sort) — unselects. */
+  onClear: () => void;
 };
 
 export type FilterBarProps = {
@@ -44,6 +62,8 @@ export type FilterBarProps = {
   serverRows?: number;
   sort?: SortState;
   onSortChange?: (next: SortState) => void;
+  /** Saved filter presets. Hidden when omitted. */
+  savedFilters?: SavedFilterControls;
 };
 
 export function FilterBar({
@@ -59,6 +79,7 @@ export function FilterBar({
   serverRows,
   sort,
   onSortChange,
+  savedFilters,
 }: FilterBarProps) {
   const [draft, setDraft] = useState<ComposerDraft | null>(null);
   const columnRef = useRef<HTMLButtonElement | null>(null);
@@ -178,6 +199,21 @@ export function FilterBar({
     const handle = setTimeout(() => onQuickRef.current?.(quickDraft.trim()), 250);
     return () => clearTimeout(handle);
   }, [quickDraft]);
+  // Saved presets: the "presets" word is the dropdown (apply / hover-× delete);
+  // the save button swaps it for a small name input. No selected-preset state —
+  // applying is a one-shot action, not a mode.
+  const [presetDraft, setPresetDraft] = useState<string | null>(null);
+  const presetInputRef = useRef<HTMLInputElement | null>(null);
+  useEffect(() => {
+    if (presetDraft !== null) presetInputRef.current?.focus();
+  }, [presetDraft !== null]);
+  const applyPresetDraft = () => {
+    const name = presetDraft?.trim();
+    if (!name) return;
+    savedFilters?.onSave(name);
+    setPresetDraft(null);
+  };
+
   const quickValue = quickDraft;
   const quickColumnValue = quickFilterColumn ?? textColumns[0]?.key ?? "";
   const quickActive = quickValue.trim().length > 0;
@@ -431,6 +467,55 @@ export function FilterBar({
             >
               {sort.direction}
             </button>
+          )}
+        </div>
+      )}
+      {savedFilters && (
+        <div className="grid-orderby">
+          {presetDraft !== null ? (
+            <>
+              <input
+                ref={presetInputRef}
+                className="grid-filter-input mono"
+                value={presetDraft}
+                onChange={(e) => setPresetDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    applyPresetDraft();
+                  }
+                  if (e.key === "Escape") {
+                    e.stopPropagation();
+                    setPresetDraft(null);
+                  }
+                }}
+                placeholder="preset name"
+                aria-label="Preset name"
+              />
+              <button
+                className="grid-filter-apply"
+                onClick={applyPresetDraft}
+                disabled={!presetDraft.trim()}
+              >
+                save
+              </button>
+              <button
+                className="grid-filter-cancel"
+                onClick={() => setPresetDraft(null)}
+                aria-label="Cancel saving preset"
+              >
+                <GridIcon.close size={9} />
+              </button>
+            </>
+          ) : (
+            <PresetMenu
+              names={savedFilters.names}
+              activeName={savedFilters.activeName ?? null}
+              onApply={savedFilters.onApply}
+              onDelete={savedFilters.onDelete}
+              onClear={savedFilters.onClear}
+              onSaveRequest={() => setPresetDraft("")}
+            />
           )}
         </div>
       )}

--- a/packages/data-grid/src/FilterBar.tsx
+++ b/packages/data-grid/src/FilterBar.tsx
@@ -206,7 +206,7 @@ export function FilterBar({
   const presetInputRef = useRef<HTMLInputElement | null>(null);
   useEffect(() => {
     if (presetDraft !== null) presetInputRef.current?.focus();
-  }, [presetDraft !== null]);
+  }, [presetDraft]);
   const applyPresetDraft = () => {
     const name = presetDraft?.trim();
     if (!name) return;

--- a/packages/data-grid/src/PresetMenu.tsx
+++ b/packages/data-grid/src/PresetMenu.tsx
@@ -112,70 +112,76 @@ export function PresetMenu({
                 {names.map((name) => {
                   const isActive = name === activeName;
                   return (
-                    <button
+                    <div
                       key={name}
-                      type="button"
-                      role="menuitemradio"
-                      aria-checked={isActive}
                       className={
                         "grid-menu-item" + (isActive ? " is-selected" : "")
                       }
-                      // Clicking the active preset again unselects it.
-                      onClick={() => act(isActive ? onClear : () => onApply(name))}
                     >
-                      <span className="grid-menu-check">
-                        {isActive && <GridIcon.check size={10} />}
-                      </span>
-                      <span className="grid-menu-item-label">{name}</span>
+                      <button
+                        type="button"
+                        role="menuitemradio"
+                        aria-checked={isActive}
+                        className="grid-menu-item-main"
+                        // Clicking the active preset again unselects it.
+                        onClick={() =>
+                          act(isActive ? onClear : () => onApply(name))
+                        }
+                      >
+                        <span className="grid-menu-check">
+                          {isActive && <GridIcon.check size={10} />}
+                        </span>
+                        <span className="grid-menu-item-label">{name}</span>
+                      </button>
                       {/* The active preset can't be deleted — clear it first,
                           otherwise the toolbar is left on a view that no
                           longer exists anywhere. */}
                       {!isActive && (
-                        <span
-                          role="button"
-                          tabIndex={-1}
+                        <button
+                          type="button"
                           className="grid-filter-remove grid-menu-delete"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            onDelete(name);
-                          }}
+                          onClick={() => onDelete(name)}
                           aria-label={`Delete preset ${name}`}
                           title="Delete preset"
                         >
                           <GridIcon.close size={9} />
-                        </span>
+                        </button>
                       )}
-                    </button>
+                    </div>
                   );
                 })}
                 <div className="grid-menu-separator" role="separator" />
               </>
             )}
-            <button
-              type="button"
-              role="menuitem"
-              className="grid-menu-item"
-              onClick={() => act(onSaveRequest)}
-            >
-              <span className="grid-menu-check">
-                <GridIcon.plus size={10} />
-              </span>
-              <span className="grid-menu-item-label">
-                Save current as preset…
-              </span>
-            </button>
-            {activeName && (
+            <div className="grid-menu-item">
               <button
                 type="button"
                 role="menuitem"
-                className="grid-menu-item"
-                onClick={() => act(onClear)}
+                className="grid-menu-item-main"
+                onClick={() => act(onSaveRequest)}
               >
                 <span className="grid-menu-check">
-                  <GridIcon.close size={9} />
+                  <GridIcon.plus size={10} />
                 </span>
-                <span className="grid-menu-item-label">Clear preset</span>
+                <span className="grid-menu-item-label">
+                  Save current as preset…
+                </span>
               </button>
+            </div>
+            {activeName && (
+              <div className="grid-menu-item">
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="grid-menu-item-main"
+                  onClick={() => act(onClear)}
+                >
+                  <span className="grid-menu-check">
+                    <GridIcon.close size={9} />
+                  </span>
+                  <span className="grid-menu-item-label">Clear preset</span>
+                </button>
+              </div>
             )}
           </div>,
           document.body,

--- a/packages/data-grid/src/PresetMenu.tsx
+++ b/packages/data-grid/src/PresetMenu.tsx
@@ -1,0 +1,185 @@
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { GridIcon } from "./icons";
+
+export type PresetMenuProps = {
+  names: readonly string[];
+  /** Preset the current toolbar state matches, if any — gets the checkmark. */
+  activeName: string | null;
+  onApply: (name: string) => void;
+  onDelete: (name: string) => void;
+  /** Reset the toolbar (unselect the active preset). */
+  onClear: () => void;
+  /** Open the host's "name this preset" input. */
+  onSaveRequest: () => void;
+};
+
+/**
+ * Dropdown menu for saved filter presets: preset items (check on the active
+ * one, hover “×” to delete), then save/clear actions. Portal + fixed
+ * positioning for the same reason as GridSelect — the filter bar clips
+ * overflow.
+ */
+export function PresetMenu({
+  names,
+  activeName,
+  onApply,
+  onDelete,
+  onClear,
+  onSaveRequest,
+}: PresetMenuProps) {
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState({ left: 0, top: 0, minWidth: 0 });
+
+  const openMenu = () => {
+    const rect = buttonRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    // See GridSelect: the app zooms <body>, so viewport coords must be
+    // divided by --ui-scale to land the fixed-position menu correctly.
+    const zoom =
+      Number(
+        getComputedStyle(document.documentElement).getPropertyValue(
+          "--ui-scale",
+        ),
+      ) || 1;
+    setPos({
+      left: rect.left / zoom,
+      top: (rect.bottom + 4) / zoom,
+      minWidth: rect.width / zoom,
+    });
+    setOpen(true);
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (menuRef.current?.contains(target)) return;
+      if (buttonRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    const close = () => setOpen(false);
+    window.addEventListener("mousedown", onPointerDown);
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("scroll", close, true);
+    window.addEventListener("resize", close);
+    return () => {
+      window.removeEventListener("mousedown", onPointerDown);
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("scroll", close, true);
+      window.removeEventListener("resize", close);
+    };
+  }, [open]);
+
+  const act = (action: () => void) => {
+    setOpen(false);
+    action();
+  };
+
+  return (
+    <>
+      <button
+        ref={buttonRef}
+        type="button"
+        className={"grid-preset-trigger" + (activeName ? " is-active" : "")}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label="Saved filter presets"
+        title="Saved filter presets"
+        onClick={() => (open ? setOpen(false) : openMenu())}
+      >
+        <GridIcon.bookmark size={11} />
+        <span className="grid-preset-trigger-label">
+          {activeName ?? "Presets"}
+        </span>
+        <GridIcon.chevronDown size={8} />
+      </button>
+      {open &&
+        createPortal(
+          <div
+            ref={menuRef}
+            className="grid-menu"
+            role="menu"
+            style={{ left: pos.left, top: pos.top, minWidth: pos.minWidth }}
+          >
+            {names.length > 0 && (
+              <>
+                {names.map((name) => {
+                  const isActive = name === activeName;
+                  return (
+                    <button
+                      key={name}
+                      type="button"
+                      role="menuitemradio"
+                      aria-checked={isActive}
+                      className={
+                        "grid-menu-item" + (isActive ? " is-selected" : "")
+                      }
+                      // Clicking the active preset again unselects it.
+                      onClick={() => act(isActive ? onClear : () => onApply(name))}
+                    >
+                      <span className="grid-menu-check">
+                        {isActive && <GridIcon.check size={10} />}
+                      </span>
+                      <span className="grid-menu-item-label">{name}</span>
+                      {/* The active preset can't be deleted — clear it first,
+                          otherwise the toolbar is left on a view that no
+                          longer exists anywhere. */}
+                      {!isActive && (
+                        <span
+                          role="button"
+                          tabIndex={-1}
+                          className="grid-filter-remove grid-menu-delete"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onDelete(name);
+                          }}
+                          aria-label={`Delete preset ${name}`}
+                          title="Delete preset"
+                        >
+                          <GridIcon.close size={9} />
+                        </span>
+                      )}
+                    </button>
+                  );
+                })}
+                <div className="grid-menu-separator" role="separator" />
+              </>
+            )}
+            <button
+              type="button"
+              role="menuitem"
+              className="grid-menu-item"
+              onClick={() => act(onSaveRequest)}
+            >
+              <span className="grid-menu-check">
+                <GridIcon.plus size={10} />
+              </span>
+              <span className="grid-menu-item-label">
+                Save current as preset…
+              </span>
+            </button>
+            {activeName && (
+              <button
+                type="button"
+                role="menuitem"
+                className="grid-menu-item"
+                onClick={() => act(onClear)}
+              >
+                <span className="grid-menu-check">
+                  <GridIcon.close size={9} />
+                </span>
+                <span className="grid-menu-item-label">Clear preset</span>
+              </button>
+            )}
+          </div>,
+          document.body,
+        )}
+    </>
+  );
+}

--- a/packages/data-grid/src/icons.tsx
+++ b/packages/data-grid/src/icons.tsx
@@ -56,6 +56,8 @@ export const GridIcon = {
     </I>
   ),
   filter: (p: IconProps) => <I {...p} d="M3 5h18l-7 9v6l-4-2v-4z" />,
+  bookmark: (p: IconProps) => <I {...p} d="M6 3h12v18l-6-4.5L6 21z" />,
+  check: (p: IconProps) => <I {...p} d="M4 12l5 5L20 6" />,
   search: (p: IconProps) => (
     <I {...p}>
       <circle cx="11" cy="11" r="7" />

--- a/packages/data-grid/src/index.ts
+++ b/packages/data-grid/src/index.ts
@@ -48,7 +48,11 @@ export {
   parseCellInput,
   type CellEditorProps,
 } from "./Cell";
-export { FilterBar, type FilterBarProps } from "./FilterBar";
+export {
+  FilterBar,
+  type FilterBarProps,
+  type SavedFilterControls,
+} from "./FilterBar";
 export { PendingBar, type PendingBarProps } from "./PendingBar";
 export { TypeIcon } from "./TypeIcon";
 


### PR DESCRIPTION
Adds per-table saved filter presets so a quick filter + where-chips + order-by combination can be saved under a name and reapplied later in one click. A new dropdown-menu control (`PresetMenu`) in the filter bar lists presets with a checkmark on the active one, hover-× delete (disabled for the active preset), "Save current as preset…", and "Clear preset" to unselect. The active preset is derived by comparing the current toolbar state against the saved snapshots, so it clears itself the moment anything is edited. Presets are stored per `connection::db.schema.table` key in localStorage via a new `useFilterPresets` Zustand store (same pattern as `tableLayouts`), with a round-trip test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added saved filter presets to the table toolbar.
  * Users can save, apply, delete, and clear presets from a new “Saved filter presets” dropdown.
  * Presets persist between sessions and capture filter, sort, and quick-filter/column state.
* **Bug Fixes**
  * More robust preset persistence so missing/invalid stored data (or storage write issues) won’t break the toolbar.
* **Tests**
  * Added tests covering saving, overwriting, and deleting per-table presets behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->