### PR TITLE
fix: make Messages tab columns resizable

### DIFF
--- a/apps/desktop/src/components/BottomMessagesPanel.tsx
+++ b/apps/desktop/src/components/BottomMessagesPanel.tsx
@@ -1,4 +1,10 @@
-import { useState } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
 
 import {
   formatMessageTime,
@@ -8,6 +14,44 @@ import {
   type QueryMessageSeverity,
 } from "../lib/queryMessages";
 
+type MessageColumnKey = "time" | "level" | "source" | "message" | "metrics";
+
+type MessageColumnWidths = Record<MessageColumnKey, number>;
+
+type ColumnResizeState = {
+  columnKey: MessageColumnKey;
+  startX: number;
+  startWidth: number;
+};
+
+const MESSAGE_COLUMNS: ReadonlyArray<{
+  key: MessageColumnKey;
+  label: string;
+}> = [
+  { key: "time", label: "time" },
+  { key: "level", label: "level" },
+  { key: "source", label: "source" },
+  { key: "message", label: "message" },
+  { key: "metrics", label: "metrics" },
+];
+
+/** Defaults sized for JetBrains Mono at 14px so values don't collide. */
+const DEFAULT_COLUMN_WIDTHS: MessageColumnWidths = {
+  time: 130,
+  level: 88,
+  source: 108,
+  message: 480,
+  metrics: 180,
+};
+
+const MIN_COLUMN_WIDTHS: MessageColumnWidths = {
+  time: 88,
+  level: 64,
+  source: 72,
+  message: 180,
+  metrics: 96,
+};
+
 export function MessagesView({
   messages,
   hasActiveTab = true,
@@ -16,9 +60,73 @@ export function MessagesView({
   hasActiveTab?: boolean;
 }) {
   const [filter, setFilter] = useState<QueryMessageSeverity | "all">("all");
+  const [widths, setWidths] = useState<MessageColumnWidths>(DEFAULT_COLUMN_WIDTHS);
+  const [resizing, setResizing] = useState<ColumnResizeState | null>(null);
+  const resizingRef = useRef<ColumnResizeState | null>(null);
+  const widthsRef = useRef(widths);
   const counts = severityCounts(messages);
   const visible =
     filter === "all" ? messages : messages.filter((m) => m.severity === filter);
+
+  useEffect(() => {
+    widthsRef.current = widths;
+  }, [widths]);
+
+  useEffect(() => {
+    resizingRef.current = resizing;
+  }, [resizing]);
+
+  useEffect(() => {
+    if (!resizing) return;
+    const previousCursor = document.body.style.cursor;
+    const previousUserSelect = document.body.style.userSelect;
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+
+    const onPointerMove = (event: PointerEvent) => {
+      const active = resizingRef.current;
+      if (!active) return;
+      const nextWidth = Math.max(
+        MIN_COLUMN_WIDTHS[active.columnKey],
+        Math.round(active.startWidth + event.clientX - active.startX),
+      );
+      setWidths({
+        ...widthsRef.current,
+        [active.columnKey]: nextWidth,
+      });
+    };
+
+    const onPointerUp = () => {
+      resizingRef.current = null;
+      setResizing(null);
+    };
+
+    window.addEventListener("pointermove", onPointerMove);
+    window.addEventListener("pointerup", onPointerUp, { once: true });
+    window.addEventListener("pointercancel", onPointerUp, { once: true });
+    return () => {
+      window.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("pointerup", onPointerUp);
+      window.removeEventListener("pointercancel", onPointerUp);
+      document.body.style.cursor = previousCursor;
+      document.body.style.userSelect = previousUserSelect;
+    };
+  }, [resizing]);
+
+  function beginColumnResize(
+    event: ReactPointerEvent<HTMLSpanElement>,
+    columnKey: MessageColumnKey,
+  ) {
+    event.preventDefault();
+    event.stopPropagation();
+    const next: ColumnResizeState = {
+      columnKey,
+      startX: event.clientX,
+      startWidth: widthsRef.current[columnKey],
+    };
+    resizingRef.current = next;
+    setResizing(next);
+  }
 
   if (!hasActiveTab) {
     return (
@@ -64,19 +172,62 @@ export function MessagesView({
           detail="Adjust the severity filter to inspect the current execution feedback."
         />
       ) : (
-        <div className="min-h-0 flex-1 overflow-auto">
-          <div className="grid min-w-[720px] grid-cols-[92px_74px_86px_minmax(220px,1fr)_160px] border-b border-border-divider px-2 py-1 font-mono text-[12px] uppercase text-fg-3">
-            <span>time</span>
-            <span>level</span>
-            <span>source</span>
-            <span>message</span>
-            <span>metrics</span>
+        <div className="min-h-0 min-w-0 flex-1 overflow-auto">
+          <div className="inline-flex min-w-full flex-col font-mono text-sm">
+            <div className="sticky top-0 z-[1] flex border-b border-border-divider bg-bg-inset text-[12px] uppercase text-fg-3">
+              {MESSAGE_COLUMNS.map((column) => (
+                <HeaderCell
+                  key={column.key}
+                  columnKey={column.key}
+                  label={column.label}
+                  width={widths[column.key]}
+                  resizing={resizing?.columnKey === column.key}
+                  onResizeStart={(event) => beginColumnResize(event, column.key)}
+                />
+              ))}
+            </div>
+            {visible.map((message) => (
+              <MessageRow key={message.id} message={message} widths={widths} />
+            ))}
           </div>
-          {visible.map((message) => (
-            <MessageRow key={message.id} message={message} />
-          ))}
         </div>
       )}
+    </div>
+  );
+}
+
+function HeaderCell({
+  columnKey,
+  label,
+  width,
+  resizing,
+  onResizeStart,
+}: {
+  columnKey: MessageColumnKey;
+  label: string;
+  width: number;
+  resizing: boolean;
+  onResizeStart: (event: ReactPointerEvent<HTMLSpanElement>) => void;
+}) {
+  return (
+    <div
+      className="relative shrink-0 border-r border-border-subtle"
+      style={columnStyle(width)}
+    >
+      <span className="block truncate px-2.5 py-1">{label}</span>
+      <span
+        className={
+          "absolute top-0 right-[-2px] bottom-0 z-[5] w-1.5 cursor-col-resize touch-none hover:bg-accent-line " +
+          (resizing ? "bg-accent-line" : "")
+        }
+        role="separator"
+        aria-orientation="vertical"
+        aria-label={`Resize ${label} column`}
+        aria-valuemin={MIN_COLUMN_WIDTHS[columnKey]}
+        aria-valuenow={width}
+        tabIndex={-1}
+        onPointerDown={onResizeStart}
+      />
     </div>
   );
 }
@@ -108,16 +259,48 @@ function SeverityFilter({
   );
 }
 
-function MessageRow({ message }: { message: QueryMessage }) {
+function MessageRow({
+  message,
+  widths,
+}: {
+  message: QueryMessage;
+  widths: MessageColumnWidths;
+}) {
   return (
-    <div className="grid min-w-[720px] grid-cols-[92px_74px_86px_minmax(220px,1fr)_160px] items-start border-b border-border-subtle px-2 py-1.5 font-mono text-sm leading-[1.45] hover:bg-bg-1">
-      <span className="text-fg-3">{formatMessageTime(message.timestamp)}</span>
-      <span className={severityClass(message.severity)}>{message.severity}</span>
-      <span className="text-fg-2">{message.source}</span>
-      <span className="min-w-0 whitespace-pre-wrap break-words pr-3 text-fg-1">
+    <div className="flex items-start border-b border-border-subtle hover:bg-bg-1">
+      <span
+        className="shrink-0 truncate overflow-hidden border-r border-border-subtle px-2.5 py-1.5 leading-[1.45] text-fg-3"
+        style={columnStyle(widths.time)}
+      >
+        {formatMessageTime(message.timestamp)}
+      </span>
+      <span
+        className={
+          "shrink-0 truncate overflow-hidden border-r border-border-subtle px-2.5 py-1.5 leading-[1.45] " +
+          severityClass(message.severity)
+        }
+        style={columnStyle(widths.level)}
+      >
+        {message.severity}
+      </span>
+      <span
+        className="shrink-0 truncate overflow-hidden border-r border-border-subtle px-2.5 py-1.5 leading-[1.45] text-fg-2"
+        style={columnStyle(widths.source)}
+      >
+        {message.source}
+      </span>
+      <span
+        className="shrink-0 overflow-hidden border-r border-border-subtle whitespace-pre-wrap break-words px-2.5 py-1.5 leading-[1.45] text-fg-1"
+        style={columnStyle(widths.message)}
+      >
         {message.text}
       </span>
-      <span className="text-fg-3">{metricsText(message)}</span>
+      <span
+        className="shrink-0 truncate overflow-hidden px-2.5 py-1.5 leading-[1.45] text-fg-3"
+        style={columnStyle(widths.metrics)}
+      >
+        {metricsText(message)}
+      </span>
     </div>
   );
 }
@@ -139,13 +322,25 @@ function EmptyMessagePanel({
   );
 }
 
+function columnStyle(width: number): CSSProperties {
+  return {
+    width,
+    flexBasis: width,
+    maxWidth: width,
+  };
+}
+
 function metricsText(message: QueryMessage): string {
   const parts: string[] = [];
   if (message.durationMs != null) parts.push(`${message.durationMs} ms`);
   if (message.rowCount != null) {
-    parts.push(`${message.rowCount.toLocaleString("en-US")} row${message.rowCount === 1 ? "" : "s"}`);
+    parts.push(
+      `${message.rowCount.toLocaleString("en-US")} row${message.rowCount === 1 ? "" : "s"}`,
+    );
   }
-  if (message.statementIndex != null) parts.push(`stmt ${message.statementIndex + 1}`);
+  if (message.statementIndex != null) {
+    parts.push(`stmt ${message.statementIndex + 1}`);
+  }
   return parts.length ? parts.join(" | ") : "-";
 }
 

--- a/apps/desktop/src/components/BottomPanel.test.tsx
+++ b/apps/desktop/src/components/BottomPanel.test.tsx
@@ -28,6 +28,11 @@ describe("MessagesView", () => {
     expect(html).toContain("Loaded public.orders");
     expect(html).toContain("12 ms");
     expect(html).toContain("2 rows");
+    expect(html).toContain("Resize time column");
+    expect(html).toContain("Resize level column");
+    expect(html).toContain("Resize source column");
+    expect(html).toContain("Resize message column");
+    expect(html).toContain("Resize metrics column");
   });
 });
 


### PR DESCRIPTION
## Summary
- Replaces the fixed Messages tab CSS grid with flex columns that use explicit widths, so time/level/source no longer collide.
- Adds drag handles on every header so columns can be resized, with wider defaults sized for the mono font.
- Extends the MessagesView test to assert resize affordances are present.

## Test plan
- [ ] Open the Messages tab after running a query and confirm columns are spaced without overlap
- [ ] Drag header edges to resize time, level, source, message, and metrics
- [ ] Confirm long message text still wraps within its column and horizontal scroll works when needed

Made with [Cursor](https://cursor.com)