### PR TITLE
feat: generate GUIDs from table cell context menu

### DIFF
--- a/apps/desktop/src/components/Workspace.tsx
+++ b/apps/desktop/src/components/Workspace.tsx
@@ -1,5 +1,7 @@
 import {
+  applyCellChange,
   DataGrid,
+  isGuidType,
   useGridState,
   type GridRow,
   type PendingChanges,
@@ -18,7 +20,11 @@ import { SqlEditor } from "./SqlEditor";
 import { renderGridEditor } from "./grid/GridDateEditor";
 import { SchemaComparePane } from "./SchemaComparePane";
 import { ErDiagram } from "./er/ErDiagram";
-import { ContextMenu, type ContextMenuState } from "./ContextMenu";
+import {
+  ContextMenu,
+  type ContextMenuState,
+  type MenuItem,
+} from "./ContextMenu";
 import { TabBar } from "./TabBar";
 import { CellarMark } from "./CellarMark";
 import { Icon } from "./icons";
@@ -388,6 +394,7 @@ function TableTabPane({
   }, [filtersKey, sortKey, quickFilter, quickColumn]);
   const [rowMenu, setRowMenu] = useState<ContextMenuState | null>(null);
   const [headerMenu, setHeaderMenu] = useState<ContextMenuState | null>(null);
+  const [cellMenu, setCellMenu] = useState<ContextMenuState | null>(null);
   const findUsages = useFindUsages((s) => s.findUsages);
   // The grid hands back the row object on selection, so copy never has to
   // re-derive the grid's filter/sort/insert order.
@@ -623,9 +630,40 @@ function TableTabPane({
             ],
           });
         }}
+        onCellContextMenu={(event, row, column) => {
+          event.preventDefault();
+          const pending = changes[row.id]?.edits?.[column.key];
+          const displayed = pending ? pending.to : (row[column.key] ?? null);
+          const items: MenuItem[] = [
+            {
+              label: "Copy cell",
+              icon: <Icon.copy size={12} />,
+              onClick: () =>
+                copyText(displayed == null ? "" : String(displayed)),
+            },
+          ];
+          if (isGuidType(column.type) && changes[row.id]?.kind !== "delete") {
+            items.unshift({
+              label: "Generate new GUID",
+              onClick: () => {
+                grid.setEditing(null);
+                const guid = crypto.randomUUID();
+                handleGridChange(
+                  applyCellChange(changes, row.id, column.key, displayed, guid),
+                );
+              },
+            });
+          }
+          setCellMenu({
+            x: event.clientX,
+            y: event.clientY,
+            items,
+          });
+        }}
       />
       <ContextMenu state={rowMenu} onClose={() => setRowMenu(null)} />
       <ContextMenu state={headerMenu} onClose={() => setHeaderMenu(null)} />
+      <ContextMenu state={cellMenu} onClose={() => setCellMenu(null)} />
     </div>
   );
 }

--- a/packages/data-grid/src/DataGrid.tsx
+++ b/packages/data-grid/src/DataGrid.tsx
@@ -8,6 +8,7 @@ import {
   type PointerEvent as ReactPointerEvent,
   type UIEvent,
 } from "react";
