### PR TITLE
feat: polish updates and retire Intel builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,11 +26,6 @@ jobs:
             args: --target aarch64-apple-darwin
             rust-targets: aarch64-apple-darwin
             stable-asset-name: Cellar-mac-arm64.dmg
-          - label: macOS Intel
-            platform: macos-latest
-            args: --target x86_64-apple-darwin
-            rust-targets: x86_64-apple-darwin
-            stable-asset-name: Cellar-mac-x64.dmg
 
     steps:
       - name: Checkout
@@ -200,11 +195,7 @@ jobs:
           tarball="$(find "$macos_dir" -name "*.app.tar.gz" -type f -print -quit 2>/dev/null || true)"
 
           if [[ -n "$tarball" ]]; then
-            if [[ "$TARGET_TRIPLE" == "aarch64-apple-darwin" ]]; then
-              stable_sig_name="Cellar_aarch64.app.tar.gz.sig"
-            else
-              stable_sig_name="Cellar_x64.app.tar.gz.sig"
-            fi
+            stable_sig_name="Cellar_aarch64.app.tar.gz.sig"
 
             echo "Signing updater bundle: $tarball"
             npx @tauri-apps/cli signer sign \
@@ -286,47 +277,30 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Download the .sig files from the release to build latest.json.
+          # Download the Apple Silicon signature to build latest.json. Cellar
+          # 0.3.5 is the final Intel release; later manifests intentionally
+          # omit darwin-x86_64 so those installations remain on 0.3.5.
           tmpdir="$(mktemp -d)"
           gh release download "$RELEASE_TAG" \
             --pattern 'Cellar_aarch64.app.tar.gz.sig' \
-            --pattern 'Cellar_x64.app.tar.gz.sig' \
-            --dir "$tmpdir" || true
+            --dir "$tmpdir"
 
-          aarch64_sig=""
-          x64_sig=""
-          [[ -f "$tmpdir/Cellar_aarch64.app.tar.gz.sig" ]] && aarch64_sig="$(cat "$tmpdir/Cellar_aarch64.app.tar.gz.sig")"
-          [[ -f "$tmpdir/Cellar_x64.app.tar.gz.sig" ]] && x64_sig="$(cat "$tmpdir/Cellar_x64.app.tar.gz.sig")"
+          aarch64_sig="$(cat "$tmpdir/Cellar_aarch64.app.tar.gz.sig")"
+          base_url="https://github.com/${GH_REPO}/releases/download/${RELEASE_TAG}"
+          pub_date="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
-          if [[ -z "$aarch64_sig" && -z "$x64_sig" ]]; then
-            echo "No signature files found — skipping latest.json generation" >&2
-          else
-            base_url="https://github.com/${GH_REPO}/releases/download/${RELEASE_TAG}"
-            pub_date="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          jq -n \
+            --arg version "$RELEASE_TAG" \
+            --rawfile notes "$RUNNER_TEMP/changelog-full.md" \
+            --arg pub_date "$pub_date" \
+            --arg signature "$aarch64_sig" \
+            --arg url "$base_url/Cellar_aarch64.app.tar.gz" \
+            '{version: $version, notes: ($notes | rtrimstr("\n")), pub_date: $pub_date, platforms: {"darwin-aarch64": {signature: $signature, url: $url}}}' \
+            > "$tmpdir/latest.json"
 
-            # Use jq to build valid JSON with properly escaped signatures.
-            platforms='{}'
-            if [[ -n "$aarch64_sig" ]]; then
-              platforms="$(jq --arg sig "$aarch64_sig" --arg url "$base_url/Cellar_aarch64.app.tar.gz" \
-                '. + {"darwin-aarch64": {signature: $sig, url: $url}}' <<<"$platforms")"
-            fi
-            if [[ -n "$x64_sig" ]]; then
-              platforms="$(jq --arg sig "$x64_sig" --arg url "$base_url/Cellar_x64.app.tar.gz" \
-                '. + {"darwin-x86_64": {signature: $sig, url: $url}}' <<<"$platforms")"
-            fi
-
-            jq -n \
-              --arg version "$RELEASE_TAG" \
-              --rawfile notes "$RUNNER_TEMP/changelog-full.md" \
-              --arg pub_date "$pub_date" \
-              --argjson platforms "$platforms" \
-              '{version: $version, notes: ($notes | rtrimstr("\n")), pub_date: $pub_date, platforms: $platforms}' \
-              > "$tmpdir/latest.json"
-
-            echo "Generated latest.json:"
-            cat "$tmpdir/latest.json"
-            gh release upload "$RELEASE_TAG" "$tmpdir/latest.json" --clobber
-          fi
+          echo "Generated latest.json:"
+          cat "$tmpdir/latest.json"
+          gh release upload "$RELEASE_TAG" "$tmpdir/latest.json" --clobber
 
       - name: Publish GitHub Release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,7 +187,8 @@ jobs:
           cp "$dmg_path" "/tmp/$STABLE_ASSET_NAME"
           gh release upload "$RELEASE_TAG" "/tmp/$STABLE_ASSET_NAME" --clobber
 
