### PR TITLE
fix: keep grid date picker from clipping under the pending bar

### DIFF
--- a/apps/desktop/src/components/grid/GridDateEditor.test.ts
+++ b/apps/desktop/src/components/grid/GridDateEditor.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseTime, ymd } from "./GridDateEditor";
+import { parseTime, placeCalendarPopover, ymd } from "./GridDateEditor";
 
 describe("ymd", () => {
   it("formats from local components (no UTC day-shift)", () => {
@@ -17,5 +17,43 @@ describe("parseTime", () => {
 
   it("defaults to midnight when no time is present", () => {
     expect(parseTime("2023-04-03")).toBe("00:00:00");
+    expect(parseTime("")).toBe("00:00:00");
+  });
+});
+
+describe("placeCalendarPopover", () => {
+  const bounds = { top: 8, bottom: 500, left: 8, right: 800 };
+  const panel = { width: 280, height: 320 };
+
+  it("opens below the cell when there is room in the scroll viewport", () => {
+    expect(
+      placeCalendarPopover(
+        { top: 100, left: 40, bottom: 124 },
+        panel,
+        bounds,
+      ),
+    ).toEqual({ top: 124, left: 40 });
+  });
+
+  it("flips above the cell when a downward open would hit the pending bar", () => {
+    // Cell near the bottom of .grid-scroll; calendar would overflow into the
+    // pending/pagination bars if placed below.
+    expect(
+      placeCalendarPopover(
+        { top: 400, left: 40, bottom: 424 },
+        panel,
+        bounds,
+      ),
+    ).toEqual({ top: 80, left: 40 });
+  });
+
+  it("clamps horizontally inside the viewport", () => {
+    expect(
+      placeCalendarPopover(
+        { top: 100, left: 750, bottom: 124 },
+        panel,
+        bounds,
+      ),
+    ).toEqual({ top: 124, left: 520 });
   });
 });

--- a/apps/desktop/src/components/grid/GridDateEditor.tsx
+++ b/apps/desktop/src/components/grid/GridDateEditor.tsx
@@ -9,7 +9,10 @@
  */
 import { nativeControl, type CellEditorProps } from "@cellar/data-grid";
 import { useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { DayPicker } from "react-day-picker";
+
+const VIEWPORT_MARGIN = 8;
 
 const pad = (n: number) => String(n).padStart(2, "0");
 // Format from local components, NOT toISOString(), so a date picked in the
@@ -116,10 +119,59 @@ function GridDateEditor({
 }
 
 /**
+ * Collision bounds for the date popover. Prefer the grid's scroll viewport so
+ * we flip above the cell when the pending/pagination bars (or an open bottom
+ * panel) would otherwise clip a downward open. Fall back to the window.
+ */
+function collisionBounds(anchor: HTMLElement): {
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+} {
+  const scroll = anchor.closest(".grid-scroll") as HTMLElement | null;
+  if (scroll) {
+    const r = scroll.getBoundingClientRect();
+    return {
+      top: r.top + VIEWPORT_MARGIN,
+      bottom: r.bottom - VIEWPORT_MARGIN,
+      left: VIEWPORT_MARGIN,
+      right: window.innerWidth - VIEWPORT_MARGIN,
+    };
+  }
+  return {
+    top: VIEWPORT_MARGIN,
+    bottom: window.innerHeight - VIEWPORT_MARGIN,
+    left: VIEWPORT_MARGIN,
+    right: window.innerWidth - VIEWPORT_MARGIN,
+  };
+}
+
+/** Pure placement math — exported for unit tests. */
+export function placeCalendarPopover(
+  cell: { top: number; left: number; bottom: number },
+  panel: { width: number; height: number },
+  bounds: { top: number; bottom: number; left: number; right: number },
+): { top: number; left: number } {
+  const left = Math.max(
+    bounds.left,
+    Math.min(cell.left, bounds.right - panel.width),
+  );
+  // Prefer below; flip above when a downward open would hit the scroll
+  // viewport bottom (pending bar / pagination / bottom panel edge).
+  const fitsBelow = cell.bottom + panel.height <= bounds.bottom;
+  const top = fitsBelow
+    ? cell.bottom
+    : Math.max(bounds.top, cell.top - panel.height);
+  return { top, left };
+}
+
+/**
  * A fixed-position popover anchored under the editing cell. Escape cancels;
  * clicking away or scrolling commits (the usual "click-off applies" behaviour
- * of a picker). Uses `position: fixed` with a one-pass correction so it escapes
- * the grid cell's `overflow: hidden` and any transformed layout ancestor.
+ * of a picker). Portaled to `document.body` so `.grid-scroll`'s overflow and
+ * the pending bar can't clip it; flips above the cell when there isn't room
+ * below inside the grid viewport.
  */
 function CalendarPopover({
   anchorRef,
@@ -133,43 +185,34 @@ function CalendarPopover({
   children: React.ReactNode;
 }) {
   const panelRef = useRef<HTMLDivElement | null>(null);
-  const targetRef = useRef<{ top: number; left: number } | null>(null);
   const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
   const [settled, setSettled] = useState(false);
 
-  // Pass 1 — intended viewport position from the cell box.
   useLayoutEffect(() => {
     const cell =
       (anchorRef.current?.closest(".grid-cell") as HTMLElement | null) ??
       anchorRef.current;
-    if (!cell) return;
-    const r = cell.getBoundingClientRect();
-    const h = panelRef.current?.offsetHeight ?? 0;
-    const w = panelRef.current?.offsetWidth ?? 300;
-    const left = Math.max(8, Math.min(r.left, window.innerWidth - w - 8));
-    const below = r.bottom;
-    const top =
-      below + h <= window.innerHeight - 8 ? below : Math.max(8, r.top - h);
-    targetRef.current = { top, left };
-    setSettled(false);
-    setPos({ top, left });
-  }, [anchorRef]);
-
-  // Pass 2 — fixed is resolved against the nearest transformed ancestor (not
-  // the viewport here), so nudge by the delta between intended and actual.
-  useLayoutEffect(() => {
     const panel = panelRef.current;
-    const target = targetRef.current;
-    if (!panel || !target || !pos) return;
-    const actual = panel.getBoundingClientRect();
-    const dx = target.left - actual.left;
-    const dy = target.top - actual.top;
-    if (Math.abs(dx) < 0.5 && Math.abs(dy) < 0.5) {
-      if (!settled) setSettled(true);
-      return;
-    }
-    setPos({ top: pos.top + dy, left: pos.left + dx });
-  }, [pos, settled]);
+    if (!cell || !panel) return;
+
+    const place = (markSettled: boolean) => {
+      const r = cell.getBoundingClientRect();
+      setPos(
+        placeCalendarPopover(
+          { top: r.top, left: r.left, bottom: r.bottom },
+          { width: panel.offsetWidth || 300, height: panel.offsetHeight },
+          collisionBounds(cell),
+        ),
+      );
+      if (markSettled) setSettled(true);
+    };
+
+    // First pass positions with whatever height is available; a second pass on
+    // the next frame re-flips once DayPicker's month grid has real dimensions.
+    place(false);
+    const raf = requestAnimationFrame(() => place(true));
+    return () => cancelAnimationFrame(raf);
+  }, [anchorRef]);
 
   useLayoutEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -198,7 +241,7 @@ function CalendarPopover({
     };
   }, [onOutside, onEscape]);
 
-  return (
+  return createPortal(
     <div
       ref={panelRef}
       className="grid-date-popover"
@@ -210,6 +253,7 @@ function CalendarPopover({
       }
     >
       {children}
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/apps/desktop/src/styles/date-picker.css
+++ b/apps/desktop/src/styles/date-picker.css
@@ -6,7 +6,9 @@
 
 .grid-date-popover {
   position: fixed;
-  z-index: 200;
+  /* Match other grid overlays (menus / rich-cell popovers) so the calendar
+     stays above the pending bar and bottom panel after portaling to body. */
+  z-index: 1000;
   display: flex;
   flex-direction: column;
   gap: 8px;


### PR DESCRIPTION
## Summary
- Flip the grid date/datetime calendar above the cell when it would overflow the `.grid-scroll` viewport (pending/pagination bars or bottom panel).
- Portal the popover to `document.body` and raise its z-index so grid overflow no longer clips it.
- Add unit coverage for the placement math (below, flip-above, horizontal clamp).

## Test plan
- [ ] Edit a datetime cell near the bottom of the grid with the pending bar visible — calendar opens upward and stays fully readable
- [ ] Edit a datetime cell with plenty of space below — calendar still opens downward
- [ ] Confirm Apply/Cancel/Escape and click-outside still work after the portal change


Made with [Cursor](https://cursor.com)