### PR TITLE
fix: improve AI SQL answer workflow

### DIFF
--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -34,6 +34,7 @@ pub fn builder() -> Builder<tauri::Wry> {
         schema::find_usages,
         schema::er_graph,
         query::run_query,
+        query::run_read_only_query,
         query::cancel_query,
         query::explain_query,
         query::detect_query_parameters,

--- a/apps/desktop/src-tauri/src/commands/query.rs
+++ b/apps/desktop/src-tauri/src/commands/query.rs
@@ -80,6 +80,25 @@ pub async fn run_query(
     result
 }
 
+#[tauri::command]
+#[specta::specta]
+pub async fn run_read_only_query(
+    registry: State<'_, ConnectionRegistry>,
+    connection_id: String,
+    sql: String,
+    max_rows: Option<u32>,
+    database: Option<String>,
+) -> Result<QueryResult, CellarError> {
+    let mut query = Query::new(sql).read_only();
+    if let Some(n) = max_rows {
+        query = query.with_max_rows(n);
+    }
+    if let Some(db) = database {
+        query = query.with_database(db);
+    }
+    registry.run_query(&connection_id, query).await
+}
+
 /// Cancel a running query previously started through [`run_query`] with a
 /// `query_id`. Returns `true` when a running statement was found and
 /// signalled, `false` when it had already finished.

--- a/apps/desktop/src-tauri/src/state/mod.rs
+++ b/apps/desktop/src-tauri/src/state/mod.rs
@@ -256,6 +256,12 @@ impl ConnectionRegistry {
                 .ok_or_else(|| CellarError::NotConnected(format!("no open connection for {id}")))?;
             (open.config.engine, Arc::clone(&open.connection))
         };
+        if query.read_only && engine != cellar_core::driver::Engine::Postgres {
+            return Err(CellarError::query(format!(
+                "read-only AI query execution is not available for {} yet",
+                engine.as_str()
+            )));
+        }
         let driver = driver_for(engine)?;
         match driver.execute_query(connection.as_ref(), &query).await {
             Ok(result) => Ok(result),

--- a/apps/desktop/src/components/AIMessage.test.ts
+++ b/apps/desktop/src/components/AIMessage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseSegments } from "./AIMessage";
+import { canRunFromAi, firstRunnableSql, parseSegments } from "./AIMessage";
 
 describe("parseSegments", () => {
   it("returns a single text segment for plain prose", () => {
@@ -25,5 +25,26 @@ describe("parseSegments", () => {
   it("handles multiple code blocks", () => {
     const segs = parseSegments("```sql\nA\n```\nmid\n```sql\nB\n```");
     expect(segs.filter((s) => s.kind === "code")).toHaveLength(2);
+  });
+});
+
+describe("canRunFromAi", () => {
+  it("allows read-only SQL blocks", () => {
+    expect(canRunFromAi("sql", "SELECT * FROM public.orders")).toBe(true);
+    expect(canRunFromAi("postgres", "-- check\nWITH x AS (SELECT 1) SELECT * FROM x")).toBe(true);
+  });
+
+  it("blocks write SQL and non-SQL fences", () => {
+    expect(canRunFromAi("sql", "DELETE FROM public.orders")).toBe(false);
+    expect(canRunFromAi("sql", "EXPLAIN ANALYZE DELETE FROM public.orders")).toBe(false);
+    expect(canRunFromAi("sql", "WITH gone AS (DELETE FROM t RETURNING *) SELECT * FROM gone")).toBe(false);
+    expect(canRunFromAi("sql", "CREATE TABLE public.x (id int)")).toBe(false);
+    expect(canRunFromAi("text", "SELECT 1")).toBe(false);
+  });
+});
+
+describe("firstRunnableSql", () => {
+  it("returns the first safe SQL block", () => {
+    expect(firstRunnableSql("x\n```sql\nDELETE FROM t\n```\ny\n```sql\nSELECT 1\n```")).toBe("SELECT 1");
   });
 });

--- a/apps/desktop/src/components/AIMessage.tsx
+++ b/apps/desktop/src/components/AIMessage.tsx
@@ -11,6 +11,10 @@ type Segment =
   | { kind: "code"; lang: string; code: string };
 
 const FENCE = /```([\w-]*)\n?([\s\S]*?)```/g;
+const READ_ONLY_SQL =
+  /^(?:\s|\/\*[\s\S]*?\*\/|--[^\n]*\n)*(select|with|show|describe|desc|explain)\b/i;
+const WRITE_SQL =
+  /\b(insert|update|delete|drop|truncate|alter|create|merge|grant|revoke|vacuum|analyze)\b/i;
 
 /** Split markdown-ish content into prose and fenced code blocks. We only need
  * enough fidelity to render SQL in a mono box with a copy button. */
@@ -35,8 +39,63 @@ export function parseSegments(content: string): Segment[] {
   return out;
 }
 
-function CodeBlock({ lang, code }: { lang: string; code: string }) {
+export function canRunFromAi(lang: string, code: string): boolean {
+  const sql = code.trim();
+  return SQL_LANGS.test(lang.trim()) && READ_ONLY_SQL.test(sql) && !WRITE_SQL.test(sql);
+}
+
+export function firstRunnableSql(content: string): string | null {
+  for (const seg of parseSegments(content)) {
+    if (seg.kind === "code" && canRunFromAi(seg.lang, seg.code)) return seg.code;
+  }
+  return null;
+}
+
+function TextBlock({ text }: { text: string }) {
+  const lines = text.split("\n").filter((line) => line.trim().length > 0);
+  return (
+    <div className="space-y-1 text-sm leading-[1.55] text-fg-1">
+      {lines.map((line, i) => {
+        const trimmed = line.trim();
+        const heading = trimmed.match(/^#{1,4}\s+(.+)$/);
+        const bullet = trimmed.match(/^[-*]\s+(.+)$/);
+        const body = (heading?.[1] ?? bullet?.[1] ?? trimmed)
+          .replace(/\*\*([^*]+)\*\*/g, "$1")
+          .replace(/`([^`]+)`/g, "$1");
+        return (
+          <div
+            key={i}
+            className={
+              heading
+                ? "pt-1 font-semibold text-fg-0"
+                : bullet
+                  ? "pl-3 before:mr-2 before:content-['-']"
+                  : ""
+            }
+          >
+            {body}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function CodeBlock({
+  lang,
+  code,
+  onInsert,
+  onRun,
+  running,
+}: {
+  lang: string;
+  code: string;
+  onInsert?: (code: string) => void;
+  onRun?: (code: string) => void;
+  running?: boolean;
+}) {
   const [copied, setCopied] = useState(false);
+  const runnable = canRunFromAi(lang, code);
   const copy = () => {
     void navigator.clipboard?.writeText(code).then(() => {
       setCopied(true);
@@ -45,18 +104,45 @@ function CodeBlock({ lang, code }: { lang: string; code: string }) {
   };
   return (
     <div className="overflow-hidden rounded-[5px] border border-border-default bg-bg-inset">
-      <div className="flex items-center justify-between border-b border-border-divider px-2 py-1">
+      <div className="flex items-center justify-between gap-2 border-b border-border-divider px-2 py-1">
         <span className="font-mono text-[10.5px] uppercase tracking-[0.05em] text-fg-3">
           {lang || "code"}
         </span>
-        <button
-          onClick={copy}
-          className="inline-flex items-center gap-1 rounded-[3px] px-1 text-[11px] text-fg-2 hover:bg-bg-3 hover:text-fg-0"
-          title="Copy"
-        >
-          <Icon.copy size={10} />
-          <span>{copied ? "copied" : "copy"}</span>
-        </button>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={copy}
+            className="inline-flex items-center gap-1 rounded-[3px] px-1 text-[11px] text-fg-2 hover:bg-bg-3 hover:text-fg-0"
+            title="Copy"
+          >
+            <Icon.copy size={10} />
+            <span>{copied ? "copied" : "copy"}</span>
+          </button>
+          {SQL_LANGS.test(lang.trim()) && (
+            <>
+              <button
+                onClick={() => onInsert?.(code)}
+                className="inline-flex items-center gap-1 rounded-[3px] px-1 text-[11px] text-fg-2 hover:bg-bg-3 hover:text-fg-0"
+                title="Insert into a query tab"
+              >
+                <Icon.edit size={10} />
+                <span>insert</span>
+              </button>
+              <button
+                onClick={() => onRun?.(code)}
+                disabled={!runnable || running}
+                className="inline-flex items-center gap-1 rounded-[3px] px-1 text-[11px] text-accent hover:bg-accent-soft disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
+                title={
+                  runnable
+                    ? "Run read-only SQL"
+                    : "Only read-only AI SQL can run directly"
+                }
+              >
+                <Icon.playSm size={10} />
+                <span>{running ? "running" : "run"}</span>
+              </button>
+            </>
+          )}
+        </div>
       </div>
       <pre className="overflow-x-auto px-2.5 py-2 font-mono text-sm leading-[1.5] text-fg-0">
         {SQL_LANGS.test(lang.trim()) ? (
@@ -73,7 +159,17 @@ function CodeBlock({ lang, code }: { lang: string; code: string }) {
   );
 }
 
-export function AIMessage({ entry }: { entry: AiChatEntry }) {
+export function AIMessage({
+  entry,
+  onInsertSql,
+  onRunSql,
+  runningSql,
+}: {
+  entry: AiChatEntry;
+  onInsertSql?: (sql: string) => void;
+  onRunSql?: (sql: string) => void;
+  runningSql?: boolean;
+}) {
   if (entry.role === "user") {
     return (
       <div className="flex flex-col items-end gap-1">
@@ -107,14 +203,16 @@ export function AIMessage({ entry }: { entry: AiChatEntry }) {
     <div className="flex flex-col gap-2">
       {segments.map((seg, i) =>
         seg.kind === "code" ? (
-          <CodeBlock key={i} lang={seg.lang} code={seg.code} />
-        ) : (
-          <div
+          <CodeBlock
             key={i}
-            className="whitespace-pre-wrap text-sm leading-[1.55] text-fg-1"
-          >
-            {seg.text}
-          </div>
+            lang={seg.lang}
+            code={seg.code}
+            onInsert={onInsertSql}
+            onRun={onRunSql}
+            running={runningSql}
+          />
+        ) : (
+          <TextBlock key={i} text={seg.text} />
         ),
       )}
       {entry.usage && (

--- a/apps/desktop/src/components/AIPanel.tsx
+++ b/apps/desktop/src/components/AIPanel.tsx
@@ -1,11 +1,31 @@
-import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { ORDERED_TOPICS, TOPICS, type AiTopic } from "@cellar/ai";
+import { commands, unwrap, type QueryResult } from "@cellar/ipc";
 import { Icon } from "./icons";
 import { useAi } from "../state/ai";
 import { useTabs } from "../state/tabs";
-import { useConnections } from "../state/connections";
+import { noteConnectionIssue, useConnections } from "../state/connections";
 import { buildActiveContext, type AiContextChip } from "../lib/aiContext";
-import { AIMessage } from "./AIMessage";
+import { AIMessage, firstRunnableSql } from "./AIMessage";
+import { QUERY_ROW_LIMIT } from "../hooks/useQueryRunner";
+import { cellValueToGrid, queryResultToGrid } from "../lib/gridMapping";
+import {
+  buildRunErrorMessage,
+  buildRunResultMessages,
+  buildRunStartedMessage,
+  type QueryRunContext,
+} from "../lib/queryMessages";
+import { useQueryMessages } from "../state/queryMessages";
+import { queryResultSource, useTabResults } from "../state/tabResults";
+import { useBottomPanel } from "../state/bottomPanel";
+import { useStatus } from "../state/status";
 
 const chipMeta: Record<AiContextChip["kind"], { icon: ReactNode; color: string }> = {
   schema: { icon: <Icon.schema size={9} />, color: "var(--fg-1)" },
@@ -35,6 +55,41 @@ const DISABLED_ICON =
 
 const TOPIC_BUTTONS: AiTopic[] = ORDERED_TOPICS.filter((t) => t !== "ask");
 
+type SqlScope = {
+  connectionId: string;
+  database: string;
+  tabId: string;
+  title: string;
+};
+
+function formatAiQueryAnswer(result: QueryResult): string {
+  if (result.rows_affected != null) {
+    return `Result: ${result.rows_affected.toLocaleString()} row${result.rows_affected === 1 ? "" : "s"} affected.`;
+  }
+  if (result.rows.length === 0) return "Result: no rows returned.";
+
+  const headers = result.columns.map((c) => c.name);
+  const rows = result.rows.slice(0, 5).map((row) =>
+    row.map((cell) => String(cellValueToGrid(cell) ?? "NULL")),
+  );
+
+  if (headers.length === 1 && rows.length === 1) {
+    return `Result: ${headers[0]} = ${rows[0]?.[0] ?? "NULL"}.`;
+  }
+  if (rows.length === 1) {
+    return [
+      "Result:",
+      ...headers.map((h, i) => `${h}: ${rows[0]?.[i] ?? "NULL"}`),
+    ].join("\n");
+  }
+
+  const body = rows.map((row) =>
+    headers.map((h, i) => `${h}: ${row[i] ?? "NULL"}`).join(", "),
+  );
+  const suffix = result.rows.length > rows.length ? `\nShowing ${rows.length} of ${result.rows.length} rows.` : "";
+  return ["Result:", ...body].join("\n") + suffix;
+}
+
 export function AIPanel({
   onClose,
   onOpenSettings,
@@ -53,6 +108,14 @@ export function AIPanel({
   const sending = useAi((s) => s.sending);
   const send = useAi((s) => s.send);
   const newThread = useAi((s) => s.newThread);
+  const setQuerySql = useTabs((s) => s.setQuerySql);
+  const newQueryTab = useTabs((s) => s.newQueryTab);
+  const setActiveTab = useTabs((s) => s.setActive);
+  const setBottomTab = useBottomPanel((s) => s.setActive);
+  const [runningSql, setRunningSql] = useState(false);
+  const autoRanMessageId = useRef<string | null>(null);
+  const mounted = useRef(true);
+  const runSeq = useRef(0);
 
   // Recompute context whenever the active tab or its schema changes.
   const activeId = useTabs((s) => s.activeId);
@@ -66,6 +129,14 @@ export function AIPanel({
   useEffect(() => {
     void init();
   }, [init]);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+      runSeq.current++;
+    };
+  }, []);
 
   const ready = keyConfigured && !!modelId;
   const canSend = ready && draft.trim().length > 0 && !sending;
@@ -88,6 +159,158 @@ export function AIPanel({
     setTopic((cur) => (cur === t ? "ask" : t));
     textareaRef.current?.focus();
   };
+
+  const insertSql = useCallback((sql: string): SqlScope | null => {
+    const state = useTabs.getState();
+    const active = state.tabs.find((t) => t.id === state.activeId);
+    if (!active) return null;
+    const id = active.kind === "query"
+      ? active.id
+      : newQueryTab(active.connectionId, active.database);
+    setQuerySql(id, sql.trim() + "\n");
+    setActiveTab(id);
+    const tab = useTabs.getState().tabs.find((t) => t.id === id && t.kind === "query");
+    if (!tab || tab.kind !== "query") return null;
+    return {
+      connectionId: tab.connectionId,
+      database: tab.database,
+      tabId: tab.id,
+      title: tab.title,
+    };
+  }, [newQueryTab, setActiveTab, setQuerySql]);
+
+  const activeScope = useCallback((): SqlScope | null => {
+    const state = useTabs.getState();
+    const active = state.tabs.find((t) => t.id === state.activeId);
+    if (!active) return null;
+    return {
+      connectionId: active.connectionId,
+      database: active.database,
+      tabId: active.id,
+      title: active.kind === "table" ? `${active.schema}.${active.table}` : active.title,
+    };
+  }, []);
+
+  const appendAiResult = useCallback((content: string, error = false) => {
+    useAi.setState((s) => ({
+      messages: [
+        ...s.messages,
+        {
+          id: `ai-result-${crypto.randomUUID()}`,
+          role: "model",
+          topic: "explain",
+          content,
+          error,
+        },
+      ],
+    }));
+  }, []);
+
+  const scopeStillCurrent = useCallback((scope: SqlScope, sql: string) => {
+    const tab = useTabs.getState().tabs.find((t) => t.id === scope.tabId);
+    return tab?.kind === "query" && tab.sql.trim() === sql.trim();
+  }, []);
+
+  const runSql = useCallback((sql: string, opts?: { insert?: boolean; answerInPanel?: boolean }) => {
+    if (runningSql) return;
+    const scope = opts?.insert ? insertSql(sql) : activeScope();
+    if (!scope) return;
+    const trimmed = sql.trim();
+    const database = scope.database || null;
+    const source = queryResultSource(
+      scope.connectionId,
+      database,
+      scope.tabId,
+      scope.title,
+      trimmed,
+      QUERY_ROW_LIMIT,
+    );
+    const context: QueryRunContext = {
+      tabId: scope.tabId,
+      connectionId: scope.connectionId,
+      database: scope.database || undefined,
+      label: "AI SQL",
+      sql: trimmed,
+      maxRows: QUERY_ROW_LIMIT,
+    };
+
+    setRunningSql(true);
+    const token = ++runSeq.current;
+    if (!opts?.answerInPanel) {
+      setBottomTab("results");
+      useTabResults.getState().setLoading(scope.tabId, source);
+      useQueryMessages
+        .getState()
+        .replaceForTab(scope.tabId, [buildRunStartedMessage(context)]);
+    }
+
+    void (async () => {
+      try {
+        const result = await unwrap(
+          commands.runReadOnlyQuery(
+            scope.connectionId,
+            trimmed,
+            QUERY_ROW_LIMIT,
+            database,
+          ),
+        );
+        if (!mounted.current || token !== runSeq.current) return;
+        if (opts?.insert && !scopeStillCurrent(scope, trimmed)) return;
+        if (opts?.answerInPanel) {
+          appendAiResult(formatAiQueryAnswer(result));
+        } else {
+          const { columns, rows } = queryResultToGrid(result);
+          useTabResults.getState().setReady(scope.tabId, {
+            source,
+            columns,
+            rows,
+            rowCount: rows.length,
+            truncated: result.truncated,
+            durationMs: result.duration_ms,
+            rowsAffected: result.rows_affected,
+          });
+          useQueryMessages
+            .getState()
+            .addMessages(buildRunResultMessages(context, result));
+          useTabs.getState().markQueryRun(scope.tabId);
+        }
+        useStatus.getState().setLastQuery({
+          connectionId: scope.connectionId,
+          tabId: scope.tabId,
+          rowCount: result.rows.length,
+          truncated: result.truncated,
+          durationMs: result.duration_ms,
+        });
+      } catch (err) {
+        if (!mounted.current || token !== runSeq.current) return;
+        noteConnectionIssue(scope.connectionId, err);
+        const message = err instanceof Error ? err.message : String(err);
+        if (opts?.answerInPanel) {
+          appendAiResult(`Could not run the generated query: ${message}`, true);
+        } else {
+          useTabResults.getState().setError(scope.tabId, source, message);
+          useQueryMessages
+            .getState()
+            .addMessage(buildRunErrorMessage(context, err));
+        }
+      } finally {
+        if (mounted.current && token === runSeq.current) {
+          setRunningSql(false);
+        }
+      }
+    })();
+  }, [activeScope, appendAiResult, insertSql, runningSql, scopeStillCurrent, setBottomTab]);
+
+  useEffect(() => {
+    const last = messages[messages.length - 1];
+    if (!last || last.role !== "model" || last.error) return;
+    if (last.id === autoRanMessageId.current) return;
+    if (last.topic !== "explain" && last.topic !== "ask") return;
+    const sql = firstRunnableSql(last.content);
+    if (!sql) return;
+    autoRanMessageId.current = last.id;
+    runSql(sql, { answerInPanel: true });
+  }, [messages, runSql]);
 
   return (
     <div className="flex h-full flex-col bg-bg-1 text-[13.5px]">
@@ -176,7 +399,15 @@ export function AIPanel({
             )}
           </div>
         ) : (
-          messages.map((m) => <AIMessage key={m.id} entry={m} />)
+          messages.map((m) => (
+            <AIMessage
+              key={m.id}
+              entry={m}
+              onInsertSql={insertSql}
+              onRunSql={(sql) => runSql(sql, { insert: true })}
+              runningSql={runningSql}
+            />
+          ))
         )}
         {sending && (
           <div className="flex items-center gap-2 px-1 text-[12px] text-fg-3">

--- a/apps/desktop/src/state/ai.test.ts
+++ b/apps/desktop/src/state/ai.test.ts
@@ -61,6 +61,7 @@ describe("useAi store", () => {
     // the API turn wraps the preset instruction + context around the raw text
     expect(msgs[0]!.apiContent).toContain("Schema context:\nctx");
     expect(msgs[1]!.role).toBe("model");
+    expect(msgs[1]!.topic).toBe("generate");
     expect(msgs[1]!.error).toBeFalsy();
     expect(msgs[1]!.content).toContain("SELECT 1;");
     expect(useAi.getState().sending).toBe(false);

--- a/apps/desktop/src/state/ai.ts
+++ b/apps/desktop/src/state/ai.ts
@@ -214,7 +214,7 @@ export const useAi = create<AiStore>((set, get) => ({
         sending: false,
         messages: [
           ...s.messages,
-          { id: nextId(), role: "model", content: result.text, usage: result.usage },
+          { id: nextId(), role: "model", topic, content: result.text, usage: result.usage },
         ],
       }));
     } catch (e) {
@@ -222,7 +222,7 @@ export const useAi = create<AiStore>((set, get) => ({
         sending: false,
         messages: [
           ...s.messages,
-          { id: nextId(), role: "model", content: describeError(e), error: true },
+          { id: nextId(), role: "model", topic, content: describeError(e), error: true },
         ],
       }));
     }

--- a/crates/cellar-core/src/query.rs
+++ b/crates/cellar-core/src/query.rs
@@ -40,6 +40,10 @@ pub struct Query {
     /// does not trust caller-supplied ordering.
     #[serde(default)]
     pub params: Vec<QueryParam>,
+    /// Execute under the strongest read-only guard the driver supports.
+    /// Used for AI-generated answer queries; normal editor runs stay explicit.
+    #[serde(default)]
+    pub read_only: bool,
 }
 
 /// One bound parameter value supplied by the caller. Carries a typed
@@ -90,6 +94,7 @@ impl Query {
             database: None,
             query_id: None,
             params: Vec::new(),
+            read_only: false,
         }
     }
 
@@ -115,6 +120,11 @@ impl Query {
 
     pub fn with_params(mut self, params: Vec<QueryParam>) -> Self {
         self.params = params;
+        self
+    }
+
+    pub fn read_only(mut self) -> Self {
+        self.read_only = true;
         self
     }
 }

--- a/crates/cellar-drivers/postgres/src/query.rs
+++ b/crates/cellar-drivers/postgres/src/query.rs
@@ -11,7 +11,7 @@ use cellar_core::value::{CellValue, ColumnMeta, Row};
 use cellar_diff::{build_postgres_plan, TableChangeRequest, TableCommitResult};
 use futures::TryStreamExt;
 use serde_json::{Map, Value};
-use sqlx::{Column as _, Row as _, TypeInfo as _};
+use sqlx::{Column as _, PgPool, Row as _, TypeInfo as _};
 
 use crate::connect::PgConnection;
 use crate::decode::decode_cell;
@@ -59,6 +59,9 @@ pub async fn execute_query(conn: &PgConnection, query: &Query) -> CellarResult<Q
         .unwrap_or(conn.config().database.as_str());
     let pool = conn.pool_for_database(database).await?;
     let pool = &pool;
+    if query.read_only {
+        return execute_read_only_query(pool, query).await;
+    }
 
     let max_rows = query.max_rows.unwrap_or(DEFAULT_MAX_ROWS);
     let max_rows_usize = max_rows as usize;
@@ -76,26 +79,7 @@ pub async fn execute_query(conn: &PgConnection, query: &Query) -> CellarResult<Q
     // rewrites named/positional placeholders to `$1..$N` and reports them in
     // bind order, and we bind the typed values through sqlx — never by
     // interpolating them into the SQL text.
-    let prepared_sql: Cow<str>;
-    let bind_values: Vec<&CellValue>;
-    if query.params.is_empty() {
-        prepared_sql = Cow::Borrowed(query.sql.as_str());
-        bind_values = Vec::new();
-    } else {
-        let prepared = cellar_sql::prepare(&query.sql, Engine::Postgres)
-            .map_err(|e| CellarError::query(e.to_string()))?;
-        let by_name: HashMap<&str, &CellValue> = query
-            .params
-            .iter()
-            .map(|p| (p.name.as_str(), &p.value))
-            .collect();
-        bind_values = cellar_sql::order_values(&prepared.parameters, &by_name)
-            .map_err(|e| CellarError::query(e.to_string()))?
-            .into_iter()
-            .copied()
-            .collect();
-        prepared_sql = Cow::Owned(prepared.sql);
-    }
+    let (prepared_sql, bind_values) = prepare_query(query)?;
     let exec_sql: &str = prepared_sql.as_ref();
 
     // SQL passes through verbatim. Driving LIMIT into user-supplied SQL would
@@ -215,6 +199,111 @@ pub async fn execute_query(conn: &PgConnection, query: &Query) -> CellarResult<Q
         // wrapping the SQL in a COUNT subquery, which requires parsing.
         total_rows: None,
     })
+}
+
+async fn execute_read_only_query(pool: &PgPool, query: &Query) -> CellarResult<QueryResult> {
+    let max_rows = query.max_rows.unwrap_or(DEFAULT_MAX_ROWS);
+    let max_rows_usize = max_rows as usize;
+    let skip_rows = query.offset.unwrap_or(0) as usize;
+    let capacity = max_rows.min(10_000) as usize;
+    let (prepared_sql, bind_values) = prepare_query(query)?;
+    let exec_sql: &str = prepared_sql.as_ref();
+    let started = Instant::now();
+
+    let mut tx = pool.begin().await.map_err(query_sqlx_err)?;
+    sqlx::query("SET TRANSACTION READ ONLY")
+        .execute(&mut *tx)
+        .await
+        .map_err(query_sqlx_err)?;
+
+    let mut statement = sqlx::query(exec_sql);
+    for &value in &bind_values {
+        statement = crate::bind::bind_value(statement, value)?;
+    }
+    #[allow(deprecated)]
+    let mut stream = statement.fetch_many(&mut *tx);
+    let mut columns: Option<Vec<ColumnMeta>> = None;
+    let mut materialized: Vec<Row> = Vec::with_capacity(capacity);
+    let mut truncated = false;
+    let mut rows_seen: usize = 0;
+    let mut rows_affected: Option<u64> = None;
+
+    while let Some(item) = stream.try_next().await.map_err(query_sqlx_err)? {
+        let r = match item {
+            sqlx::Either::Left(done) => {
+                rows_affected = Some(rows_affected.unwrap_or(0) + done.rows_affected());
+                continue;
+            }
+            sqlx::Either::Right(row) => row,
+        };
+        if columns.is_none() {
+            columns = Some(
+                r.columns()
+                    .iter()
+                    .map(|c| ColumnMeta {
+                        name: c.name().to_string(),
+                        data_type: c.type_info().name().to_string().to_lowercase(),
+                        nullable: true,
+                    })
+                    .collect(),
+            );
+        }
+        if rows_seen < skip_rows {
+            rows_seen += 1;
+            continue;
+        }
+        if materialized.len() >= max_rows_usize {
+            truncated = true;
+            break;
+        }
+
+        let mut cells: Row = Vec::with_capacity(r.columns().len());
+        for i in 0..r.columns().len() {
+            cells.push(decode_cell(&r, i)?);
+        }
+        materialized.push(cells);
+    }
+    drop(stream);
+    tx.rollback().await.map_err(query_sqlx_err)?;
+
+    let rows_affected = if columns.is_none() {
+        rows_affected
+    } else {
+        None
+    };
+
+    Ok(QueryResult {
+        columns: columns.unwrap_or_default(),
+        rows: materialized,
+        notices: Vec::new(),
+        notice_capture: NoticeCapture::unsupported(
+            "Postgres server notices are parsed by sqlx, but the current PgPool query path consumes NoticeResponse frames internally and exposes only log/tracing output without SQLSTATE, detail, hint, or query correlation.",
+        ),
+        rows_affected,
+        duration_ms: started.elapsed().as_millis() as u64,
+        truncated,
+        total_rows: None,
+    })
+}
+
+fn prepare_query(query: &Query) -> CellarResult<(Cow<'_, str>, Vec<&CellValue>)> {
+    if query.params.is_empty() {
+        return Ok((Cow::Borrowed(query.sql.as_str()), Vec::new()));
+    }
+
+    let prepared = cellar_sql::prepare(&query.sql, Engine::Postgres)
+        .map_err(|e| CellarError::query(e.to_string()))?;
+    let by_name: HashMap<&str, &CellValue> = query
+        .params
+        .iter()
+        .map(|p| (p.name.as_str(), &p.value))
+        .collect();
+    let bind_values = cellar_sql::order_values(&prepared.parameters, &by_name)
+        .map_err(|e| CellarError::query(e.to_string()))?
+        .into_iter()
+        .copied()
+        .collect();
+    Ok((Cow::Owned(prepared.sql), bind_values))
 }
 
 /// How the committed row count is checked against the plan's expectation.

--- a/packages/ai/src/prompts.ts
+++ b/packages/ai/src/prompts.ts
@@ -27,9 +27,9 @@ export const TOPICS: Record<AiTopic, TopicMeta> = {
       "Generate a SQL query for the request below. Return the query in a single ```sql block, then a one-sentence explanation of what it does.",
   },
   explain: {
-    hint: "Explain SQL, a table, or a result",
+    hint: "Explain SQL or answer with a read-only query",
     instruction:
-      "Explain the following clearly and concisely. If it is SQL, describe what it returns and any performance characteristics worth noting.",
+      "If the request is SQL, explain what it returns and any performance characteristics worth noting. If it is a natural-language question about the data, return one read-only SQL query in a single ```sql block so Cellar can run it, then add one short sentence describing what the result will show.",
   },
   optimize: {
     hint: "Suggest a faster equivalent query",

--- a/packages/ipc/src/generated.ts
+++ b/packages/ipc/src/generated.ts
@@ -118,6 +118,14 @@ async runQuery(connectionId: string, sql: string, maxRows: number | null, offset
     else return { status: "error", error: e  as any };
 }
 },
+async runReadOnlyQuery(connectionId: string, sql: string, maxRows: number | null, database: string | null) : Promise<Result<QueryResult, CellarError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("run_read_only_query", { connectionId, sql, maxRows, database }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 /**
  * Cancel a running query previously started through [`run_query`] with a
  * `query_id`. Returns `true` when a running statement was found and


### PR DESCRIPTION
## Summary
Improves AI SQL answers so safe generated read-only SQL can run from assistant flows and answer in the right-hand panel.

## What changed
Adds SQL block actions, a conservative run guard, current query context, prompt/store topic metadata, and in-panel result formatting.

## User impact
Users asking data questions in `explain` or `ask` get an answer in the AI panel without editor focus changes, while manual `insert` and `run` still use the editor/results workflow.

## Validation
Passed `pnpm --filter @cellar/desktop typecheck`, `pnpm --filter @cellar/desktop test -- AIMessage state/ai`, `pnpm --filter @cellar/ai test`, and `pnpm --filter @cellar/desktop build`.

## Known warnings
Full desktop test suite still has the existing `settings.test.ts` UI-scale failure; Vite still warns about a chunk larger than 500 kB.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI-generated SQL can now be run directly from chat messages, with quick actions to insert or execute safe read-only queries.
  * Read-only query execution is now supported end-to-end for compatible databases, including inline results in the AI panel.
  * AI responses now better distinguish between SQL and plain text, improving how messages are displayed.

* **Bug Fixes**
  * Safer handling prevents unsupported read-only query execution on non-Postgres engines.
  * Query runs now track state more reliably to avoid stale or overlapping updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->