### PR TITLE
fix: publish CHANGELOG sections as release and updater notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,6 +155,8 @@ jobs:
           projectPath: apps/desktop
           tagName: ${{ steps.release.outputs.tag }}
           releaseName: Cellar ${{ steps.release.outputs.version }}
+          # Draft-only placeholder; publish-release overwrites the body with
+          # the version's CHANGELOG.md section before publishing.
           releaseBody: See the assets below to download Cellar for your platform.
           releaseDraft: true
           prerelease: ${{ steps.release.outputs.prerelease }}
@@ -228,6 +230,9 @@ jobs:
     needs: build-tauri
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Resolve release tag
         id: release
         shell: bash
@@ -241,6 +246,25 @@ jobs:
           fi
 
           echo "tag=$release_tag" >> "$GITHUB_OUTPUT"
+
+      - name: Extract release notes from CHANGELOG
+        env:
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          awk -v ver="$RELEASE_TAG" \
+            '$0 == "## " ver {found=1; next} /^## / {found=0} found' \
+            CHANGELOG.md > "$RUNNER_TEMP/release-notes.md"
+
+          if [[ ! -s "$RUNNER_TEMP/release-notes.md" ]]; then
+            echo "No CHANGELOG.md section for $RELEASE_TAG — falling back to placeholder" >&2
+            echo "See the assets below to download Cellar for your platform." \
+              > "$RUNNER_TEMP/release-notes.md"
+          fi
+
+          cat "$RUNNER_TEMP/release-notes.md"
 
       - name: Generate and upload updater manifest
         env:
@@ -282,10 +306,10 @@ jobs:
 
             jq -n \
               --arg version "$RELEASE_TAG" \
-              --arg notes "See the assets below to download Cellar for your platform." \
+              --rawfile notes "$RUNNER_TEMP/release-notes.md" \
               --arg pub_date "$pub_date" \
               --argjson platforms "$platforms" \
-              '{version: $version, notes: $notes, pub_date: $pub_date, platforms: $platforms}' \
+              '{version: $version, notes: ($notes | rtrimstr("\n")), pub_date: $pub_date, platforms: $platforms}' \
               > "$tmpdir/latest.json"
 
             echo "Generated latest.json:"
@@ -302,4 +326,6 @@ jobs:
         run: |
           set -euo pipefail
 
-          gh release edit "$RELEASE_TAG" --draft=false
+          gh release edit "$RELEASE_TAG" \
+            --notes-file "$RUNNER_TEMP/release-notes.md" \
+            --draft=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,6 +266,11 @@ jobs:
 
           cat "$RUNNER_TEMP/release-notes.md"
 
+          # Full changelog (minus the "# Changelog" title) for latest.json, so
+          # users jumping multiple versions see every release in between; the
+          # app trims it to sections newer than the installed version.
+          tail -n +2 CHANGELOG.md > "$RUNNER_TEMP/changelog-full.md"
+
       - name: Generate and upload updater manifest
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -306,7 +311,7 @@ jobs:
 
             jq -n \
               --arg version "$RELEASE_TAG" \
-              --rawfile notes "$RUNNER_TEMP/release-notes.md" \
+              --rawfile notes "$RUNNER_TEMP/changelog-full.md" \
               --arg pub_date "$pub_date" \
               --argjson platforms "$platforms" \
               '{version: $version, notes: ($notes | rtrimstr("\n")), pub_date: $pub_date, platforms: $platforms}' \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,6 +232,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Resolve release tag
         id: release
@@ -254,8 +256,12 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Prefix-match the heading (tolerates "## x.y.z - date" styles) and
+          # skip blank lines before the first content line.
           awk -v ver="$RELEASE_TAG" \
-            '$0 == "## " ver {found=1; next} /^## / {found=0} found' \
+            '$0 ~ "^## " ver "([[:space:]]|$)" {found=1; next}
+             /^## / {found=0}
+             found && (started || NF) {started=1; print}' \
             CHANGELOG.md > "$RUNNER_TEMP/release-notes.md"
 
           if [[ ! -s "$RUNNER_TEMP/release-notes.md" ]]; then

