### PR TITLE
feat: grid commits for SQL Server and Azure SQL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -671,6 +671,7 @@ version = "0.2.0"
 dependencies = [
  "async-trait",
  "cellar-core",
+ "cellar-diff",
  "chrono",
  "futures-util",
  "thiserror 1.0.69",

--- a/apps/desktop/src-tauri/src/commands/transaction.rs
+++ b/apps/desktop/src-tauri/src/commands/transaction.rs
@@ -1,18 +1,34 @@
 use std::time::Instant;
 
+use cellar_core::driver::Engine;
 use cellar_core::error::CellarError;
-use cellar_diff::{build_postgres_plan, TableChangeRequest, TableCommitPreview, TableCommitResult};
+use cellar_diff::{
+    build_mssql_plan, build_postgres_plan, CommitPlan, DiffError, TableChangeRequest,
+    TableCommitPreview, TableCommitResult,
+};
 use tauri::State;
 
 use crate::history::{HistoryStore, NewQueryHistoryRecord};
 use crate::state::ConnectionRegistry;
 
+/// Build the commit plan in the connection's SQL dialect, so the reviewed
+/// preview matches what the driver will execute.
+fn plan_for(engine: Option<Engine>, request: &TableChangeRequest) -> Result<CommitPlan, DiffError> {
+    match engine.map(|e| e.family()) {
+        Some(Engine::Mssql) => build_mssql_plan(request),
+        _ => build_postgres_plan(request),
+    }
+}
+
 #[tauri::command]
 #[specta::specta]
-pub fn preview_table_changes(
+pub async fn preview_table_changes(
+    registry: State<'_, ConnectionRegistry>,
+    connection_id: String,
     request: TableChangeRequest,
 ) -> Result<TableCommitPreview, CellarError> {
-    build_postgres_plan(&request)
+    let engine = registry.engine_for(&connection_id).await;
+    plan_for(engine, &request)
         .map(|plan| plan.preview)
         .map_err(|e| CellarError::query(e.to_string()))
 }
@@ -52,7 +68,8 @@ async fn run_commit(
     import: bool,
 ) -> Result<TableCommitResult, CellarError> {
     let history_database = request.database.clone();
-    let history_sql = build_postgres_plan(&request)
+    let engine = registry.engine_for(&connection_id).await;
+    let history_sql = plan_for(engine, &request)
         .map(|plan| plan.preview.sql)
         .unwrap_or_else(|err| {
             format!(

--- a/apps/desktop/src-tauri/src/state/mod.rs
+++ b/apps/desktop/src-tauri/src/state/mod.rs
@@ -474,6 +474,18 @@ impl ConnectionRegistry {
                     Err(err) => Err(self.handle_operation_error(id, err).await),
                 }
             }
+            Engine::Mssql => {
+                let conn = connection.as_ref();
+                let outcome = if import {
+                    cellar_driver_sqlserver::commit_table_import(conn, &request).await
+                } else {
+                    cellar_driver_sqlserver::commit_table_changes(conn, &request).await
+                };
+                match outcome {
+                    Ok(result) => Ok(result),
+                    Err(err) => Err(self.handle_operation_error(id, err).await),
+                }
+            }
             other => Err(CellarError::invalid_config(format!(
                 "engine {} does not support grid commits yet",
                 other.as_str()

--- a/apps/desktop/src/components/modals/CommitModal.tsx
+++ b/apps/desktop/src/components/modals/CommitModal.tsx
@@ -76,14 +76,17 @@ export function CommitModal({ onClose }: { onClose: () => void }) {
   useEffect(() => {
     let cancelled = false;
     setCommitError(null);
-    if (!request) {
+    if (!request || !activeTable) {
       setPreviewState({ kind: "idle", preview: null, error: null });
       return;
     }
+    const connectionId = activeTable.connectionId;
     setPreviewState({ kind: "loading", preview: null, error: null });
     void (async () => {
       try {
-        const preview = await unwrap(commands.previewTableChanges(request));
+        const preview = await unwrap(
+          commands.previewTableChanges(connectionId, request),
+        );
         if (!cancelled) setPreviewState({ kind: "ready", preview, error: null });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -95,7 +98,7 @@ export function CommitModal({ onClose }: { onClose: () => void }) {
     return () => {
       cancelled = true;
     };
-  }, [request]);
+  }, [request, activeTable]);
 
   const preview = previewState.preview;
   const sqlText = preview?.sql ?? "";

--- a/apps/desktop/src/components/modals/ImportDataModal.tsx
+++ b/apps/desktop/src/components/modals/ImportDataModal.tsx
@@ -153,7 +153,7 @@ export function ImportDataModal({ onClose }: { onClose: () => void }) {
     const sample: ParsedCsv = { headers: csv.headers, rows: csv.rows.slice(0, 25) };
     try {
       const preview = await unwrap(
-        commands.previewTableChanges(buildImportRequest(sample, cfg)),
+        commands.previewTableChanges(tab.connectionId, buildImportRequest(sample, cfg)),
       );
       setPreviewSql(preview.sql);
     } catch (err) {

--- a/crates/cellar-diff/src/lib.rs
+++ b/crates/cellar-diff/src/lib.rs
@@ -102,22 +102,37 @@ pub struct CommitPlan {
 }
 
 pub fn build_postgres_plan(request: &TableChangeRequest) -> Result<CommitPlan, DiffError> {
+    build_plan(request, Dialect::Postgres)
+}
+
+/// T-SQL plan for SQL Server / Azure SQL: bracket quoting, null-safe `=` in
+/// key predicates (portable to pre-2022 servers without
+/// `IS NOT DISTINCT FROM`), and `MERGE` for upserts.
+pub fn build_mssql_plan(request: &TableChangeRequest) -> Result<CommitPlan, DiffError> {
+    build_plan(request, Dialect::Mssql)
+}
+
+fn build_plan(request: &TableChangeRequest, dialect: Dialect) -> Result<CommitPlan, DiffError> {
     validate_request(request)?;
 
-    let table = qualified_table(&request.schema, &request.table);
+    let table = dialect.quote_qualified(&request.schema, &request.table);
     let mut statements = Vec::with_capacity(request.changes.len());
     for change in &request.changes {
-        statements.push(statement_for(change, &table)?);
+        statements.push(statement_for(change, &table, dialect)?);
     }
 
+    let (begin, commit) = match dialect {
+        Dialect::Mssql => ("BEGIN TRANSACTION;", "COMMIT TRANSACTION;"),
+        _ => ("BEGIN;", "COMMIT;"),
+    };
     let mut lines = Vec::with_capacity(statements.len() * 3 + 2);
-    lines.push("BEGIN;".to_string());
+    lines.push(begin.to_string());
     for statement in &statements {
         lines.push(String::new());
         lines.push(statement.clone());
     }
     lines.push(String::new());
-    lines.push("COMMIT;".to_string());
+    lines.push(commit.to_string());
 
     Ok(CommitPlan {
         preview: TableCommitPreview {
@@ -142,7 +157,8 @@ fn validate_request(request: &TableChangeRequest) -> Result<(), DiffError> {
     Ok(())
 }
 
-fn statement_for(change: &RowChange, table: &str) -> Result<String, DiffError> {
+fn statement_for(change: &RowChange, table: &str, dialect: Dialect) -> Result<String, DiffError> {
+    let quote_ident = |ident: &str| dialect.quote_ident(ident);
     match change {
         RowChange::Update {
             row_id,
@@ -162,7 +178,7 @@ fn statement_for(change: &RowChange, table: &str) -> Result<String, DiffError> {
                 .join(",\n");
             Ok(format!(
                 "UPDATE {table}\nSET\n{set}\nWHERE {};",
-                where_clause(keys)
+                where_clause(keys, dialect)
             ))
         }
         RowChange::Insert { row_id, values } => {
@@ -187,7 +203,7 @@ fn statement_for(change: &RowChange, table: &str) -> Result<String, DiffError> {
             }
             Ok(format!(
                 "DELETE FROM {table}\nWHERE {};",
-                where_clause(keys)
+                where_clause(keys, dialect)
             ))
         }
         RowChange::Upsert {
@@ -201,6 +217,9 @@ fn statement_for(change: &RowChange, table: &str) -> Result<String, DiffError> {
             }
             if conflict_columns.is_empty() {
                 return Err(DiffError::MissingConflictTarget(row_id.clone()));
+            }
+            if matches!(dialect, Dialect::Mssql) {
+                return merge_statement(table, conflict_columns, values, update_columns, dialect);
             }
             let cols = values
                 .iter()
@@ -235,26 +254,74 @@ fn statement_for(change: &RowChange, table: &str) -> Result<String, DiffError> {
     }
 }
 
-fn where_clause(keys: &[CellAssignment]) -> String {
+/// T-SQL upsert. SQL Server has no `ON CONFLICT`, so an upsert compiles to a
+/// single-row `MERGE`: the proposed values form the source rowset, matching on
+/// the conflict columns. An empty update set omits `WHEN MATCHED` (insert-only,
+/// skip duplicates) — the T-SQL equivalent of `DO NOTHING`.
+fn merge_statement(
+    table: &str,
+    conflict_columns: &[String],
+    values: &[CellAssignment],
+    update_columns: &[String],
+    dialect: Dialect,
+) -> Result<String, DiffError> {
+    let quote_ident = |ident: &str| dialect.quote_ident(ident);
+    let source = values
+        .iter()
+        .map(|v| format!("{} AS {}", literal(&v.value), quote_ident(&v.column)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let on = conflict_columns
+        .iter()
+        .map(|c| {
+            let c = quote_ident(c);
+            // Null-safe match, same semantics as ON CONFLICT on a nullable key.
+            format!("(t.{c} = s.{c} OR (t.{c} IS NULL AND s.{c} IS NULL))")
+        })
+        .collect::<Vec<_>>()
+        .join(" AND ");
+    // Never overwrite a match-key column, even if the caller listed it.
+    let sets = update_columns
+        .iter()
+        .filter(|c| !conflict_columns.contains(*c))
+        .map(|c| format!("  {0} = s.{0}", quote_ident(c)))
+        .collect::<Vec<_>>();
+    let matched = if sets.is_empty() {
+        String::new()
+    } else {
+        format!("WHEN MATCHED THEN UPDATE SET\n{}\n", sets.join(",\n"))
+    };
+    let cols = values
+        .iter()
+        .map(|v| quote_ident(&v.column))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let src_vals = values
+        .iter()
+        .map(|v| format!("s.{}", quote_ident(&v.column)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    Ok(format!(
+        "MERGE {table} AS t\nUSING (SELECT {source}) AS s\nON {on}\n{matched}WHEN NOT MATCHED THEN INSERT ({cols})\nVALUES ({src_vals});"
+    ))
+}
+
+fn where_clause(keys: &[CellAssignment], dialect: Dialect) -> String {
     keys.iter()
         .map(|k| {
-            format!(
-                "{} IS NOT DISTINCT FROM {}",
-                quote_ident(&k.column),
-                literal(&k.value)
-            )
+            let ident = dialect.quote_ident(&k.column);
+            match dialect {
+                // T-SQL before 2022 lacks IS NOT DISTINCT FROM; the literal is
+                // known here, so NULL keys compile straight to IS NULL.
+                Dialect::Mssql => match &k.value.value {
+                    None => format!("{ident} IS NULL"),
+                    Some(_) => format!("{ident} = {}", literal(&k.value)),
+                },
+                _ => format!("{ident} IS NOT DISTINCT FROM {}", literal(&k.value)),
+            }
         })
         .collect::<Vec<_>>()
         .join(" AND ")
-}
-
-fn qualified_table(schema: &str, table: &str) -> String {
-    Dialect::Postgres.quote_qualified(schema, table)
-}
-
-// ponytail: quote_ident removed — call Dialect::Postgres.quote_ident() directly
-fn quote_ident(value: &str) -> String {
-    Dialect::Postgres.quote_ident(value)
 }
 
 fn literal(value: &DiffValue) -> String {
@@ -364,6 +431,81 @@ mod tests {
             .preview
             .sql
             .contains("ON CONFLICT (\"id\") DO NOTHING;"));
+    }
+
+    #[test]
+    fn builds_mssql_update_with_null_safe_keys() {
+        let plan = build_mssql_plan(&TableChangeRequest {
+            database: Some("epiczone".into()),
+            schema: "epiczone".into(),
+            table: "Settings".into(),
+            primary_key: vec!["Id".into()],
+            columns: vec![],
+            changes: vec![RowChange::Update {
+                row_id: "1".into(),
+                keys: vec![assign("Id", Some("c532")), assign("Region", None)],
+                edits: vec![assign("Enabled", Some("true"))],
+            }],
+        })
+        .expect("plan");
+
+        let sql = &plan.preview.sql;
+        assert!(sql.contains("BEGIN TRANSACTION;"));
+        assert!(sql.contains("UPDATE [epiczone].[Settings]"));
+        assert!(sql.contains("[Enabled] = 'true'"));
+        assert!(sql.contains("[Id] = 'c532'"));
+        assert!(sql.contains("[Region] IS NULL"));
+        assert!(!sql.contains("IS NOT DISTINCT FROM"));
+        assert!(sql.contains("COMMIT TRANSACTION;"));
+    }
+
+    #[test]
+    fn builds_mssql_upsert_as_merge() {
+        let plan = build_mssql_plan(&TableChangeRequest {
+            database: None,
+            schema: "dbo".into(),
+            table: "users".into(),
+            primary_key: vec!["id".into()],
+            columns: vec![],
+            changes: vec![RowChange::Upsert {
+                row_id: "csv:1".into(),
+                conflict_columns: vec!["id".into()],
+                values: vec![assign("id", Some("1")), assign("name", Some("Ada"))],
+                update_columns: vec!["name".into(), "id".into()],
+            }],
+        })
+        .expect("plan");
+
+        let sql = &plan.preview.sql;
+        assert!(sql.contains("MERGE [dbo].[users] AS t"));
+        assert!(sql.contains("USING (SELECT '1' AS [id], 'Ada' AS [name]) AS s"));
+        assert!(sql.contains("(t.[id] = s.[id] OR (t.[id] IS NULL AND s.[id] IS NULL))"));
+        assert!(sql.contains("WHEN MATCHED THEN UPDATE SET\n  [name] = s.[name]"));
+        // match-key column excluded from the SET list
+        assert!(!sql.contains("[id] = s.[id]\n"));
+        assert!(sql.contains("WHEN NOT MATCHED THEN INSERT ([id], [name])"));
+        assert!(sql.contains("VALUES (s.[id], s.[name]);"));
+    }
+
+    #[test]
+    fn builds_mssql_insert_only_upsert_without_when_matched() {
+        let plan = build_mssql_plan(&TableChangeRequest {
+            database: None,
+            schema: "dbo".into(),
+            table: "users".into(),
+            primary_key: vec!["id".into()],
+            columns: vec![],
+            changes: vec![RowChange::Upsert {
+                row_id: "csv:1".into(),
+                conflict_columns: vec!["id".into()],
+                values: vec![assign("id", Some("1"))],
+                update_columns: vec![],
+            }],
+        })
+        .expect("plan");
+
+        assert!(!plan.preview.sql.contains("WHEN MATCHED"));
+        assert!(plan.preview.sql.contains("WHEN NOT MATCHED THEN INSERT"));
     }
 
     fn assign(column: &str, value: Option<&str>) -> CellAssignment {

--- a/crates/cellar-drivers/sqlserver/Cargo.toml
+++ b/crates/cellar-drivers/sqlserver/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [dependencies]
 cellar-core = { path = "../../cellar-core" }
+cellar-diff = { path = "../../cellar-diff" }
 chrono = { version = "0.4", default-features = false }
 async-trait = "0.1"
 futures-util = "0.3"

--- a/crates/cellar-drivers/sqlserver/src/lib.rs
+++ b/crates/cellar-drivers/sqlserver/src/lib.rs
@@ -43,6 +43,22 @@ impl Default for SqlServerDriver {
     }
 }
 
+pub async fn commit_table_changes(
+    conn: &dyn Connection,
+    request: &cellar_diff::TableChangeRequest,
+) -> CellarResult<cellar_diff::TableCommitResult> {
+    let sql = connect::as_sqlserver(conn)?;
+    query::commit_table_changes(sql, request).await
+}
+
+pub async fn commit_table_import(
+    conn: &dyn Connection,
+    request: &cellar_diff::TableChangeRequest,
+) -> CellarResult<cellar_diff::TableCommitResult> {
+    let sql = connect::as_sqlserver(conn)?;
+    query::commit_table_import(sql, request).await
+}
+
 pub async fn browse_table(
     conn: &dyn Connection,
     request: &TableBrowseRequest,

--- a/crates/cellar-drivers/sqlserver/src/query.rs
+++ b/crates/cellar-drivers/sqlserver/src/query.rs
@@ -1,12 +1,13 @@
 use std::time::Instant;
 
-use cellar_core::error::CellarResult;
+use cellar_core::error::{CellarError, CellarResult};
 use cellar_core::query::{NoticeCapture, Query, QueryResult};
 use cellar_core::value::{ColumnMeta, Row};
+use cellar_diff::{build_mssql_plan, TableChangeRequest, TableCommitResult};
 use futures_util::TryStreamExt;
 use tiberius::QueryItem;
 
-use crate::connect::{map_tiberius_runtime_err, SqlServerConnection};
+use crate::connect::{map_tiberius_runtime_err, SqlServerConnection, TdsClient};
 use crate::decode::decode_cell;
 
 const DEFAULT_MAX_ROWS: u32 = 500;
@@ -111,4 +112,98 @@ async fn execute_sql(
 
 fn quote_ident(ident: &str) -> String {
     format!("[{}]", ident.replace(']', "]]"))
+}
+
+/// How the committed row count is checked against the plan's expectation.
+/// Mirrors the Postgres driver: `Exact` for grid edits, `AtMost` for
+/// idempotent CSV imports whose no-op rows affect zero rows.
+#[derive(Clone, Copy)]
+enum RowCountCheck {
+    Exact,
+    AtMost,
+}
+
+pub async fn commit_table_changes(
+    conn: &SqlServerConnection,
+    request: &TableChangeRequest,
+) -> CellarResult<TableCommitResult> {
+    commit_plan(conn, request, RowCountCheck::Exact).await
+}
+
+pub async fn commit_table_import(
+    conn: &SqlServerConnection,
+    request: &TableChangeRequest,
+) -> CellarResult<TableCommitResult> {
+    commit_plan(conn, request, RowCountCheck::AtMost).await
+}
+
+async fn commit_plan(
+    conn: &SqlServerConnection,
+    request: &TableChangeRequest,
+    check: RowCountCheck,
+) -> CellarResult<TableCommitResult> {
+    let plan = build_mssql_plan(request).map_err(|e| CellarError::query(e.to_string()))?;
+    let started = Instant::now();
+
+    conn.with_client(async |client| {
+        // Route to the request's target database; the shared client stays on
+        // the configured default otherwise.
+        if let Some(database) = request.database.as_deref() {
+            if database != conn.config().database {
+                run_control(client, &format!("USE {}", quote_ident(database))).await?;
+            }
+        }
+
+        // XACT_ABORT makes any statement error abort and roll back the whole
+        // transaction server-side; the guarded ROLLBACK below covers errors
+        // XACT_ABORT does not (e.g. the row-count mismatch raised client-side).
+        run_control(client, "SET XACT_ABORT ON; BEGIN TRANSACTION").await?;
+
+        let mut rows_affected = 0u64;
+        for statement in &plan.statements {
+            match client.execute(statement.as_str(), &[]).await {
+                Ok(result) => rows_affected += result.total(),
+                Err(err) => {
+                    rollback(client).await;
+                    return Err(map_tiberius_runtime_err(err, "table commit"));
+                }
+            }
+        }
+
+        let mismatch = match check {
+            RowCountCheck::Exact => rows_affected != plan.preview.expected_rows,
+            RowCountCheck::AtMost => rows_affected > plan.preview.expected_rows,
+        };
+        if mismatch {
+            rollback(client).await;
+            return Err(CellarError::query(format!(
+                "expected {} affected rows but database reported {}; the table may have changed since it was loaded",
+                plan.preview.expected_rows, rows_affected
+            )));
+        }
+
+        run_control(client, "COMMIT TRANSACTION").await?;
+        Ok(TableCommitResult {
+            sql: plan.preview.sql.clone(),
+            rows_affected,
+            duration_ms: started.elapsed().as_millis() as u64,
+        })
+    })
+    .await
+}
+
+async fn run_control(client: &mut TdsClient, sql: &str) -> CellarResult<()> {
+    client
+        .execute(sql, &[])
+        .await
+        .map(|_| ())
+        .map_err(|e| map_tiberius_runtime_err(e, "table commit"))
+}
+
+/// Best-effort rollback on the error path; the original error is what the
+/// caller needs to see, and XACT_ABORT may already have rolled back.
+async fn rollback(client: &mut TdsClient) {
+    let _ = client
+        .execute("IF @@TRANCOUNT > 0 ROLLBACK TRANSACTION", &[])
+        .await;
 }

--- a/packages/ipc/src/generated.ts
+++ b/packages/ipc/src/generated.ts
@@ -168,9 +168,9 @@ async browseTable(request: TableBrowseRequest) : Promise<Result<QueryResult, Cel
     else return { status: "error", error: e  as any };
 }
 },
-async previewTableChanges(request: TableChangeRequest) : Promise<Result<TableCommitPreview, CellarError>> {
+async previewTableChanges(connectionId: string, request: TableChangeRequest) : Promise<Result<TableCommitPreview, CellarError>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("preview_table_changes", { request }) };
+    return { status: "ok", data: await TAURI_INVOKE("preview_table_changes", { connectionId, request }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };


### PR DESCRIPTION
Grid edits and CSV imports can now be committed on SQL Server, Azure SQL, and MSSQL connections, which previously failed with "engine mssql does not support grid commits yet". A new T-SQL plan builder in cellar-diff emits bracket-quoted identifiers, null-safe key predicates (portable to pre-2022 servers), and MERGE-based upserts, while the sqlserver driver runs statements in one transaction with XACT_ABORT and the same row-count safety checks as Postgres. The SQL preview in the Review & Commit and Import dialogs is now engine-aware, so it shows the dialect that will actually execute instead of always Postgres. Query history also records the correct dialect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Commit previews and table commits now support SQL Server connections in addition to PostgreSQL.
  * Import and change commits now use the selected connection when generating previews.

* **Bug Fixes**
  * Improved SQL generation to match the connected database’s dialect.
  * Fixed row-matching behavior for nullable keys and upserts across supported databases.
  * Commit operations now validate affected row counts and roll back safely on errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->