-          # Sign the .app.tar.gz updater bundle and upload the signature.
+          # Sign the .app.tar.gz updater bundle and upload both files under
+          # stable names that match the URLs emitted in latest.json.
           # tauri-action@v0 doesn't correctly handle Tauri v2 updater artifacts,
           # so we sign the bundle ourselves using the tauri CLI.
           bundle_root="$(dirname "$(dirname "$dmg_path")")"
@@ -195,25 +196,31 @@ jobs:
           tarball="$(find "$macos_dir" -name "*.app.tar.gz" -type f -print -quit 2>/dev/null || true)"
 
           if [[ -n "$tarball" ]]; then
-            stable_sig_name="Cellar_aarch64.app.tar.gz.sig"
+            stable_bundle_name="Cellar_aarch64.app.tar.gz"
+            stable_sig_name="${stable_bundle_name}.sig"
 
             echo "Signing updater bundle: $tarball"
             npx @tauri-apps/cli signer sign \
               -k "$TAURI_SIGNING_PRIVATE_KEY" \
               -p "" \
-              "$tarball" || true
+              "$tarball"
 
             sig_file="${tarball}.sig"
             if [[ -f "$sig_file" ]]; then
+              cp "$tarball" "/tmp/$stable_bundle_name"
               cp "$sig_file" "/tmp/$stable_sig_name"
+              echo "Uploading updater bundle as $stable_bundle_name"
+              gh release upload "$RELEASE_TAG" "/tmp/$stable_bundle_name" --clobber
               echo "Uploading signature as $stable_sig_name"
               gh release upload "$RELEASE_TAG" "/tmp/$stable_sig_name" --clobber
             else
               echo "Sign command did not produce $sig_file" >&2
               ls -la "$macos_dir"
+              exit 1
             fi
           else
             echo "No .app.tar.gz found under $macos_dir" >&2
+            exit 1
           fi
 
   publish-release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,25 +4,39 @@
 
 ### Features
 
-- **Selective setup exports** — choose which saved connections to include in a
-  setup bundle, with table layouts filtered to the selected connections.
-- **Remembered table sorts** — optionally restore each table's last column sort
-  when it is reopened; enabled by default in Data grid settings.
+- **Selective setup exports** — choose exactly which saved connections to
+  include, use Select all or Unselect all for quick changes, and export only
+  the table layouts belonging to those connections.
+- **Remembered table sorts** — restore each table's last column sort when it is
+  reopened. The behavior is enabled by default and can be changed in Data grid
+  settings.
 - **Generate GUID values** — right-click UUID, GUID, or `uniqueidentifier` cells
   to generate a new value through the normal pending-edit workflow.
+- **Copy cells from the context menu** — table cells now offer the same Copy
+  cell action as query results.
 
 ### Bug fixes
 
-- **SQL Server grid editing** — fixed transaction handling for grid commits,
-  added TRUE/FALSE selection for `bit` columns, and reliably close inline
-  editors after refresh without misclassifying Postgres bit strings.
+- **SQL Server grid commits** — transaction control and database switching now
+  run as raw batches, fixing failed commits caused by mismatched transaction
+  counts.
+- **Boolean cell editing** — SQL Server `bit` columns now use a TRUE, FALSE, and
+  optional NULL selector instead of free text.
+- **Editor cleanup after commits** — inline cell editors close when refreshed
+  after a commit and no longer reopen from the same double-click.
+- **Postgres bit strings** — Postgres `bit` and `bit(n)` values keep their text
+  editor instead of being mistaken for SQL Server booleans.
 - **Date picker placement** — date and datetime editors now flip above cells or
   clamp horizontally when needed instead of being clipped by grid controls.
 - **Resizable Messages columns** — message metadata no longer overlaps, and
   every column can be resized from its header.
-- **Website delivery and sharing** — fixed Tailwind availability in production
-  site builds and added a purpose-built social preview card with complete Open
-  Graph and X metadata.
+- **Export and sort edge cases** — empty connection selections no longer leak
+  table layouts into setup exports, saved sorts apply as soon as remembering is
+  enabled, and temporarily missing columns no longer erase persisted sorts.
+- **Production website styles** — Tailwind is now available during Nixpacks
+  builds, preventing missing production styles.
+- **Social link previews** — links now use a purpose-built Cellar social card
+  with explicit Open Graph and X metadata, dimensions, format, and alt text.
 
 ## 0.3.4
 