--- a/apps/desktop/src/components/modals/settingsSystemPanels.tsx
+++ b/apps/desktop/src/components/modals/settingsSystemPanels.tsx
@@ -2,6 +2,7 @@ import { Icon } from "../icons";
 import { Row, Section, StaticSegment, Toggle } from "./settingsPrimitives";
 import { useConnections } from "../../state/connections";
 import { useUpdater } from "../../lib/updater";
+import { notesSince } from "../../lib/releaseNotes";
 import { openExternal } from "../../lib/openExternal";
 import changelogMd from "../../../../../CHANGELOG.md?raw";
 
@@ -200,13 +201,16 @@ export function SettingsUpdates() {
         title="What's new"
         sub={
           status.kind === "available"
-            ? `Release notes for v${status.version}`
+            ? `What changed since ${versionLabel}`
             : `Recent changes in ${versionLabel}`
         }
       >
         <Changelog
           source={
-            (status.kind === "available" && status.update.body) || changelogMd
+            (status.kind === "available" &&
+              status.update.body &&
+              notesSince(status.update.body, appVersion)) ||
+            changelogMd
           }
         />
       </Section>

--- a/apps/desktop/src/components/modals/settingsSystemPanels.tsx
+++ b/apps/desktop/src/components/modals/settingsSystemPanels.tsx
@@ -207,10 +207,9 @@ export function SettingsUpdates() {
       >
         <Changelog
           source={
-            (status.kind === "available" &&
-              status.update.body &&
-              notesSince(status.update.body, appVersion)) ||
-            changelogMd
+            status.kind === "available" && status.update.body
+              ? notesSince(status.update.body, appVersion)
+              : changelogMd
           }
         />
       </Section>

--- a/apps/desktop/src/lib/releaseNotes.test.ts
+++ b/apps/desktop/src/lib/releaseNotes.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { notesSince } from "./releaseNotes";
+
+const changelog = [
+  "# Changelog",
+  "",
+  "## 0.3.2",
+  "",
+  "- fonts",
+  "",
+  "## 0.3.1",
+  "",
+  "- theme",
+  "",
+  "## 0.2.0",
+  "",
+  "- grid",
+].join("\n");
+
+describe("notesSince", () => {
+  it("keeps only sections newer than the installed version", () => {
+    const out = notesSince(changelog, "0.2.0");
+    expect(out).toContain("## 0.3.2");
+    expect(out).toContain("## 0.3.1");
+    expect(out).not.toContain("## 0.2.0");
+    expect(out).not.toContain("# Changelog");
+  });
+
+  it("keeps only the latest section when one version behind", () => {
+    const out = notesSince(changelog, "0.3.1");
+    expect(out).toContain("## 0.3.2");
+    expect(out).not.toContain("## 0.3.1");
+  });
+
+  it("compares numerically, not lexically", () => {
+    expect(notesSince("## 0.10.0\n- ten", "0.9.0")).toContain("## 0.10.0");
+  });
+
+  it("passes through notes without version headings", () => {
+    const single = "### Features\n- something";
+    expect(notesSince(single, "0.2.0")).toBe(single);
+  });
+
+  it("passes everything through when installed version is unknown", () => {
+    expect(notesSince(changelog, "")).toBe(changelog);
+  });
+});

--- a/apps/desktop/src/lib/releaseNotes.test.ts
+++ b/apps/desktop/src/lib/releaseNotes.test.ts
@@ -36,6 +36,18 @@ describe("notesSince", () => {
     expect(notesSince("## 0.10.0\n- ten", "0.9.0")).toContain("## 0.10.0");
   });
 
+  it("matches headings with a date suffix", () => {
+    const out = notesSince("## 0.3.2 - 2026-07-01\n- fonts\n## 0.3.1 - 2026-06-30\n- theme", "0.3.1");
+    expect(out).toContain("- fonts");
+    expect(out).not.toContain("- theme");
+  });
+
+  it("treats malformed segments as 0, over-showing rather than dropping", () => {
+    // "0.3.2-beta.1" parses as 0.3.0, so 0.3.x sections still show.
+    expect(notesSince("## 0.4.0\n- next", "0.3.2-beta.1")).toContain("- next");
+    expect(notesSince(changelog, "0.3.2-beta.1")).toContain("## 0.3.1");
+  });
+
   it("passes through notes without version headings", () => {
     const single = "### Features\n- something";
     expect(notesSince(single, "0.2.0")).toBe(single);

--- a/apps/desktop/src/lib/releaseNotes.ts
+++ b/apps/desktop/src/lib/releaseNotes.ts
@@ -3,8 +3,10 @@
 // newer than the installed version.
 
 function compareVersions(a: string, b: string): number {
-  const pa = a.split(".").map(Number);
-  const pb = b.split(".").map(Number);
+  // Number() || 0 keeps malformed segments (e.g. "0-beta") from becoming NaN
+  // and silently comparing as equal.
+  const pa = a.split(".").map((n) => Number(n) || 0);
+  const pb = b.split(".").map((n) => Number(n) || 0);
   for (let i = 0; i < 3; i++) {
     const d = (pa[i] ?? 0) - (pb[i] ?? 0);
     if (d) return d;
@@ -22,7 +24,7 @@ export function notesSince(notes: string, installed: string): string {
   let keep = false;
   let sawVersionHeading = false;
   for (const line of lines) {
-    const m = /^##\s+(\d+\.\d+\.\d+)\s*$/.exec(line);
+    const m = /^##\s+(\d+\.\d+\.\d+)(?:\s|$)/.exec(line);
     if (m) {
       sawVersionHeading = true;
       keep = compareVersions(m[1]!, installed) > 0;

--- a/apps/desktop/src/lib/releaseNotes.ts
+++ b/apps/desktop/src/lib/releaseNotes.ts
@@ -1,0 +1,34 @@
+// The updater manifest ships the full CHANGELOG so users jumping multiple
+// versions see every release in between. Trim it client-side to the sections
+// newer than the installed version.
+
+function compareVersions(a: string, b: string): number {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    const d = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (d) return d;
+  }
+  return 0;
+}
+
+// Keep only `## x.y.z` sections newer than the installed version. Notes with
+// no version headings (single-release bodies, the old placeholder) pass
+// through untouched, as do all notes when the installed version is unknown.
+export function notesSince(notes: string, installed: string): string {
+  if (!installed) return notes;
+  const lines = notes.replace(/\r\n/g, "\n").split("\n");
+  const out: string[] = [];
+  let keep = false;
+  let sawVersionHeading = false;
+  for (const line of lines) {
+    const m = /^##\s+(\d+\.\d+\.\d+)\s*$/.exec(line);
+    if (m) {
+      sawVersionHeading = true;
+      keep = compareVersions(m[1]!, installed) > 0;
+    }
+    if (keep) out.push(line);
+  }
+  if (!sawVersionHeading) return notes;
+  return out.join("\n").trim();
+}


### PR DESCRIPTION
The release workflow hardcoded "See the assets below to download Cellar for your platform." into both the GitHub release body and the `notes` field of `latest.json`, so the in-app "What's new" panel showed that placeholder instead of real release notes. The publish-release job now checks out the repo, extracts the tagged version's `## x.y.z` section from `CHANGELOG.md`, and uses it for both the updater manifest notes and the release body (via `gh release edit --notes-file`). If no CHANGELOG section exists for the version, it falls back to the old placeholder with a warning. The draft-stage `releaseBody` placeholder is kept, with a comment noting it gets overwritten at publish. The already-published 0.3.2 release was patched the same way out-of-band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub Releases now automatically pull the matching release-notes section from `CHANGELOG.md` and publish it to the release body.
  * The app’s “What’s new” can display only the updates since your installed version (with updated “What changed since …” wording).

* **Bug Fixes**
  * “Latest” release metadata now uses changelog-derived notes instead of a generic placeholder.
  * Improved changelog parsing and trimming for updater scenarios, including date-suffixed headings.

* **Tests**
  * Expanded Vitest coverage for version filtering behavior, including edge cases for malformed headings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->