### PR TITLE
fix: keep filter dropdowns open while scrolling menus

### DIFF
--- a/apps/desktop/src/styles/grid.css
+++ b/apps/desktop/src/styles/grid.css
@@ -176,6 +176,7 @@
   z-index: 1000;
   max-height: 260px;
   overflow-y: auto;
+  overscroll-behavior: contain;
   padding: 3px;
   border: 1px solid var(--border-strong);
   border-radius: 5px;
@@ -237,6 +238,7 @@
   min-width: 180px;
   max-height: 300px;
   overflow-y: auto;
+  overscroll-behavior: contain;
   padding: 4px;
   border: 1px solid var(--border-strong);
   border-radius: 6px;

--- a/packages/data-grid/src/GridSelect.tsx
+++ b/packages/data-grid/src/GridSelect.tsx
@@ -65,13 +65,21 @@ export const GridSelect = forwardRef<HTMLButtonElement, GridSelectProps>(
         if (buttonRef.current?.contains(target)) return;
         setOpen(false);
       };
+      // Capture phase catches scrolls on the grid's inner `.grid-scroll` (which
+      // never reach `window` via bubbling) so the menu doesn't float away from
+      // its trigger. Scrolling *inside* the menu (long column lists) must not
+      // dismiss it — same pattern as the cell Popover.
+      const onScroll = (e: Event) => {
+        if (menuRef.current?.contains(e.target as Node | null)) return;
+        setOpen(false);
+      };
       const close = () => setOpen(false);
       window.addEventListener("mousedown", onPointerDown);
-      window.addEventListener("scroll", close, true);
+      window.addEventListener("scroll", onScroll, true);
       window.addEventListener("resize", close);
       return () => {
         window.removeEventListener("mousedown", onPointerDown);
-        window.removeEventListener("scroll", close, true);
+        window.removeEventListener("scroll", onScroll, true);
         window.removeEventListener("resize", close);
       };
     }, [open]);

--- a/packages/data-grid/src/PresetMenu.tsx
+++ b/packages/data-grid/src/PresetMenu.tsx
@@ -63,15 +63,22 @@ export function PresetMenu({
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") setOpen(false);
     };
+    // Capture phase catches scrolls on the grid's inner `.grid-scroll` so the
+    // menu doesn't float away from its trigger. Scrolling *inside* the menu
+    // (long preset lists) must not dismiss it — same pattern as GridSelect.
+    const onScroll = (e: Event) => {
+      if (menuRef.current?.contains(e.target as Node | null)) return;
+      setOpen(false);
+    };
     const close = () => setOpen(false);
     window.addEventListener("mousedown", onPointerDown);
     window.addEventListener("keydown", onKeyDown);
-    window.addEventListener("scroll", close, true);
+    window.addEventListener("scroll", onScroll, true);
     window.addEventListener("resize", close);
     return () => {
       window.removeEventListener("mousedown", onPointerDown);
       window.removeEventListener("keydown", onKeyDown);
-      window.removeEventListener("scroll", close, true);
+      window.removeEventListener("scroll", onScroll, true);
       window.removeEventListener("resize", close);
     };
   }, [open]);


### PR DESCRIPTION
## Summary
- Filter select and preset menus no longer close when you scroll inside the dropdown; only outside grid scroll dismisses them (same pattern as the cell Popover).
- Added `overscroll-behavior: contain` so menu scroll does not chain into the database editor underneath.

## Test plan
- [ ] Open a table with many columns, click **add** filter, open the column dropdown, and scroll the list — menu stays open and scrolls
- [ ] Scroll the grid while a filter dropdown is open — menu closes
- [ ] Repeat for the saved presets menu when the list is long enough to scroll


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dropdown menus no longer close when scrolling through their internal option or preset lists.
  * Improved menu scrolling behavior by preventing scroll chaining and bounce beyond the open menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->