--- a/apps/desktop/src/components/modals/settingsSystemPanels.tsx
+++ b/apps/desktop/src/components/modals/settingsSystemPanels.tsx
@@ -169,7 +169,7 @@ export function SettingsUpdates() {
                 type="button"
                 onClick={downloadAndInstall}
                 disabled={isBusy}
-                className="inline-flex h-[26px] items-center gap-1 rounded-[4px] border border-accent-line bg-accent-soft px-2 text-[12px] font-medium text-accent hover:bg-accent/20"
+                className="update-download-cta inline-flex h-[26px] items-center gap-1 rounded-[4px] px-2 text-[12px] font-medium text-accent"
               >
                 <Icon.download size={11} />
                 <span>Download &amp; install</span>

--- a/apps/desktop/src/styles/base.css
+++ b/apps/desktop/src/styles/base.css
@@ -95,3 +95,64 @@
   background: transparent;
   color: var(--fg-2);
 }
+
+/* The moving edge marks an update as ready without making the compact settings
+   toolbar louder or changing its layout. */
+.update-download-cta {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  border: 1px solid transparent;
+  background: var(--accent-soft);
+  box-shadow: 0 0 12px color-mix(in srgb, var(--accent) 18%, transparent);
+  transition: color 160ms, box-shadow 160ms;
+}
+
+.update-download-cta::before,
+.update-download-cta::after {
+  position: absolute;
+  content: "";
+  pointer-events: none;
+}
+
+.update-download-cta::before {
+  z-index: -2;
+  inset: -90%;
+  background: conic-gradient(
+    from 20deg,
+    transparent 0 34%,
+    var(--accent) 43%,
+    var(--info) 50%,
+    var(--accent) 57%,
+    transparent 66% 100%
+  );
+  animation: update-download-border 2.4s linear infinite;
+}
+
+.update-download-cta::after {
+  z-index: -1;
+  inset: 1px;
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--bg-2) 86%, var(--accent) 14%);
+}
+
+.update-download-cta:hover {
+  color: var(--fg-0);
+  box-shadow: 0 0 16px color-mix(in srgb, var(--accent) 28%, transparent);
+}
+
+.update-download-cta:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+@keyframes update-download-border {
+  to { transform: rotate(1turn); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .update-download-cta::before {
+    animation: none;
+    transform: rotate(120deg);
+  }
+}

--- a/apps/site/src/App.tsx
+++ b/apps/site/src/App.tsx
@@ -25,13 +25,12 @@ const RELEASE_API = "https://api.github.com/repos/MRL-00/cellar/releases";
 type ReleaseAsset = { name: string; size: number; browser_download_url: string };
 type Release = { draft?: boolean; tag_name: string; assets: ReleaseAsset[] };
 type Installer = { href: string; meta: string };
-type DownloadInfo = { label: string; meta: string; silicon: Installer; intel: Installer };
+type DownloadInfo = { label: string; meta: string; installer: Installer };
 
 const defaultDownload: DownloadInfo = {
-  label: "Choose Mac version",
-  meta: "macOS 13+",
-  silicon: { href: RELEASES, meta: "M1 or newer" },
-  intel: { href: RELEASES, meta: "Intel processor" },
+  label: "Download for Mac",
+  meta: "Apple Silicon · macOS 13+",
+  installer: { href: RELEASES, meta: "M1 or newer" },
 };
 let downloadRequest: Promise<DownloadInfo> | undefined;
 
@@ -70,20 +69,13 @@ function lookupDownload() {
         const silicon = release.assets.find(
           ({ name }) => name === "Cellar-mac-arm64.dmg" || /^Cellar_.+_aarch64\.dmg$/.test(name),
         );
-        const intel = release.assets.find(
-          ({ name }) => name === "Cellar-mac-x64.dmg" || /^Cellar_.+_x64\.dmg$/.test(name),
-        );
-        if (!silicon && !intel) continue;
+        if (!silicon) continue;
         return {
           label: "Download for Mac",
-          meta: `${release.tag_name} · macOS 13+`,
-          silicon: {
-            href: silicon?.browser_download_url ?? RELEASES,
-            meta: silicon ? `M1 or newer · ${formatSize(silicon.size)}` : "M1 or newer · View releases",
-          },
-          intel: {
-            href: intel?.browser_download_url ?? RELEASES,
-            meta: intel ? `Intel processor · ${formatSize(intel.size)}` : "Intel processor · View releases",
+          meta: `${release.tag_name} · Apple Silicon · macOS 13+`,
+          installer: {
+            href: silicon.browser_download_url,
+            meta: `M1 or newer · ${formatSize(silicon.size)}`,
           },
         };
       }
@@ -160,64 +152,24 @@ function usePageMotion() {
   }, []);
 }
 
