### PR TITLE
fix: remove connection row visual markers

### DIFF
--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -654,7 +654,6 @@ export function Sidebar({
                 error={state?.error ?? null}
                 onToggle={() => toggleExpand(c.id)}
                 onReconnect={() => void reconnect(c.id)}
-                onDisconnect={() => void disconnect(c.id)}
                 onContextMenu={(e) => openConnectionMenu(e, c)}
                 onNodeContextMenu={openNodeMenu}
                 onOpenTable={(database, schema, table) =>

--- a/apps/desktop/src/components/SidebarTree.tsx
+++ b/apps/desktop/src/components/SidebarTree.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import type { ConnectionConfig, Schema, Table } from "@cellar/ipc";
 
-import { EngineBadge, type Engine } from "./EngineBadge";
 import { Icon } from "./icons";
 import type { ConnStatus } from "../state/connections";
 
@@ -82,7 +81,6 @@ export interface ConnectionRowProps {
   error: string | null;
   onToggle: () => void;
   onReconnect: () => void;
-  onDisconnect: () => void;
   onContextMenu: (e: React.MouseEvent) => void;
   onNodeContextMenu: NodeMenuHandler;
   onOpenTable: (database: string, schema: string, table: string) => void;
@@ -105,7 +103,6 @@ export function ConnectionRow({
   error,
   onToggle,
   onReconnect,
-  onDisconnect,
   onContextMenu,
   onNodeContextMenu,
   onOpenTable,
@@ -114,15 +111,13 @@ export function ConnectionRow({
   onManageSchemas,
   drag,
 }: ConnectionRowProps) {
-  const accent = config.color ?? engineDefaultColor(config.engine as Engine);
   return (
     <div>
       <div
         className={
           ROW_BASE +
-          " h-[26px] border-l-2 pl-1 text-fg-0 cursor-pointer"
+          " h-[26px] pl-1 text-fg-0 cursor-pointer"
         }
-        style={{ borderLeftColor: accent }}
         onClick={onToggle}
         onContextMenu={onContextMenu}
         draggable={drag?.draggable}
@@ -153,7 +148,6 @@ export function ConnectionRow({
             <Icon.chevronRight size={10} />
           )}
         </button>
-        <EngineBadge engine={config.engine as Engine} size={12} color={accent} />
         <span className={NODE_LABEL}>
           {config.name}
         </span>
@@ -170,30 +164,6 @@ export function ConnectionRow({
           </span>
         )}
         <StatusDot status={status} />
-        <button
-          type="button"
-          className="icon-btn ml-1 opacity-0 transition-opacity duration-100 group-hover:opacity-100"
-          title="Actions"
-          onClick={(e) => {
-            e.stopPropagation();
-            onContextMenu(e);
-          }}
-        >
-          <Icon.more size={11} />
-        </button>
-        {status === "connected" && (
-          <button
-            type="button"
-            className="icon-btn opacity-0 transition-opacity duration-100 group-hover:opacity-100"
-            title="Disconnect"
-            onClick={(e) => {
-              e.stopPropagation();
-              onDisconnect();
-            }}
-          >
-            <Icon.power size={11} />
-          </button>
-        )}
       </div>
 
       {expanded && error && (
@@ -701,21 +671,4 @@ function writeFolderOpen(key: string, open: boolean) {
   const map = readFolderOpenMap();
   map[key] = open;
   window.localStorage.setItem(FOLDER_OPEN_STORAGE_KEY, JSON.stringify(map));
-}
-
-function engineDefaultColor(engine: Engine): string {
-  switch (engine) {
-    case "postgres":
-      return "var(--eng-postgres)";
-    case "mysql":
-      return "var(--eng-mysql)";
-    case "mssql":
-      return "var(--eng-mssql)";
-    case "azure":
-      return "var(--eng-azure)";
-    case "sqlite":
-      return "var(--eng-sqlite)";
-    case "firestore":
-      return "var(--eng-firestore)";
-  }
 }

--- a/packages/ipc/src/mock.ts
+++ b/packages/ipc/src/mock.ts
@@ -45,8 +45,24 @@ const mockDriverInfo: DriverInfo = {
   version: "PostgreSQL 16.2 (mock — vite web mode)",
 };
 
+// Temporary repro data — revert before commit.
+const reproEngines: Engine[] = ["postgres", "mssql", "azure", "mysql"];
+const reproConnections: ConnectionConfig[] = Array.from({ length: 14 }, (_, i) => ({
+  id: `repro-${i}`,
+  name: `conn-${i}`,
+  engine: reproEngines[i % reproEngines.length]!,
+  host: "localhost",
+  port: 5432,
+  database: "db",
+  user: "u",
+  ssl_mode: "prefer" as never,
+  env_tag: null,
+  application_name: null,
+  color: null,
+}));
+
 export const mockCommands = {
-  listConnections: async (): Promise<Result<ConnectionConfig[], CellarError>> => ok([]),
+  listConnections: async (): Promise<Result<ConnectionConfig[], CellarError>> => ok(reproConnections),
 
   saveConnection: async (
     config: ConnectionConfig,

--- a/packages/ipc/src/mock.ts
+++ b/packages/ipc/src/mock.ts
@@ -45,24 +45,8 @@ const mockDriverInfo: DriverInfo = {
   version: "PostgreSQL 16.2 (mock — vite web mode)",
 };
 
-// Temporary repro data — revert before commit.
-const reproEngines: Engine[] = ["postgres", "mssql", "azure", "mysql"];
-const reproConnections: ConnectionConfig[] = Array.from({ length: 14 }, (_, i) => ({
-  id: `repro-${i}`,
-  name: `conn-${i}`,
-  engine: reproEngines[i % reproEngines.length]!,
-  host: "localhost",
-  port: 5432,
-  database: "db",
-  user: "u",
-  ssl_mode: "prefer" as never,
-  env_tag: null,
-  application_name: null,
-  color: null,
-}));
-
 export const mockCommands = {
-  listConnections: async (): Promise<Result<ConnectionConfig[], CellarError>> => ok(reproConnections),
+  listConnections: async (): Promise<Result<ConnectionConfig[], CellarError>> => ok([]),
 
   saveConnection: async (
     config: ConnectionConfig,


### PR DESCRIPTION
Removes the extra visual markers from connection rows: the colored accent strip, engine badge, and hover-only row action buttons.\n\nKeeps connection actions available through the existing context menu while making the sidebar rows visually quieter.\n\nValidation: `pnpm --filter @cellar/ipc test` and `pnpm --filter @cellar/desktop typecheck`.