### PR TITLE
fix: enlarge export controls and add native save dialog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ashpd"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39"
+dependencies = [
+ "async-fs",
+ "async-net",
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.9.4",
+ "raw-window-handle",
+ "serde",
+ "serde_repr",
+ "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "zbus",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,6 +129,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
 name = "async-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,6 +166,17 @@ dependencies = [
  "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
 ]
 
 [[package]]
@@ -563,7 +607,8 @@ dependencies = [
  "cellar-secrets",
  "cellar-sql",
  "dirs 5.0.1",
- "quick-xml",
+ "quick-xml 0.39.4",
+ "rfd",
  "serde",
  "serde_json",
  "specta",
@@ -1162,6 +1207,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "dlopen2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1215,6 +1269,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpi"
@@ -3353,7 +3413,7 @@ checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml",
+ "quick-xml 0.39.4",
  "serde",
  "time",
 ]
@@ -3397,6 +3457,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
 name = "potential_utf"
@@ -3511,6 +3577,15 @@ name = "quick-xml"
 version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -3832,6 +3907,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
+dependencies = [
+ "ashpd",
+ "block2",
+ "dispatch2",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "pollster",
+ "raw-window-handle",
+ "urlencoding",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4099,6 +4198,12 @@ dependencies = [
  "serde_derive_internals",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -6174,6 +6279,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016ccf01d1c58b6f8999612813e17c9b2390f7d70671428869913310f83f54b8"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
+dependencies = [
+ "bitflags 2.11.1",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.41.0",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7236,6 +7401,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
+ "url",
  "winnow 1.0.3",
  "zvariant_derive",
  "zvariant_utils",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -40,6 +40,7 @@ tauri-specta = { version = "=2.0.0-rc.21", features = ["derive", "typescript"] }
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 tauri-plugin-opener = "2"
+rfd = "0.15"
 cellar-core = { path = "../../../crates/cellar-core" }
 cellar-driver-convex = { path = "../../../crates/cellar-drivers/convex" }
 cellar-driver-cosmos = { path = "../../../crates/cellar-drivers/cosmos" }

--- a/apps/desktop/src-tauri/src/commands/export.rs
+++ b/apps/desktop/src-tauri/src/commands/export.rs
@@ -1,0 +1,38 @@
+//! Native save-dialog export for query result downloads (SPEC §9.1).
+//!
+//! The frontend formats CSV/TSV/JSON/SQL in TypeScript; this command only
+//! prompts for a destination and writes the bytes the user already approved.
+
+use cellar_core::error::CellarError;
+use tokio::fs;
+use tokio::task::spawn_blocking;
+
+/// Show a platform save dialog prefilled with `default_name`, then write
+/// `contents` to the chosen path. Returns `Ok(None)` when the user cancels.
+#[tauri::command]
+#[specta::specta]
+pub async fn save_text_file(
+    default_name: String,
+    contents: String,
+    filter_name: String,
+    filter_ext: String,
+) -> Result<Option<String>, CellarError> {
+    let chosen = spawn_blocking(move || {
+        rfd::FileDialog::new()
+            .set_file_name(&default_name)
+            .add_filter(&filter_name, &[filter_ext.as_str()])
+            .save_file()
+    })
+    .await
+    .map_err(|e| CellarError::Internal(format!("save dialog task failed: {e}")))?;
+
+    let Some(path) = chosen else {
+        return Ok(None);
+    };
+
+    fs::write(&path, contents.as_bytes())
+        .await
+        .map_err(|e| CellarError::Io(format!("failed to write {}: {e}", path.display())))?;
+
+    Ok(Some(path.to_string_lossy().into_owned()))
+}

--- a/apps/desktop/src-tauri/src/commands/export.rs
+++ b/apps/desktop/src-tauri/src/commands/export.rs
@@ -3,8 +3,12 @@
 //! The frontend formats CSV/TSV/JSON/SQL in TypeScript; this command only
 //! prompts for a destination and writes the bytes the user already approved.
 
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use cellar_core::error::CellarError;
 use tokio::fs;
+use tokio::io::AsyncWriteExt;
 use tokio::task::spawn_blocking;
 
 /// Show a platform save dialog prefilled with `default_name`, then write
@@ -30,9 +34,44 @@ pub async fn save_text_file(
         return Ok(None);
     };
 
-    fs::write(&path, contents.as_bytes())
-        .await
-        .map_err(|e| CellarError::Io(format!("failed to write {}: {e}", path.display())))?;
+    write_atomically(&path, contents.as_bytes()).await?;
 
     Ok(Some(path.to_string_lossy().into_owned()))
+}
+
+/// Write `contents` via a same-directory temp file, sync, then rename over
+/// `path` so a failed overwrite cannot leave a truncated destination.
+async fn write_atomically(path: &Path, contents: &[u8]) -> Result<(), CellarError> {
+    let tmp = temp_sibling(path);
+    let io = |e: std::io::Error| {
+        CellarError::Io(format!("failed to write {}: {e}", path.display()))
+    };
+
+    let write_result = async {
+        let mut file = fs::File::create(&tmp).await.map_err(&io)?;
+        file.write_all(contents).await.map_err(&io)?;
+        file.sync_all().await.map_err(&io)?;
+        drop(file);
+        fs::rename(&tmp, path).await.map_err(&io)?;
+        Ok(())
+    }
+    .await;
+
+    if write_result.is_err() {
+        let _ = fs::remove_file(&tmp).await;
+    }
+    write_result
+}
+
+fn temp_sibling(path: &Path) -> PathBuf {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let stem = path
+        .file_name()
+        .map(|n| n.to_string_lossy())
+        .unwrap_or_else(|| "export".into());
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    parent.join(format!(".{stem}.{}.{nanos}.tmp", std::process::id()))
 }

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -7,6 +7,7 @@
 
 pub mod ai;
 pub mod connection;
+pub mod export;
 pub mod history;
 pub mod query;
 pub mod schema;
@@ -52,6 +53,7 @@ pub fn builder() -> Builder<tauri::Wry> {
         templates::list_query_templates,
         templates::save_query_template,
         templates::delete_query_template,
+        export::save_text_file,
         ai::ai_store_key,
         ai::ai_load_key,
         ai::ai_delete_key,

--- a/apps/desktop/src/components/AIPanel.tsx
+++ b/apps/desktop/src/components/AIPanel.tsx
@@ -26,6 +26,7 @@ import {
 import { useQueryMessages } from "../state/queryMessages";
 import { queryResultSource, useTabResults } from "../state/tabResults";
 import { useBottomPanel } from "../state/bottomPanel";
+import { revealBottomPanel } from "../state/layout";
 import { useStatus } from "../state/status";
 
 const chipMeta: Record<AiContextChip["kind"], { icon: ReactNode; color: string }> = {
@@ -261,6 +262,7 @@ export function AIPanel({
     setRunningSql(true);
     const token = ++runSeq.current;
     if (!opts?.answerInPanel) {
+      revealBottomPanel();
       setBottomTab("results");
       useTabResults.getState().setLoading(scope.tabId, source);
       useQueryMessages

--- a/apps/desktop/src/components/BottomPanel.tsx
+++ b/apps/desktop/src/components/BottomPanel.tsx
@@ -1,9 +1,9 @@
 import { useMemo, useRef, useState, type ReactNode } from "react";
 import {
-  downloadText,
   exportFilename,
   exportText,
   EXPORT_FORMATS,
+  saveText,
 } from "../lib/export";
 import { ContextMenu, type ContextMenuState } from "./ContextMenu";
 
@@ -147,9 +147,9 @@ export function BottomPanel({ onClose }: { onClose: () => void }) {
           <div className="mx-1.5 h-[18px] w-px self-center bg-border-divider" />
           <HeaderMeta activeTab={activeTab} result={result} />
         </div>
-        <div className="flex items-center gap-px">
+        <div className="flex items-center gap-0.5 pr-0.5">
           <button
-            className={"icon-btn" + (exportable ? "" : " opacity-45")}
+            className="inline-flex h-6 w-6 items-center justify-center rounded-[4px] text-fg-2 transition-[background,color] duration-150 hover:bg-bg-3 hover:text-fg-0 disabled:cursor-default disabled:opacity-45 disabled:hover:bg-transparent disabled:hover:text-fg-2"
             disabled={!exportable}
             title={
               exportable
@@ -171,7 +171,7 @@ export function BottomPanel({ onClose }: { onClose: () => void }) {
                       columns: exportable.columns,
                       rows: exportable.rows,
                     };
-                    downloadText(
+                    void saveText(
                       exportFilename(label, format),
                       format,
                       exportText(format, view.columns, view.rows),
@@ -181,13 +181,21 @@ export function BottomPanel({ onClose }: { onClose: () => void }) {
               });
             }}
           >
-            <Icon.fileText size={11} />
+            <Icon.fileText size={15} />
           </button>
-          <button className="icon-btn opacity-45" disabled title="Pop out not implemented yet">
-            <Icon.expand size={11} />
+          <button
+            className="inline-flex h-6 w-6 items-center justify-center rounded-[4px] text-fg-2 opacity-45"
+            disabled
+            title="Pop out not implemented yet"
+          >
+            <Icon.expand size={15} />
           </button>
-          <button className="icon-btn" onClick={onClose} title="Hide">
-            <Icon.chevronsDown size={12} />
+          <button
+            className="inline-flex h-6 w-6 items-center justify-center rounded-[4px] text-fg-2 transition-[background,color] duration-150 hover:bg-bg-3 hover:text-fg-0"
+            onClick={onClose}
+            title="Hide"
+          >
+            <Icon.chevronsDown size={15} />
           </button>
         </div>
       </div>

--- a/apps/desktop/src/components/BottomPanel.tsx
+++ b/apps/desktop/src/components/BottomPanel.tsx
@@ -171,11 +171,31 @@ export function BottomPanel({ onClose }: { onClose: () => void }) {
                       columns: exportable.columns,
                       rows: exportable.rows,
                     };
-                    void saveText(
-                      exportFilename(label, format),
-                      format,
-                      exportText(format, view.columns, view.rows),
-                    );
+                    void (async () => {
+                      try {
+                        await saveText(
+                          exportFilename(label, format),
+                          format,
+                          exportText(format, view.columns, view.rows),
+                        );
+                      } catch (err) {
+                        const text =
+                          err instanceof Error ? err.message : String(err);
+                        if (!activeTab) {
+                          console.error("Export failed:", err);
+                          return;
+                        }
+                        useQueryMessages.getState().addMessage({
+                          tabId: activeTab.id,
+                          connectionId: activeTab.connectionId,
+                          database: activeTab.database || undefined,
+                          severity: "error",
+                          source: "client",
+                          text: `Export failed: ${text}`,
+                        });
+                        setActive("messages");
+                      }
+                    })();
                   },
                 })),
               });

--- a/apps/desktop/src/hooks/useQueryRunner.ts
+++ b/apps/desktop/src/hooks/useQueryRunner.ts
@@ -12,9 +12,11 @@ import {
   buildRunStartedMessage,
   type QueryRunContext,
 } from "../lib/queryMessages";
+import { useBottomPanel } from "../state/bottomPanel";
 import { useNotices } from "../state/notices";
 import { useQueryMessages } from "../state/queryMessages";
 import { noteConnectionIssue } from "../state/connections";
+import { revealBottomPanel } from "../state/layout";
 import { useStatus } from "../state/status";
 import type { QueryTab } from "../state/tabs";
 import { useTabs } from "../state/tabs";
@@ -145,6 +147,8 @@ export function useQueryRunner(tab: QueryTab): QueryRunner {
       setCancelRequested(false);
       setErrorLine(null);
       if (!append) {
+        revealBottomPanel();
+        useBottomPanel.getState().setActive("results");
         useTabResults.getState().setLoading(tab.id, source);
         useQueryMessages
           .getState()

--- a/apps/desktop/src/lib/export.ts
+++ b/apps/desktop/src/lib/export.ts
@@ -1,8 +1,10 @@
 import type { GridColumn, GridRow, GridValue } from "@cellar/data-grid";
+import { commands, isTauri, unwrap } from "@cellar/ipc";
 
 // Pure exporters from the grid's column/row shapes into portable text formats.
-// Shared by the bottom-panel "Export" button (file download) and the result
-// grid's "Copy as" context menu (clipboard), per SPEC §9.1.
+// Shared by the bottom-panel "Export" button (native save dialog / file
+// download) and the result grid's "Copy as" context menu (clipboard), per
+// SPEC §9.1.
 
 export type ExportFormat = "csv" | "tsv" | "json" | "sql";
 
@@ -167,7 +169,39 @@ export function exportFilename(label: string, format: ExportFormat): string {
   return `${base}.${EXTENSIONS[format]}`;
 }
 
-/** Trigger a browser-style download — same pattern as ExportSetupModal. */
+const FILTER_NAMES: Record<ExportFormat, string> = {
+  csv: "CSV",
+  tsv: "TSV",
+  json: "JSON",
+  sql: "SQL",
+};
+
+/**
+ * Ask where to save (native dialog in Tauri), then write the file. Falls back
+ * to a browser download in `pnpm dev:web`. Returns `false` if the user
+ * cancelled the dialog.
+ */
+export async function saveText(
+  filename: string,
+  format: ExportFormat,
+  contents: string,
+): Promise<boolean> {
+  if (isTauri) {
+    const path = await unwrap(
+      commands.saveTextFile(
+        filename,
+        contents,
+        FILTER_NAMES[format],
+        EXTENSIONS[format],
+      ),
+    );
+    return path != null;
+  }
+  downloadText(filename, format, contents);
+  return true;
+}
+
+/** Trigger a browser-style download — used by web mode and ExportSetupModal. */
 export function downloadText(
   filename: string,
   format: ExportFormat,

--- a/apps/desktop/src/state/layout.ts
+++ b/apps/desktop/src/state/layout.ts
@@ -50,3 +50,20 @@ export const useLayout = create<LayoutStore>()(
     },
   ),
 );
+
+const BOTTOM_MIN_HEIGHT = 140;
+
+/**
+ * Open the bottom panel at ~1/4 of the window height when it is currently
+ * closed. Used when a query run starts so results are visible without a
+ * manual toggle. Leaves an already-open panel's height alone.
+ */
+export function revealBottomPanel(quarterHeight = true): void {
+  const { panels, setPanel, setBottomHeight } = useLayout.getState();
+  if (panels.bottom) return;
+  setPanel("bottom", true);
+  if (!quarterHeight || typeof window === "undefined") return;
+  const target = Math.round(window.innerHeight / 4);
+  const max = Math.round(window.innerHeight * 0.7);
+  setBottomHeight(Math.max(BOTTOM_MIN_HEIGHT, Math.min(target, max)));
+}

--- a/apps/desktop/src/state/layout.ts
+++ b/apps/desktop/src/state/layout.ts
@@ -63,7 +63,9 @@ export function revealBottomPanel(quarterHeight = true): void {
   if (panels.bottom) return;
   setPanel("bottom", true);
   if (!quarterHeight || typeof window === "undefined") return;
-  const target = Math.round(window.innerHeight / 4);
-  const max = Math.round(window.innerHeight * 0.7);
-  setBottomHeight(Math.max(BOTTOM_MIN_HEIGHT, Math.min(target, max)));
+  const viewportHeight = Math.max(0, window.innerHeight);
+  const max = Math.round(viewportHeight * 0.7);
+  const min = Math.min(BOTTOM_MIN_HEIGHT, max);
+  const target = Math.round(viewportHeight / 4);
+  setBottomHeight(Math.min(max, Math.max(min, target)));
 }

--- a/packages/ipc/src/generated.ts
+++ b/packages/ipc/src/generated.ts
@@ -303,6 +303,18 @@ async deleteQueryTemplate(name: string) : Promise<Result<null, CellarError>> {
 }
 },
 /**
+ * Show a platform save dialog prefilled with `default_name`, then write
+ * `contents` to the chosen path. Returns `Ok(None)` when the user cancels.
+ */
+async saveTextFile(defaultName: string, contents: string, filterName: string, filterExt: string) : Promise<Result<string | null, CellarError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("save_text_file", { defaultName, contents, filterName, filterExt }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
  * Persist the API key for `provider` in the OS keychain, overwriting any
  * existing entry.
  */

--- a/packages/ipc/src/index.test.ts
+++ b/packages/ipc/src/index.test.ts
@@ -47,6 +47,7 @@ describe("@cellar/ipc", () => {
         "saveConnection",
         "saveQueryTemplate",
         "saveSchemaSnapshot",
+        "saveTextFile",
         "testConnection",
       ].sort(),
     );

--- a/packages/ipc/src/mock.ts
+++ b/packages/ipc/src/mock.ts
@@ -320,6 +320,14 @@ export const mockCommands = {
     mockTemplates.delete(name);
     return ok(null);
   },
+
+  // No native save dialog in web mode — callers fall back to a browser download.
+  saveTextFile: async (
+    _defaultName: string,
+    _contents: string,
+    _filterName: string,
+    _filterExt: string,
+  ): Promise<Result<string | null, CellarError>> => ok(null),
 };
 
 const mockAiKeys = new Map<string, string>();


### PR DESCRIPTION
## Summary
- Enlarge the bottom-panel export/hide action buttons so they are easier to hit.
- Prompt with a native save dialog for path and filename when exporting query results (CSV/TSV/JSON/SQL).
- Auto-open the bottom Results panel to about one-quarter window height when a query run starts and the panel was closed.

## Test plan
- [ ] Run a SELECT with the bottom panel closed and confirm it opens to ~1/4 height on Results
- [ ] Export results as CSV/JSON and confirm the save dialog asks for location and filename
- [ ] Cancel the save dialog and confirm no file is written
- [ ] Confirm export/hide icons look larger and remain usable in the bottom panel header


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native “Save As” dialogs for exporting query results in the desktop app.
  * Added browser-compatible download fallback for exports.
  * Query runs now automatically reveal the results panel and select the Results view.
  * Export controls and panel actions received visual and usability improvements.

* **Bug Fixes**
  * Ensured query results are visible when launched from the AI panel or query runner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->