### PR TITLE
feat: add color accents to sidebar folders

### DIFF
--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -30,6 +30,7 @@ import {
 import { useTabs } from "../state/tabs";
 import { useFindUsages } from "../state/findUsages";
 import { useConfirm } from "../state/confirm";
+import { MARKER_SWATCHES } from "../lib/markerSwatches";
 import { qualifiedName, selectAllStatement } from "../lib/sqlIdent";
 
 export interface SidebarProps {
@@ -96,6 +97,7 @@ export function Sidebar({
   const renameFolder = useSidebarLayout((s) => s.renameFolder);
   const removeFolder = useSidebarLayout((s) => s.removeFolder);
   const toggleFolder = useSidebarLayout((s) => s.toggleFolder);
+  const setFolderColor = useSidebarLayout((s) => s.setFolderColor);
   const moveConnection = useSidebarLayout((s) => s.moveConnection);
   const moveFolder = useSidebarLayout((s) => s.moveFolder);
   const moveToFolder = useSidebarLayout((s) => s.moveToFolder);
@@ -410,14 +412,51 @@ export function Sidebar({
   const openFolderMenu = (e: React.MouseEvent, folder: SidebarFolderItem) => {
     e.preventDefault();
     e.stopPropagation();
+    // ponytail: second-page menu for colors (same pattern as Move to folder…)
+    const x = e.clientX;
+    const y = e.clientY;
     setMenu({
-      x: e.clientX,
-      y: e.clientY,
+      x,
+      y,
       items: [
         {
           label: "Rename folder",
           icon: <Icon.edit size={12} />,
           onClick: () => setRenamingFolderId(folder.id),
+        },
+        {
+          label: "Set color…",
+          icon: folder.color ? (
+            <span
+              className="h-2.5 w-2.5 rounded-full"
+              style={{ background: folder.color }}
+            />
+          ) : (
+            <Icon.folder size={12} />
+          ),
+          onClick: () =>
+            setMenu({
+              x,
+              y,
+              items: [
+                ...MARKER_SWATCHES.map(({ color: c, label }) => ({
+                  label: c === folder.color ? `${label} (current)` : label,
+                  icon: (
+                    <span
+                      className="h-2.5 w-2.5 rounded-full"
+                      style={{ background: c }}
+                    />
+                  ),
+                  onClick: () => setFolderColor(folder.id, c),
+                })),
+                {
+                  label: "Clear color",
+                  icon: <Icon.close size={12} />,
+                  disabled: !folder.color,
+                  onClick: () => setFolderColor(folder.id, null),
+                },
+              ],
+            }),
         },
         {
           label:

--- a/apps/desktop/src/components/SidebarConnectionList.tsx
+++ b/apps/desktop/src/components/SidebarConnectionList.tsx
@@ -283,6 +283,13 @@ export function SidebarConnectionList({
         <div
           key={`children:${item.id}`}
           className="ml-[13px] border-l border-border-default"
+          style={
+            item.color
+              ? {
+                  borderColor: `color-mix(in oklab, ${item.color} 45%, transparent)`,
+                }
+              : undefined
+          }
         >
           {visibleChildren.length === 0 ? (
             <div
@@ -403,6 +410,12 @@ function FolderRow({
           style={{ background: "var(--accent)" }}
         />
       )}
+      {folder.color && (
+        <span
+          className="pointer-events-none absolute left-0 top-0 h-full w-0.5 rounded-r-[1px]"
+          style={{ background: folder.color }}
+        />
+      )}
       <button
         type="button"
         className={TWISTY}
@@ -418,7 +431,10 @@ function FolderRow({
           <Icon.chevronRight size={10} />
         )}
       </button>
-      <span className={ICON_SLOT} style={{ color: "var(--fg-2)" }}>
+      <span
+        className={ICON_SLOT}
+        style={{ color: folder.color ?? "var(--fg-2)" }}
+      >
         {expanded ? <Icon.folderOpen size={12} /> : <Icon.folder size={12} />}
       </span>
       {renaming ? (

--- a/apps/desktop/src/components/modals/ConnectionDialog.tsx
+++ b/apps/desktop/src/components/modals/ConnectionDialog.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import type { ConnectionConfig, DriverInfo, EnvTag, SslMode } from "@cellar/ipc";
 import { commands, unwrap } from "@cellar/ipc";
 
+import { MARKER_SWATCHES } from "../../lib/markerSwatches";
 import { Icon } from "../icons";
 import { ENGINE_META, type Engine } from "../EngineBadge";
 import { EngineLogo } from "../EngineLogo";
@@ -32,8 +33,6 @@ const ENGINE_HEX: Record<Engine, string> = {
   neon: "#00e599",
   planetscale: "#c8ccd4",
 };
-
-const SWATCH_COLORS = ["#4f8ff7", "#f6a44a", "#d97a5a", "#5bb8e0", "#a78bfa", "#4ade80", "#f87171"];
 
 const DEFAULT_PORT: Record<Engine, number> = {
   postgres: 5432,
@@ -462,11 +461,11 @@ export function ConnectionDialog({
 
             <FormRow label="Accent" hint="Visual marker — protects against running on prod by mistake">
               <div className="flex gap-1">
-                {SWATCH_COLORS.map((c) => (
+                {MARKER_SWATCHES.map(({ color: c, label }) => (
                   <button
                     key={c}
                     onClick={() => setSwatch(c)}
-                    title={c}
+                    title={label}
                     className={
                       "h-[18px] w-[18px] rounded-[4px] border border-white/10 p-0 transition-transform hover:scale-110 " +
                       (c === swatch

--- a/apps/desktop/src/lib/markerSwatches.ts
+++ b/apps/desktop/src/lib/markerSwatches.ts
@@ -1,0 +1,16 @@
+/** Shared accent markers for connections and sidebar folders. */
+export const MARKER_SWATCHES = [
+  { color: "#4f8ff7", label: "Blue" },
+  { color: "#f6a44a", label: "Orange" },
+  { color: "#d97a5a", label: "Coral" },
+  { color: "#5bb8e0", label: "Cyan" },
+  { color: "#a78bfa", label: "Purple" },
+  { color: "#4ade80", label: "Green" },
+  { color: "#f87171", label: "Red" },
+] as const;
+
+const HEX = /^#[0-9a-fA-F]{6}$/;
+
+export function isMarkerColor(value: unknown): value is string {
+  return typeof value === "string" && HEX.test(value);
+}

--- a/apps/desktop/src/state/sidebarLayout.test.ts
+++ b/apps/desktop/src/state/sidebarLayout.test.ts
@@ -13,13 +13,14 @@ const conn = (id: string): SidebarItem => ({ kind: "connection", id });
 const folder = (
   id: string,
   children: string[],
-  extra?: Partial<{ name: string; collapsed: boolean }>,
+  extra?: Partial<{ name: string; collapsed: boolean; color: string | null }>,
 ): SidebarItem => ({
   kind: "folder",
   id,
   name: extra?.name ?? id,
   collapsed: extra?.collapsed ?? false,
   children,
+  ...(extra?.color ? { color: extra.color } : {}),
 });
 
 describe("reconcileItems", () => {
@@ -59,6 +60,26 @@ describe("reconcileItems", () => {
     ] as unknown as SidebarItem[];
     const out = reconcileItems(junk, ["a", "b"]);
     expect(out).toEqual([conn("a"), folder("f", ["b"], { name: "Folder" })]);
+  });
+
+  it("keeps valid folder colors and drops invalid ones", () => {
+    const junk = [
+      {
+        kind: "folder",
+        id: "f",
+        name: "f",
+        children: ["a"],
+        color: "#4f8ff7",
+      },
+      { kind: "folder", id: "g", name: "g", children: ["b"], color: "red" },
+      { kind: "folder", id: "h", name: "h", children: [], color: "#fff" },
+    ] as unknown as SidebarItem[];
+    const out = reconcileItems(junk, ["a", "b"]);
+    expect(out).toEqual([
+      folder("f", ["a"], { color: "#4f8ff7" }),
+      folder("g", ["b"]),
+      folder("h", []),
+    ]);
   });
 });
 
@@ -194,5 +215,25 @@ describe("useSidebarLayout store", () => {
       conn("b"),
       conn("a"),
     ]);
+  });
+
+  it("sets and clears folder color accents", () => {
+    useSidebarLayout.setState({
+      items: [folder("f", ["a"])],
+    });
+    const store = useSidebarLayout.getState();
+
+    store.setFolderColor("f", "#4ade80");
+    expect(useSidebarLayout.getState().items[0]).toMatchObject({
+      color: "#4ade80",
+    });
+
+    store.setFolderColor("f", "not-a-color");
+    expect(useSidebarLayout.getState().items[0]).toMatchObject({
+      color: "#4ade80",
+    });
+
+    store.setFolderColor("f", null);
+    expect(useSidebarLayout.getState().items[0]).toEqual(folder("f", ["a"]));
   });
 });

--- a/apps/desktop/src/state/sidebarLayout.ts
+++ b/apps/desktop/src/state/sidebarLayout.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
+import { isMarkerColor } from "../lib/markerSwatches";
 import { deferredStorage } from "./deferredStorage";
 
 /**
@@ -15,6 +16,8 @@ export type SidebarFolderItem = {
   collapsed: boolean;
   /** Connection ids in display order. */
   children: string[];
+  /** Optional left-edge accent marker (opaque hex). */
+  color?: string | null;
 };
 
 export type SidebarItem = { kind: "connection"; id: string } | SidebarFolderItem;
@@ -33,6 +36,7 @@ interface SidebarLayoutStore {
   /** Remove the folder, releasing its connections to the root at its slot. */
   removeFolder: (folderId: string) => void;
   toggleFolder: (folderId: string) => void;
+  setFolderColor: (folderId: string, color: string | null) => void;
   moveConnection: (
     connectionId: string,
     container: SidebarContainer,
@@ -62,11 +66,13 @@ function sanitizeItems(raw: unknown): SidebarItem[] {
       name?: unknown;
       collapsed?: unknown;
       children?: unknown;
+      color?: unknown;
     };
     if (typeof it.id !== "string" || it.id.length === 0) continue;
     if (it.kind === "connection") {
       out.push({ kind: "connection", id: it.id });
     } else if (it.kind === "folder") {
+      const color = isMarkerColor(it.color) ? it.color : null;
       out.push({
         kind: "folder",
         id: it.id,
@@ -75,10 +81,33 @@ function sanitizeItems(raw: unknown): SidebarItem[] {
         children: Array.isArray(it.children)
           ? it.children.filter((c): c is string => typeof c === "string")
           : [],
+        ...(color ? { color } : {}),
       });
     }
   }
   return out;
+}
+
+/** True when sanitize repaired fields on this item (so we must not keep `rawItems`). */
+function sanitizeChangedItem(raw: unknown, clean: SidebarItem): boolean {
+  if (!raw || typeof raw !== "object") return true;
+  const it = raw as {
+    kind?: unknown;
+    id?: unknown;
+    name?: unknown;
+    collapsed?: unknown;
+    children?: unknown;
+    color?: unknown;
+  };
+  if (it.kind !== clean.kind || it.id !== clean.id) return true;
+  if (clean.kind === "connection") return false;
+  return (
+    it.name !== clean.name ||
+    Boolean(it.collapsed) !== clean.collapsed ||
+    (it.color ?? null) !== (clean.color ?? null) ||
+    !Array.isArray(it.children) ||
+    it.children.some((c) => typeof c !== "string")
+  );
 }
 
 export function reconcileItems(
@@ -90,6 +119,15 @@ export function reconcileItems(
   const seen = new Set<string>();
   const out: SidebarItem[] = [];
   let changed = items.length !== rawItems.length;
+  if (!changed) {
+    for (let i = 0; i < items.length; i++) {
+      const clean = items[i];
+      if (!clean || sanitizeChangedItem(rawItems[i], clean)) {
+        changed = true;
+        break;
+      }
+    }
+  }
 
   for (const item of items) {
     if (item.kind === "connection") {
@@ -257,6 +295,21 @@ export const useSidebarLayout = create<SidebarLayoutStore>()(
               ? { ...it, collapsed: !it.collapsed }
               : it,
           ),
+        }));
+      },
+
+      setFolderColor(folderId, color) {
+        if (color !== null && !isMarkerColor(color)) return;
+        set((s) => ({
+          items: s.items.map((it) => {
+            if (!isFolder(it) || it.id !== folderId) return it;
+            if (color === null) {
+              if (!it.color) return it;
+              const { color: _removed, ...rest } = it;
+              return rest;
+            }
+            return it.color === color ? it : { ...it, color };
+          }),
         }));
       },
 


### PR DESCRIPTION
## Summary
- Right-click a folder → **Set color…** to pick (or clear) an accent from the shared marker swatches.
- Colored folders show a left-edge strip, tinted icon, and a soft nested-border tint so groups are easier to scan.
- Colors persist with sidebar layout preference state; connection accent swatches are shared via `markerSwatches`.

## Test plan
- [ ] Right-click a folder, set a color, and confirm the left strip + icon tint appear
- [ ] Expand the folder and confirm the nested border picks up a soft tint
- [ ] Clear the color and confirm accents disappear
- [ ] Reload the app and confirm the folder color persists


Made with [Cursor](https://cursor.com)