### PR TITLE
feat: type-aware where-clause pickers for date and bool

### DIFF
--- a/apps/desktop/src/components/BottomResultsPanel.tsx
+++ b/apps/desktop/src/components/BottomResultsPanel.tsx
@@ -17,6 +17,7 @@ import {
 import { useSettings } from "../lib/settings";
 import { toCsv, toJson, toSqlInserts, toTsv } from "../lib/export";
 import { ContextMenu, type ContextMenuState } from "./ContextMenu";
+import { renderFilterValue, renderGridEditor } from "./grid/GridDateEditor";
 import { Icon } from "./icons";
 import { useTabs, type TableTab } from "../state/tabs";
 import { maxRowsLabel, resultContextLabel, rowCountLabel, type TabResult } from "../state/tabResults";
@@ -292,6 +293,8 @@ function ReadOnlyResultGrid({
           onFiltersChange={grid.setFilters}
           sort={grid.sort}
           onSortChange={grid.setSort}
+          renderEditor={renderGridEditor}
+          renderFilterValue={renderFilterValue}
           readOnly
           nullDisplay={settings.grid.nullDisplay}
           stripeRows={settings.grid.stripeRows}

--- a/apps/desktop/src/components/Workspace.tsx
+++ b/apps/desktop/src/components/Workspace.tsx
@@ -17,7 +17,7 @@ import {
 } from "react";
 
 import { SqlEditor } from "./SqlEditor";
-import { renderGridEditor } from "./grid/GridDateEditor";
+import { renderFilterValue, renderGridEditor } from "./grid/GridDateEditor";
 import { SchemaComparePane } from "./SchemaComparePane";
 import { ErDiagram } from "./er/ErDiagram";
 import {
@@ -531,6 +531,7 @@ function TableTabPane({
         editing={grid.editing}
         onEdit={grid.setEditing}
         renderEditor={renderGridEditor}
+        renderFilterValue={renderFilterValue}
         filters={grid.filters}
         onFiltersChange={grid.setFilters}
         quickFilter={quickFilter}

--- a/apps/desktop/src/components/grid/GridDateEditor.tsx
+++ b/apps/desktop/src/components/grid/GridDateEditor.tsx
@@ -1,14 +1,27 @@
 /**
- * A calendar-based inline editor for date / datetime grid cells, injected into
- * the data-grid via its `renderEditor` prop. The grid package is deliberately
- * dependency-free, so the heavier UI (react-day-picker — the library shadcn/ui
- * wraps) lives here in the desktop app where Tailwind and the design tokens are.
+ * A calendar-based picker for date / datetime / time values, injected into the
+ * data-grid via `renderEditor` (cells) and `renderFilterValue` (where-clause).
+ * The grid package is deliberately dependency-free, so the heavier UI
+ * (react-day-picker — the library shadcn/ui wraps) lives here in the desktop
+ * app where Tailwind and the design tokens are.
  *
  * It only claims date and timestamp columns; time/number/text fall back to the
- * grid's built-in editor (`renderGridEditor` returns null for those).
+ * grid's built-in controls (`renderGridEditor` / `renderFilterValue` return
+ * null for those).
  */
-import { nativeControl, type CellEditorProps } from "@cellar/data-grid";
-import { useLayoutEffect, useRef, useState } from "react";
+import {
+  nativeControl,
+  type CellEditorProps,
+  type FilterValueInputProps,
+  type GridColumn,
+} from "@cellar/data-grid";
+import {
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+  type Ref,
+} from "react";
 import { createPortal } from "react-dom";
 import { DayPicker } from "react-day-picker";
 
@@ -38,19 +51,42 @@ export function parseTime(raw: string): string {
 
 type Kind = "date" | "datetime" | "time";
 
+function kindForColumn(column: GridColumn): Kind | null {
+  // Probe with an empty value so a stale/unparseable draft still gets the
+  // calendar — same idea as the filter bar's native fallback.
+  const control = nativeControl(column, "");
+  if (control?.type === "date") return "date";
+  if (control?.type === "datetime-local") return "datetime";
+  if (control?.type === "time") return "time";
+  return null;
+}
+
+function formatCommitted(kind: Kind, date: Date | undefined, time: string): string | null {
+  if (kind === "time") return time;
+  if (!date) return null;
+  return kind === "datetime" ? `${ymd(date)}T${time}` : ymd(date);
+}
+
 /**
  * Returns the editor element when this column is a date/datetime/time, else
  * null so the grid uses its built-in editor. Wire as
  * `<DataGrid renderEditor={renderGridEditor} />`.
  */
 export function renderGridEditor(props: CellEditorProps) {
-  const initial = props.value == null ? "" : String(props.value);
-  const control = nativeControl(props.col, initial);
-  if (control?.type === "date") return <GridDateEditor {...props} kind="date" />;
-  if (control?.type === "datetime-local")
-    return <GridDateEditor {...props} kind="datetime" />;
-  if (control?.type === "time") return <GridDateEditor {...props} kind="time" />;
-  return null;
+  const kind = kindForColumn(props.col);
+  if (!kind) return null;
+  return <GridDateEditor {...props} kind={kind} />;
+}
+
+/**
+ * Same calendar for the filter-bar value slot. Wire as
+ * `<DataGrid renderFilterValue={renderFilterValue} />`.
+ */
+export function renderFilterValue(props: FilterValueInputProps): ReactNode {
+  const kind = kindForColumn(props.column);
+  if (!kind) return null;
+  // Key on column so switching date fields remounts a fresh picker state.
+  return <FilterDateValueInput key={props.column.key} {...props} kind={kind} />;
 }
 
 function GridDateEditor({
@@ -65,16 +101,13 @@ function GridDateEditor({
   const anchorRef = useRef<HTMLDivElement | null>(null);
 
   const commit = () => {
-    if (kind === "time") {
-      onCommit(time);
-      return;
-    }
-    if (!date) {
+    const next = formatCommitted(kind, date, time);
+    if (next == null) {
       // Nothing chosen — leave the cell unchanged.
       onCancel();
       return;
     }
-    onCommit(kind === "datetime" ? `${ymd(date)}T${time}` : ymd(date));
+    onCommit(next);
   };
 
   return (
@@ -83,39 +116,151 @@ function GridDateEditor({
         {initial || "—"}
       </div>
       <CalendarPopover anchorRef={anchorRef} onOutside={commit} onEscape={onCancel}>
-        {kind !== "time" && (
-          <DayPicker
-            mode="single"
-            selected={date}
-            onSelect={setDate}
-            defaultMonth={date}
-            showOutsideDays
-            autoFocus
-          />
-        )}
-        {kind !== "date" && (
-          <label className="grid-date-popover-time">
-            Time
-            <input
-              type="time"
-              step={1}
-              value={time}
-              autoFocus={kind === "time"}
-              onChange={(e) => setTime(e.target.value || "00:00:00")}
-            />
-          </label>
-        )}
-        <div className="grid-date-popover-actions">
-          <button type="button" className="gdp-cancel" onClick={onCancel}>
-            Cancel
-          </button>
-          <button type="button" className="gdp-apply" onClick={commit}>
-            Apply
-          </button>
-        </div>
+        <DatePickerBody
+          kind={kind}
+          date={date}
+          time={time}
+          onDateChange={setDate}
+          onTimeChange={setTime}
+          onCommit={commit}
+          onCancel={onCancel}
+        />
       </CalendarPopover>
     </>
   );
+}
+
+function FilterDateValueInput({
+  value,
+  onChange,
+  anchorRef: externalAnchorRef,
+  kind,
+}: FilterValueInputProps & { kind: Kind }) {
+  const [open, setOpen] = useState(true);
+  const [date, setDate] = useState<Date | undefined>(() => parseDate(value));
+  const [time, setTime] = useState(() => parseTime(value));
+  const localAnchorRef = useRef<HTMLButtonElement | null>(null);
+
+  const setAnchorRefs = (node: HTMLButtonElement | null) => {
+    localAnchorRef.current = node;
+    assignRef(externalAnchorRef, node);
+  };
+
+  const openPicker = () => {
+    setDate(parseDate(value));
+    setTime(parseTime(value));
+    setOpen(true);
+  };
+
+  const commit = () => {
+    const next = formatCommitted(kind, date, time);
+    if (next != null) onChange(next);
+    setOpen(false);
+  };
+
+  const cancel = () => setOpen(false);
+
+  const placeholder =
+    kind === "time" ? "time" : kind === "datetime" ? "date & time" : "date";
+
+  return (
+    <>
+      <button
+        ref={setAnchorRefs}
+        type="button"
+        className={`grid-filter-input mono grid-filter-date-trigger grid-filter-input-${
+          kind === "datetime" ? "datetime-local" : kind
+        }`}
+        onClick={openPicker}
+        aria-label="Filter value"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+      >
+        <span className={value ? undefined : "grid-filter-date-placeholder"}>
+          {value || placeholder}
+        </span>
+      </button>
+      {open && (
+        <CalendarPopover
+          anchorRef={localAnchorRef}
+          onOutside={commit}
+          onEscape={cancel}
+        >
+          <DatePickerBody
+            kind={kind}
+            date={date}
+            time={time}
+            onDateChange={setDate}
+            onTimeChange={setTime}
+            onCommit={commit}
+            onCancel={cancel}
+          />
+        </CalendarPopover>
+      )}
+    </>
+  );
+}
+
+function DatePickerBody({
+  kind,
+  date,
+  time,
+  onDateChange,
+  onTimeChange,
+  onCommit,
+  onCancel,
+}: {
+  kind: Kind;
+  date: Date | undefined;
+  time: string;
+  onDateChange: (next: Date | undefined) => void;
+  onTimeChange: (next: string) => void;
+  onCommit: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <>
+      {kind !== "time" && (
+        <DayPicker
+          mode="single"
+          selected={date}
+          onSelect={onDateChange}
+          defaultMonth={date}
+          showOutsideDays
+          autoFocus
+        />
+      )}
+      {kind !== "date" && (
+        <label className="grid-date-popover-time">
+          Time
+          <input
+            type="time"
+            step={1}
+            value={time}
+            autoFocus={kind === "time"}
+            onChange={(e) => onTimeChange(e.target.value || "00:00:00")}
+          />
+        </label>
+      )}
+      <div className="grid-date-popover-actions">
+        <button type="button" className="gdp-cancel" onClick={onCancel}>
+          Cancel
+        </button>
+        <button type="button" className="gdp-apply" onClick={onCommit}>
+          Apply
+        </button>
+      </div>
+    </>
+  );
+}
+
+function assignRef<T>(ref: Ref<T> | undefined, value: T) {
+  if (!ref) return;
+  if (typeof ref === "function") {
+    ref(value);
+    return;
+  }
+  (ref as { current: T }).current = value;
 }
 
 /**

--- a/apps/desktop/src/styles/grid.css
+++ b/apps/desktop/src/styles/grid.css
@@ -346,6 +346,33 @@
   width: 132px;
   padding: 0 6px;
 }
+.grid-filter-input-date,
+.grid-filter-input-time {
+  width: 132px;
+  color-scheme: inherit;
+}
+.grid-filter-input-datetime-local {
+  width: 196px;
+  color-scheme: inherit;
+}
+.grid-filter-bool-select {
+  width: 72px;
+  max-width: 72px;
+}
+.grid-filter-date-trigger {
+  display: inline-flex;
+  align-items: center;
+  cursor: default;
+  text-align: left;
+}
+.grid-filter-date-trigger:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent-line);
+  outline: none;
+}
+.grid-filter-date-placeholder {
+  color: var(--fg-3);
+}
 .grid-filter-select:focus,
 .grid-filter-input:focus {
   border-color: var(--accent);

--- a/packages/data-grid/src/DataGrid.tsx
+++ b/packages/data-grid/src/DataGrid.tsx
@@ -41,7 +41,11 @@ import {
   shouldVirtualizeRows,
 } from "./virtualRows";
 
-export type { CellEditorRenderer, DataGridProps } from "./DataGridProps";
+export type {
+  CellEditorRenderer,
+  DataGridProps,
+  FilterValueRenderer,
+} from "./DataGridProps";
 export { calculateVirtualRows, shouldVirtualizeRows } from "./virtualRows";
 export { useGridState, type UseGridStateOptions } from "./useGridState";
 
@@ -106,6 +110,7 @@ export function DataGrid({
   nullDisplay = "NULL",
   renderers = defaultRendererRegistry,
   renderEditor,
+  renderFilterValue,
   saveBlob,
   stripeRows = false,
   onCellContextMenu,
@@ -599,6 +604,7 @@ export function DataGrid({
         sort={activeSort}
         onSortChange={applySort}
         savedFilters={savedFilters}
+        renderFilterValue={renderFilterValue}
       />
 
       <div

--- a/packages/data-grid/src/DataGridProps.tsx
+++ b/packages/data-grid/src/DataGridProps.tsx
@@ -3,7 +3,10 @@ import type {
   ReactNode,
 } from "react";
 import type { CellEditorProps } from "./Cell";
-import type { SavedFilterControls } from "./FilterBar";
+import type {
+  FilterValueRenderer,
+  SavedFilterControls,
+} from "./FilterBar";
 import type { RendererRegistry, SaveBlob } from "./renderers/types";
 import type {
   CellAddress,
@@ -21,6 +24,8 @@ import type {
  * built-in editor. See {@link DataGridProps.renderEditor}.
  */
 export type CellEditorRenderer = (props: CellEditorProps) => ReactNode | null;
+
+export type { FilterValueRenderer };
 
 export type DataGridProps = {
   columns: readonly GridColumn[];
@@ -92,6 +97,13 @@ export type DataGridProps = {
    * its UI dependencies into this dependency-free package.
    */
   renderEditor?: CellEditorRenderer;
+
+  /**
+   * Optional override for the filter-bar value control. Same calendar/host
+   * injection pattern as {@link renderEditor}; return `null` to keep the
+   * built-in bool select / native date / text input.
+   */
+  renderFilterValue?: FilterValueRenderer;
 
   /** Override how a renderer persists binary payloads (e.g. a native dialog). */
   saveBlob?: SaveBlob;

--- a/packages/data-grid/src/FilterBar.tsx
+++ b/packages/data-grid/src/FilterBar.tsx
@@ -1,6 +1,16 @@
-import { useEffect, useMemo, useRef, useState } from "react";
 import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+  type Ref,
+} from "react";
+import { nativeControl } from "./Cell";
+import {
+  columnCategory,
   createFilterId,
+  defaultFilterValue,
   filterNeedsValue,
   filterOperatorLabel,
   filterValuePreview,
@@ -18,6 +28,55 @@ import type {
   GridColumn,
   SortState,
 } from "./types";
+
+const BOOL_FILTER_OPTIONS = [
+  { value: "true", label: "true" },
+  { value: "false", label: "false" },
+] as const;
+
+/**
+ * Props for a host-supplied filter value control. Return an element to take over
+ * the value slot (e.g. the app calendar picker), or `null` to use the built-in
+ * control for that column.
+ */
+export type FilterValueInputProps = {
+  column: GridColumn;
+  value: string;
+  onChange: (value: string) => void;
+  /** Attach to the focusable trigger so the composer can focus the value slot. */
+  anchorRef?: Ref<HTMLElement | null>;
+};
+
+export type FilterValueRenderer = (
+  props: FilterValueInputProps,
+) => ReactNode | null;
+
+/**
+ * Native date/time control for the filter composer. Always returns a picker for
+ * temporal columns (even when the current draft value isn't parseable — the
+ * input shows empty until the user picks). Used when the host does not supply
+ * {@link FilterBarProps.renderFilterValue}.
+ */
+function filterTemporalControl(
+  column: GridColumn,
+  value: string,
+): { type: "date" | "datetime-local" | "time"; step?: string; value: string } | null {
+  const blank = nativeControl(column, "");
+  if (
+    !blank ||
+    (blank.type !== "date" &&
+      blank.type !== "datetime-local" &&
+      blank.type !== "time")
+  ) {
+    return null;
+  }
+  const parsed = nativeControl(column, value);
+  return {
+    type: blank.type,
+    step: blank.step,
+    value: parsed?.value ?? "",
+  };
+}
 
 type ComposerDraft = {
   id: string | null;
@@ -64,6 +123,12 @@ export type FilterBarProps = {
   onSortChange?: (next: SortState) => void;
   /** Saved filter presets. Hidden when omitted. */
   savedFilters?: SavedFilterControls;
+  /**
+   * Optional override for the filter value control. Same idea as the grid's
+   * `renderEditor`: return an element to take over (e.g. the app calendar), or
+   * `null` to keep the built-in bool/native-date/text control.
+   */
+  renderFilterValue?: FilterValueRenderer;
 };
 
 export function FilterBar({
@@ -80,10 +145,13 @@ export function FilterBar({
   sort,
   onSortChange,
   savedFilters,
+  renderFilterValue,
 }: FilterBarProps) {
   const [draft, setDraft] = useState<ComposerDraft | null>(null);
   const columnRef = useRef<HTMLButtonElement | null>(null);
   const valueRef = useRef<HTMLInputElement | null>(null);
+  const valueSelectRef = useRef<HTMLButtonElement | null>(null);
+  const valueAnchorRef = useRef<HTMLElement | null>(null);
   const columnsByKey = useMemo(
     () => new Map(columns.map((column) => [column.key, column])),
     [columns],
@@ -97,8 +165,21 @@ export function FilterBar({
     if (!draft) return;
     const column = columnsByKey.get(draft.columnKey);
     if (column && filterNeedsValue(draft.operator)) {
+      if (columnCategory(column) === "bool") {
+        valueSelectRef.current?.focus();
+        return;
+      }
+      if (valueAnchorRef.current) {
+        valueAnchorRef.current.focus();
+        return;
+      }
       valueRef.current?.focus();
-      valueRef.current?.select();
+      // select() throws on date/time/number inputs — same guard as CellEditor.
+      try {
+        valueRef.current?.select();
+      } catch {
+        /* non-text native control */
+      }
       return;
     }
     columnRef.current?.focus();
@@ -112,7 +193,7 @@ export function FilterBar({
       id: null,
       columnKey: first.key,
       operator,
-      value: "",
+      value: defaultFilterValue(first),
       logic: "and",
     });
   };
@@ -134,7 +215,13 @@ export function FilterBar({
     if (!column) return;
     const operator = nextOperatorForColumn(column, draft.operator);
     const needsValue = filterNeedsValue(operator);
-    const value = draft.value.trim();
+    // Bool picker always resolves to true/false; other controls use the trimmed draft.
+    const value =
+      columnCategory(column) === "bool"
+        ? draft.value === "false"
+          ? "false"
+          : "true"
+        : draft.value.trim();
     if (needsValue && value.length === 0) return;
 
     const clause: FilterClause = {
@@ -175,8 +262,26 @@ export function FilterBar({
   const draftColumn = draft ? columnsByKey.get(draft.columnKey) : null;
   const draftOperators = draftColumn ? operatorsForColumn(draftColumn) : [];
   const needsValue = draft ? filterNeedsValue(draft.operator) : false;
+  const draftCategory = draftColumn ? columnCategory(draftColumn) : null;
+  const customValue =
+    needsValue && draft && draftColumn && renderFilterValue
+      ? renderFilterValue({
+          column: draftColumn,
+          value: draft.value,
+          onChange: (next) => setDraft({ ...draft, value: next }),
+          anchorRef: valueAnchorRef,
+        })
+      : null;
+  const temporalControl =
+    !customValue && draftColumn && draftCategory === "date"
+      ? filterTemporalControl(draftColumn, draft?.value ?? "")
+      : null;
   const canApply =
-    !!draft && !!draftColumn && (!needsValue || draft.value.trim().length > 0);
+    !!draft &&
+    !!draftColumn &&
+    (!needsValue ||
+      draftCategory === "bool" ||
+      draft.value.trim().length > 0);
 
   // Quick filter targets a single text-ish column (one that accepts `contains`).
   const textColumns = useMemo(
@@ -348,7 +453,14 @@ export function FilterBar({
                 const nextColumn = columnsByKey.get(next);
                 if (!nextColumn) return;
                 const operator = nextOperatorForColumn(nextColumn, draft.operator);
-                setDraft({ ...draft, columnKey: nextColumn.key, operator });
+                setDraft({
+                  ...draft,
+                  columnKey: nextColumn.key,
+                  operator,
+                  // Column type drives the value control — reset so stale text
+                  // doesn't linger in a bool/date picker.
+                  value: defaultFilterValue(nextColumn),
+                });
               }}
               aria-label="Filter column"
             />
@@ -370,7 +482,32 @@ export function FilterBar({
               }
               aria-label="Filter operator"
             />
-            {needsValue && (
+            {needsValue && draftCategory === "bool" && (
+              <GridSelect
+                ref={valueSelectRef}
+                className="grid-filter-bool-select"
+                value={draft.value === "false" ? "false" : "true"}
+                options={BOOL_FILTER_OPTIONS}
+                onChange={(next) => setDraft({ ...draft, value: next })}
+                aria-label="Filter value"
+              />
+            )}
+            {needsValue && draftCategory !== "bool" && customValue}
+            {needsValue && draftCategory !== "bool" && !customValue && temporalControl && (
+              <input
+                ref={valueRef}
+                className={`grid-filter-input mono grid-filter-input-${temporalControl.type}`}
+                type={temporalControl.type}
+                step={temporalControl.step}
+                value={temporalControl.value}
+                onChange={(e) => setDraft({ ...draft, value: e.target.value })}
+                aria-label="Filter value"
+              />
+            )}
+            {needsValue &&
+              draftCategory !== "bool" &&
+              !customValue &&
+              !temporalControl && (
               <input
                 ref={valueRef}
                 className="grid-filter-input mono"

--- a/packages/data-grid/src/filters.test.ts
+++ b/packages/data-grid/src/filters.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  columnCategory,
+  defaultFilterValue,
   evaluateFilterClause,
   filterRows,
   operatorsForColumn,
@@ -120,6 +122,26 @@ describe("operatorsForColumn", () => {
   it("adds null operators only for nullable columns", () => {
     expect(operatorsForColumn(columns[2]!)).toContain("isNull");
     expect(operatorsForColumn(columns[0]!)).not.toContain("isNull");
+  });
+});
+
+describe("columnCategory / defaultFilterValue", () => {
+  it("classifies bool and temporal columns for typed value controls", () => {
+    expect(columnCategory(columns[4]!)).toBe("bool");
+    expect(columnCategory(columns[3]!)).toBe("date");
+    expect(columnCategory({ key: "d", name: "d", type: "date", width: 80 })).toBe(
+      "date",
+    );
+    expect(
+      columnCategory({ key: "t", name: "t", type: "datetime2", width: 80 }),
+    ).toBe("date");
+    expect(columnCategory(columns[0]!)).toBe("text");
+  });
+
+  it("defaults bool filters to true and others to empty", () => {
+    expect(defaultFilterValue(columns[4]!)).toBe("true");
+    expect(defaultFilterValue(columns[3]!)).toBe("");
+    expect(defaultFilterValue(columns[0]!)).toBe("");
   });
 });
 

--- a/packages/data-grid/src/filters.ts
+++ b/packages/data-grid/src/filters.ts
@@ -206,7 +206,7 @@ function displayValue(
 function compareOrdered(
   value: GridRow[string],
   needle: string,
-  category: ReturnType<typeof columnCategory>,
+  category: ColumnCategory,
   operator: "greaterThan" | "greaterThanOrEqual" | "lessThan" | "lessThanOrEqual",
 ): boolean {
   if (value === null || value === undefined) return false;
@@ -254,9 +254,9 @@ function likeMatch(value: string, pattern: string): boolean {
   return new RegExp(`^${regex}$`).test(value);
 }
 
-function columnCategory(
-  column: GridColumn,
-): "text" | "number" | "date" | "bool" | "unknown" {
+export type ColumnCategory = "text" | "number" | "date" | "bool" | "unknown";
+
+export function columnCategory(column: GridColumn): ColumnCategory {
   if (column.enum) return "text";
   const type = column.type.toLowerCase();
   if (BOOL_TYPES.some((t) => type.includes(t))) return "bool";
@@ -264,6 +264,11 @@ function columnCategory(
   if (DATE_TYPES.some((t) => type.includes(t))) return "date";
   if (TEXT_TYPES.some((t) => type.includes(t))) return "text";
   return "unknown";
+}
+
+/** Initial composer value when the user picks a column (or opens Add). */
+export function defaultFilterValue(column: GridColumn): string {
+  return columnCategory(column) === "bool" ? "true" : "";
 }
 
 function normalizeString(value: GridRow[string]): string {

--- a/packages/data-grid/src/index.ts
+++ b/packages/data-grid/src/index.ts
@@ -24,7 +24,9 @@ export { applyCellChange } from "./changes";
 export { countChanges, statusDotColor, statusTextColor } from "./status";
 export {
   FILTER_OPERATORS,
+  columnCategory,
   createFilterId,
+  defaultFilterValue,
   evaluateFilterClause,
   filterNeedsValue,
   filterOperatorLabel,
@@ -34,6 +36,7 @@ export {
   normalizeLikePattern,
   operatorsForColumn,
   rowMatchesFilters,
+  type ColumnCategory,
 } from "./filters";
 export { compareGridValues, cycleSortState, sortGridRows } from "./sort";
 export {
@@ -52,6 +55,8 @@ export {
 export {
   FilterBar,
   type FilterBarProps,
+  type FilterValueInputProps,
+  type FilterValueRenderer,
   type SavedFilterControls,
 } from "./FilterBar";
 export { PendingBar, type PendingBarProps } from "./PendingBar";


### PR DESCRIPTION
## Summary
- Where-clause values for boolean columns use a true/false select instead of free text.
- Date/time/timestamp filter values use the same DayPicker popover as cell editing (via a new `renderFilterValue` injection, with native inputs as fallback).
- Wired through table tabs and the read-only results grid so both surfaces stay consistent.

## Test plan
- [ ] Add a where filter on a bool column and confirm only true/false can be chosen
- [ ] Add a where filter on a date/timestamp column and confirm the app calendar (not the OS picker) opens
- [ ] Apply the filter and confirm matching rows / chip preview look correct
- [ ] Switch between text, bool, and date columns in the composer and confirm the value control resets appropriately


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added improved date, time, and date-time filtering controls.
  - Added boolean filter selection with clearer true/false options.
  - Enabled customized filter value controls for grid views.

- **Bug Fixes**
  - Improved filter defaults when switching between column types.
  - Standardized date and time value formatting when editing or filtering.
  - Enhanced focus behavior and visual styling for filter controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->