+import { applyCellChange } from "./changes";
 import {
   emptyColumnLayout,
   layoutForColumns,
@@ -31,7 +32,6 @@ import type {
   GridColumn,
   GridColumnLayout,
   GridRow,
-  PendingChange,
   PendingChanges,
   SortState,
 } from "./types";
@@ -540,27 +540,8 @@ export function DataGrid({
 
   const handleCellEdit = useCallback(
     (rowId: string, colKey: string, prev: CellChange["from"], next: CellChange["to"]) => {
-      if (prev === next) return;
-      const existing: PendingChange = changes[rowId] ?? { kind: "update", edits: {} };
-      const baseEdit = existing.edits[colKey];
-      const fromValue = baseEdit ? baseEdit.from : prev;
-
-      // If the user edited back to the original value, drop the per-cell change.
-      const nextEdits = { ...existing.edits };
-      if (fromValue === next) {
-        delete nextEdits[colKey];
-      } else {
-        nextEdits[colKey] = { from: fromValue, to: next };
-      }
-
-      const updated: PendingChanges = { ...changes };
-      const editKeys = Object.keys(nextEdits);
-      if (editKeys.length === 0 && existing.kind === "update") {
-        delete updated[rowId];
-      } else {
-        updated[rowId] = { kind: existing.kind, edits: nextEdits };
-      }
-      onChange(updated);
+      const updated = applyCellChange(changes, rowId, colKey, prev, next);
+      if (updated !== changes) onChange(updated);
     },
     [changes, onChange],
   );

--- a/packages/data-grid/src/changes.test.ts
+++ b/packages/data-grid/src/changes.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { applyCellChange } from "./changes";
+import type { PendingChanges } from "./types";
+
+describe("applyCellChange", () => {
+  it("records an update edit against an existing row", () => {
+    const next = applyCellChange({}, "r1", "id", null, "a-guid");
+    expect(next).toEqual({
+      r1: { kind: "update", edits: { id: { from: null, to: "a-guid" } } },
+    });
+  });
+
+  it("preserves insert kind when editing a pending insert", () => {
+    const changes: PendingChanges = {
+      "insert:1": { kind: "insert", edits: {} },
+    };
+    const next = applyCellChange(changes, "insert:1", "id", null, "a-guid");
+    expect(next["insert:1"]?.kind).toBe("insert");
+    expect(next["insert:1"]?.edits.id).toEqual({ from: null, to: "a-guid" });
+  });
+
+  it("anchors from to the original value across successive edits", () => {
+    const once = applyCellChange({}, "r1", "id", "old", "mid");
+    const twice = applyCellChange(once, "r1", "id", "mid", "new");
+    expect(twice.r1?.edits.id).toEqual({ from: "old", to: "new" });
+  });
+
+  it("drops an update when the value returns to original", () => {
+    const once = applyCellChange({}, "r1", "id", "old", "new");
+    const next = applyCellChange(once, "r1", "id", "new", "old");
+    expect(next).toEqual({});
+  });
+
+  it("returns the same object when prev equals next", () => {
+    const changes: PendingChanges = {};
+    expect(applyCellChange(changes, "r1", "id", "same", "same")).toBe(changes);
+  });
+});

--- a/packages/data-grid/src/changes.ts
+++ b/packages/data-grid/src/changes.ts
@@ -1,0 +1,36 @@
+import type { CellChange, PendingChange, PendingChanges } from "./types";
+
+/**
+ * Merge a single cell edit into pending changes. Preserves insert/update/delete
+ * kind, anchors `from` to the original value, and drops the edit (or the whole
+ * update row) when the value returns to original.
+ */
+export function applyCellChange(
+  changes: PendingChanges,
+  rowId: string,
+  colKey: string,
+  prev: CellChange["from"],
+  next: CellChange["to"],
+): PendingChanges {
+  if (prev === next) return changes;
+
+  const existing: PendingChange = changes[rowId] ?? { kind: "update", edits: {} };
+  const baseEdit = existing.edits[colKey];
+  const fromValue = baseEdit ? baseEdit.from : prev;
+
+  const nextEdits = { ...existing.edits };
+  if (fromValue === next) {
+    delete nextEdits[colKey];
+  } else {
+    nextEdits[colKey] = { from: fromValue, to: next };
+  }
+
+  const updated: PendingChanges = { ...changes };
+  const editKeys = Object.keys(nextEdits);
+  if (editKeys.length === 0 && existing.kind === "update") {
+    delete updated[rowId];
+  } else {
+    updated[rowId] = { kind: existing.kind, edits: nextEdits };
+  }
+  return updated;
+}

--- a/packages/data-grid/src/index.ts
+++ b/packages/data-grid/src/index.ts
@@ -20,6 +20,7 @@ export type {
   SortState,
 } from "./types";
 
+export { applyCellChange } from "./changes";
 export { countChanges, statusDotColor, statusTextColor } from "./status";
 export {
   FILTER_OPERATORS,
@@ -94,6 +95,7 @@ export {
   geometryLabel,
   baseType,
   isJsonType,
+  isGuidType,
   isArrayType,
   arrayElementType,
   isByteaType,

--- a/packages/data-grid/src/renderers/index.ts
+++ b/packages/data-grid/src/renderers/index.ts
@@ -40,6 +40,7 @@ export { geometryRenderer, geometryLabel } from "./geometry";
 export {
   baseType,
   isJsonType,
+  isGuidType,
   isArrayType,
   arrayElementType,
   isByteaType,

--- a/packages/data-grid/src/renderers/renderers.test.ts
+++ b/packages/data-grid/src/renderers/renderers.test.ts
@@ -17,7 +17,14 @@ import {
   sniffImageMime,
 } from "./bytes";
 import { geometryRenderer, geometryLabel } from "./geometry";
-import { arrayElementType, isArrayType, isByteaType, isGeometryType, isJsonType } from "./typeMatch";
+import {
+  arrayElementType,
+  isArrayType,
+  isByteaType,
+  isGeometryType,
+  isGuidType,
+  isJsonType,
+} from "./typeMatch";
 
 function col(type: string): GridColumn {
   return { key: "c", name: "c", type, width: 120 };
@@ -28,6 +35,13 @@ describe("type predicates", () => {
     expect(isJsonType("json")).toBe(true);
     expect(isJsonType("JSONB")).toBe(true);
     expect(isJsonType("text")).toBe(false);
+  });
+
+  it("detects guid types", () => {
+    expect(isGuidType("uuid")).toBe(true);
+    expect(isGuidType("GUID")).toBe(true);
+    expect(isGuidType("uniqueidentifier")).toBe(true);
+    expect(isGuidType("text")).toBe(false);
   });
 
   it("detects array types and element types", () => {

--- a/packages/data-grid/src/renderers/typeMatch.ts
+++ b/packages/data-grid/src/renderers/typeMatch.ts
@@ -13,6 +13,12 @@ export function isJsonType(type: string): boolean {
   return t === "json" || t === "jsonb";
 }
 
+/** True for UUID / GUID / uniqueidentifier columns (Postgres + SQL Server). */
+export function isGuidType(type: string): boolean {
+  const t = baseType(type);
+  return t === "uuid" || t === "guid" || t === "uniqueidentifier";
+}
+
 /**
  * True for native array types. Postgres reports these as `int4[]` / `text[]`
  * via the public name, or as the internal element type `_int4`; other engines


### PR DESCRIPTION
## Summary
- Right-click a `uuid` / `guid` / `uniqueidentifier` cell in a table tab to insert a new GUID into pending edits (inserts and updates).
- Extracts `applyCellChange` so context-menu actions share the same pending-edit path as inline cell editing, and adds `isGuidType` for type gating.
- Cell context menu also includes Copy cell for parity with query results.

## Test plan
- [ ] Insert a row on a table with a UUID/GUID column, right-click the cell, choose Generate new GUID, and confirm the pending bar shows the value
- [ ] Right-click an existing GUID cell, generate a new value, and preview/commit the UPDATE
- [ ] Confirm non-GUID columns only show Copy cell (no Generate new GUID)
- [ ] Confirm deleted rows do not offer Generate new GUID


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a cell context menu with options to copy cell values.
  * Added “Generate new GUID” for eligible GUID/UUID fields.
  * Generated GUIDs can be applied directly to editable cells.

* **Bug Fixes**
  * Improved tracking of cell edits, including reverting values to their originals and handling multiple edits consistently.

* **Tests**
  * Added coverage for cell change tracking and GUID type detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->