-function DownloadPicker({
+function DownloadButton({
   className,
   compact = false,
-  align = "left",
-  side = "bottom",
 }: {
   className?: string;
   compact?: boolean;
-  align?: "left" | "center" | "right";
-  side?: "bottom" | "top";
 }) {
   const download = useDownload();
-  const alignment = {
-    left: "left-0",
-    center: "left-1/2 -translate-x-1/2",
-    right: "right-0",
-  }[align];
   return (
-    <details className={cn("group relative z-30 inline-block", className)}>
-      <summary
-        className={cn(
-          buttonVariants({ size: compact ? "default" : "lg" }),
-          "w-full cursor-pointer list-none marker:hidden [&::-webkit-details-marker]:hidden",
-        )}
-      >
-        <Download className="size-4" aria-hidden="true" />
-        {compact ? "Download" : download.label}
-        <ChevronDown className="size-4 transition-transform duration-300 ease-out-quint group-open:rotate-180" aria-hidden="true" />
-      </summary>
-      <div
-        className={cn(
-          "absolute z-50 w-[min(19rem,calc(100vw-2.5rem))] rounded-2xl border border-line bg-oxide p-2 text-left text-paper shadow-[0_24px_70px_oklch(0.03_0.003_255/0.65)]",
-          side === "bottom" ? "top-full mt-2" : "bottom-full mb-2",
-          alignment,
-        )}
-        aria-label="Choose Mac installer"
-      >
-        {([
-          ["M", "Apple Silicon", download.silicon],
-          ["I", "Intel Mac", download.intel],
-        ] as const).map(([mark, label, installer]) => (
-          <a
-            key={label}
-            href={installer.href}
-            className="flex items-center gap-3 rounded-xl px-3 py-3 transition-colors hover:bg-paper/7 focus-visible:bg-paper/7 focus-visible:outline-none"
-            rel="noopener"
-          >
-            <span className="grid size-9 shrink-0 place-items-center rounded-full border border-line bg-paper/5 font-mono text-xs text-paper-muted">
-              {mark}
-            </span>
-            <span className="grid gap-0.5">
-              <strong className="text-sm font-medium text-paper">{label}</strong>
-              <span className="font-mono text-[10px] uppercase tracking-[0.06em] text-paper-dim">{installer.meta}</span>
-            </span>
-          </a>
-        ))}
-      </div>
-    </details>
+    <a
+      href={download.installer.href}
+      className={cn(buttonVariants({ size: compact ? "default" : "lg" }), className)}
+      rel="noopener"
+      title={download.installer.meta}
+    >
+      <Download className="size-4" aria-hidden="true" />
+      {compact ? "Download" : download.label}
+    </a>
   );
 }
 
@@ -254,7 +206,7 @@ function Nav() {
           <a href={GITHUB} className="text-sm text-paper-muted transition-colors hover:text-paper" rel="noopener">
             GitHub
           </a>
-          <DownloadPicker compact align="right" />
+          <DownloadButton compact />
         </div>
         <button
           className="ml-auto grid size-10 place-items-center rounded-full border border-line text-paper md:hidden"
@@ -277,7 +229,7 @@ function Nav() {
             <a href={GITHUB} className="py-3 text-lg" rel="noopener">
               GitHub
             </a>
-            <DownloadPicker className="mt-3 w-full" compact align="right" />
+            <DownloadButton className="mt-3 w-full" compact />
           </div>
         </div>
       )}
@@ -312,7 +264,7 @@ function Hero() {
             A fast desktop database client for people who live in SQL. Browse schemas, edit data, and review every change before it commits.
           </p>
           <div className="mt-8 flex flex-wrap items-center gap-3">
-            <DownloadPicker />
+            <DownloadButton />
             <a href="#product" className={buttonVariants({ variant: "outline", size: "lg" })}>
               See it move <ArrowDown className="size-4" aria-hidden="true" />
             </a>
@@ -544,7 +496,7 @@ function FinalCta() {
         <p className="section-kicker text-coral">Free · Open source · macOS</p>
         <h2 className="mt-8 text-[clamp(4rem,9vw,10rem)] font-medium leading-[0.78] tracking-[-0.08em]">Meet your data.</h2>
         <p className="mt-8 max-w-[38rem] text-lg leading-relaxed text-paper-muted">Download the early-access build, connect a database, and get back to the work.</p>
-        <DownloadPicker className="mt-10" align="center" side="top" />
+        <DownloadButton className="mt-10" />
       </div>
     </section>
   );

--- a/docs/release.md
+++ b/docs/release.md
@@ -34,10 +34,12 @@ Before tagging, make sure the package metadata in `package.json`,
 `apps/desktop/package.json`, `apps/desktop/src-tauri/tauri.conf.json`,
 `Cargo.toml`, and `Cargo.lock` matches the tag.
 
-The `Release` workflow currently builds macOS Apple Silicon and macOS Intel
-artifacts only. It signs and notarizes the app with Developer ID, creates a
-draft GitHub Release while the matrix jobs upload installers, then publishes
-the release after both macOS jobs finish successfully. Tags with prerelease
+The `Release` workflow builds macOS Apple Silicon artifacts only. Cellar 0.3.5
+is the final Intel release; its installers remain available from that GitHub
+Release, but Intel Macs do not receive later updates. The workflow signs and
+notarizes the app with Developer ID, creates a draft GitHub Release while the
+installer uploads, then publishes the release after the build finishes
+successfully. Tags with prerelease
 suffixes, such as `0.1.0-alpha.1`, are marked as prereleases.
 
 To publish an already-created draft manually:
@@ -79,8 +81,9 @@ Release signing and notarization require these GitHub Actions secrets:
 Release. The app fetches it from
 `https://github.com/MRL-00/cellar/releases/latest/download/latest.json`.
 Prereleases are excluded from the `/releases/latest` redirect, so only stable
-releases are served to the updater. The manifest maps each platform target
-(`aarch64-apple-darwin`, `x86_64-apple-darwin`) to its signed bundle URL.
+releases are served to the updater. The manifest maps `darwin-aarch64` to its
+signed Apple Silicon bundle and intentionally omits `darwin-x86_64` after
+0.3.5.
 
 ### Rotating or losing the signing key
 
@@ -92,21 +95,18 @@ the public key is swapped in `tauri.conf.json`.
 
 ## Website downloads
 
-The website presents separate Apple Silicon and Intel Mac buttons instead of
-assuming the visitor's CPU architecture. It falls back to the GitHub Releases
-page, then upgrades the buttons to direct DMG links when the public GitHub
-Releases API returns matching assets.
+The website presents a direct Apple Silicon download. It falls back to the
+GitHub Releases page, then upgrades the button to the latest direct DMG link
+when the public GitHub Releases API returns a matching asset. Intel users can
+continue using the preserved 0.3.5 release.
 
-The release workflow attempts to upload stable aliases for the Tauri-generated
-DMGs:
+The release workflow uploads a stable alias for the Tauri-generated DMG:
 
 - `Cellar-mac-arm64.dmg` for Apple Silicon.
-- `Cellar-mac-x64.dmg` for Intel.
 
-The website also recognizes Tauri's versioned DMG names, such as
-`Cellar_0.1.0_aarch64.dmg` and `Cellar_0.1.0_x64.dmg`. This keeps downloads
-working for prereleases and early releases where GitHub's `/releases/latest`
-endpoint may not resolve.
+The website also recognizes versioned names such as
+`Cellar_0.1.0_aarch64.dmg`. This keeps downloads working for prereleases and
+early releases where GitHub's `/releases/latest` endpoint may not resolve.
 
 ## Before public distribution
 


### PR DESCRIPTION
## Summary

- Expand the 0.3.5 changelog so every shipped feature and bug fix appears in release history.
- Highlight the available update action with an accessible animated gradient border.
- Make future releases Apple Silicon-only, simplify the website to a direct ARM download, and document 0.3.5 as the final preserved Intel build.

## Validation

- `pnpm --filter @cellar/desktop test`
- `pnpm --filter @cellar/desktop typecheck`
- `pnpm --filter @cellar/desktop build`
- `pnpm --filter @cellar/site test`
- `pnpm --filter @cellar/site typecheck`
- `pnpm --filter @cellar/site build`
- Release workflow YAML and Apple Silicon updater-manifest shape validated locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added direct downloads for macOS Apple Silicon installers.
  * Added an animated, accessible update download button with reduced-motion support.
  * Added changelog entries for context-menu cell copying and expanded database editing fixes.

* **Bug Fixes**
  * Improved SQL Server editing, date picker placement, resizable message columns, exports, sorting, website styles, and social previews.

* **Documentation**
  * Clarified Apple Silicon–only releases and Intel support through version 0.3.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->