### PR TITLE
feat: add DeepSeek AI provider

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -79,7 +79,7 @@ Cellar is **not** aimed at non-technical business users. The UI assumes you unde
 | DB drivers | `sqlx` (Postgres, MySQL, SQLite), `tiberius` (SQL Server) | Mature, async, dialect-aware |
 | IPC type generation | `specta` + `tauri-specta` | End hand-syncing types between Rust and TS |
 | Credential storage | OS keychain via `keyring` crate, fallback to encrypted file | Standard, secure |
-| AI providers | Provider adapters plus typed Tauri IPC for privileged auth | Most providers can use direct HTTP; OpenAI keys and ChatGPT OAuth stay out of the webview |
+| AI providers | Provider adapters plus typed Tauri IPC for privileged auth | Backend providers keep API keys and OAuth credentials out of the webview |
 | Telemetry | None by default. Opt-in only, self-hosted endpoint configurable. | Trust |
 | Package management | pnpm workspaces + Cargo workspaces | Two ecosystems, two tools |
 | Monorepo orchestration | Turborepo | Just enough, no Nx complexity |
@@ -361,6 +361,7 @@ AI is a first-class feature, not an afterthought. It lives in the right panel an
 
 - Anthropic (Claude models)
 - OpenAI (GPT models)
+- DeepSeek (V4 models)
 - Ollama (any local model)
 - Custom OpenAI-compatible endpoints (Together, Groq, etc.)
 
@@ -372,6 +373,10 @@ OpenAI supports two authentication modes:
 - **ChatGPT sign-in** — subscription access through a local Codex app-server browser or device-code OAuth flow. Codex owns token storage and refresh in the OS keychain.
 
 See `docs/architecture/adr/0002-openai-auth.md` for the trust boundary and runtime constraints.
+
+DeepSeek uses a backend-only API key and the provider's OpenAI-compatible Chat
+Completions API. Models are discovered live, and thinking mode is an explicit
+provider setting. See `docs/architecture/adr/0003-deepseek-provider.md`.
 
 #### Modes
 
@@ -542,7 +547,7 @@ Driver authoring guide: `docs/drivers/writing-a-driver.md`.
 
 #### AI providers
 
-An AI provider implements the `AiProvider` interface from `packages/ai`. First-party: Anthropic, OpenAI, Ollama. Community providers register via the plugin SDK. A first-party provider may use typed Rust IPC when its credentials or supported authentication flow should not enter the renderer; OpenAI is the first such provider.
+An AI provider implements the `AiProvider` interface from `packages/ai`. First-party: Anthropic, OpenAI, DeepSeek, Ollama. Community providers register via the plugin SDK. A first-party provider may use typed Rust IPC when its credentials or supported authentication flow should not enter the renderer; OpenAI and DeepSeek use this boundary today.
 
 #### Exporters
 

--- a/apps/desktop/src-tauri/src/ai_backend/chat_completions.rs
+++ b/apps/desktop/src-tauri/src/ai_backend/chat_completions.rs
@@ -1,0 +1,242 @@
+use cellar_core::error::{CellarError, CellarResult};
+use serde_json::{json, Value};
+
+use super::{
+    AiThinkingMode, BackendAiGenerateRequest, BackendAiGenerateResult, BackendAiModel,
+    BackendAiTokenUsage, ProviderConfig,
+};
+
+pub(super) async fn list_models(
+    client: &reqwest::Client,
+    config: ProviderConfig,
+    api_key: &str,
+) -> CellarResult<Vec<BackendAiModel>> {
+    let response = client
+        .get(format!("{}/models", config.base_url))
+        .bearer_auth(api_key)
+        .send()
+        .await
+        .map_err(|error| network_error(config, error))?;
+    let status = response.status();
+    let body = response
+        .json::<Value>()
+        .await
+        .map_err(|error| network_error(config, error))?;
+    if !status.is_success() {
+        return Err(provider_error(
+            config,
+            status.as_u16(),
+            &body,
+            "Failed to list models",
+        ));
+    }
+    parse_models(&body)
+}
+
+pub(super) async fn generate(
+    client: &reqwest::Client,
+    config: ProviderConfig,
+    api_key: &str,
+    request: BackendAiGenerateRequest,
+) -> CellarResult<BackendAiGenerateResult> {
+    let payload = chat_payload(config, &request);
+    let response = client
+        .post(format!("{}/chat/completions", config.base_url))
+        .bearer_auth(api_key)
+        .json(&payload)
+        .send()
+        .await
+        .map_err(|error| network_error(config, error))?;
+    let status = response.status();
+    let body = response
+        .json::<Value>()
+        .await
+        .map_err(|error| network_error(config, error))?;
+    if !status.is_success() {
+        return Err(provider_error(
+            config,
+            status.as_u16(),
+            &body,
+            "Generation failed",
+        ));
+    }
+    parse_generation(config, &body)
+}
+
+fn chat_payload(config: ProviderConfig, request: &BackendAiGenerateRequest) -> Value {
+    let mut messages = Vec::with_capacity(request.messages.len() + 1);
+    if let Some(instruction) = request
+        .system_instruction
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        messages.push(json!({ "role": "system", "content": instruction }));
+    }
+    messages.extend(request.messages.iter().filter_map(|message| {
+        let content = message.content.trim();
+        if content.is_empty() {
+            return None;
+        }
+        let role = match message.role.as_str() {
+            "model" | "assistant" => "assistant",
+            _ => "user",
+        };
+        Some(json!({ "role": role, "content": content }))
+    }));
+
+    let mut payload = json!({
+        "model": request.model,
+        "messages": messages,
+        "stream": false
+    });
+    if config.supports_thinking {
+        if let Some(mode) = request.thinking {
+            payload["thinking"] = json!({
+                "type": match mode {
+                    AiThinkingMode::Enabled => "enabled",
+                    AiThinkingMode::Disabled => "disabled",
+                }
+            });
+        }
+    }
+    payload
+}
+
+fn parse_models(body: &Value) -> CellarResult<Vec<BackendAiModel>> {
+    let data = body
+        .get("data")
+        .and_then(Value::as_array)
+        .ok_or_else(|| CellarError::decode("Provider model response did not include data"))?;
+    let mut models = data
+        .iter()
+        .filter_map(|item| item.get("id").and_then(Value::as_str))
+        .map(|id| BackendAiModel {
+            id: id.to_string(),
+            label: id.to_string(),
+            description: None,
+            is_default: false,
+        })
+        .collect::<Vec<_>>();
+    models.sort_by(|a, b| a.id.cmp(&b.id));
+    models.dedup_by(|a, b| a.id == b.id);
+    Ok(models)
+}
+
+fn parse_generation(config: ProviderConfig, body: &Value) -> CellarResult<BackendAiGenerateResult> {
+    let text = body
+        .pointer("/choices/0/message/content")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    if text.trim().is_empty() {
+        return Err(CellarError::query(format!(
+            "{} returned an empty response",
+            config.label
+        )));
+    }
+    let usage = body.get("usage").map(|usage| BackendAiTokenUsage {
+        prompt_tokens: value_u64(usage, "prompt_tokens"),
+        completion_tokens: value_u64(usage, "completion_tokens"),
+        total_tokens: value_u64(usage, "total_tokens"),
+    });
+    Ok(BackendAiGenerateResult { text, usage })
+}
+
+fn value_u64(value: &Value, field: &str) -> u64 {
+    value.get(field).and_then(Value::as_u64).unwrap_or(0)
+}
+
+fn network_error(config: ProviderConfig, error: reqwest::Error) -> CellarError {
+    if error.is_timeout() {
+        CellarError::Timeout(format!("The {} request timed out.", config.label))
+    } else {
+        CellarError::Connection(format!("{} request failed: {error}", config.label))
+    }
+}
+
+fn provider_error(
+    config: ProviderConfig,
+    status: u16,
+    body: &Value,
+    fallback: &str,
+) -> CellarError {
+    let message = body
+        .pointer("/error/message")
+        .and_then(Value::as_str)
+        .unwrap_or(fallback);
+    match status {
+        401 | 403 => CellarError::Authentication(message.into()),
+        408 => CellarError::Timeout(message.into()),
+        _ => CellarError::Query(format!("{}: {message} (HTTP {status})", config.label)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{chat_payload, parse_generation, parse_models};
+    use crate::ai_backend::{
+        AiThinkingMode, BackendAiChatMessage, BackendAiGenerateRequest, BackendAiProvider,
+    };
+    use serde_json::json;
+
+    #[test]
+    fn discovers_models_without_a_hardcoded_allowlist() {
+        let models = parse_models(&json!({
+            "data": [
+                { "id": "deepseek-v4-pro" },
+                { "id": "deepseek-v4-flash" },
+                { "id": "future-model" }
+            ]
+        }))
+        .unwrap();
+        assert_eq!(
+            models
+                .iter()
+                .map(|model| model.id.as_str())
+                .collect::<Vec<_>>(),
+            ["deepseek-v4-flash", "deepseek-v4-pro", "future-model"]
+        );
+    }
+
+    #[test]
+    fn builds_role_aware_payload_with_thinking_mode() {
+        let request = BackendAiGenerateRequest {
+            model: "deepseek-v4-pro".into(),
+            messages: vec![
+                BackendAiChatMessage {
+                    role: "user".into(),
+                    content: "question".into(),
+                },
+                BackendAiChatMessage {
+                    role: "model".into(),
+                    content: "answer".into(),
+                },
+            ],
+            system_instruction: Some("be useful".into()),
+            thinking: Some(AiThinkingMode::Disabled),
+        };
+        let payload = chat_payload(BackendAiProvider::Deepseek.config(), &request);
+        assert_eq!(payload["thinking"]["type"], "disabled");
+        assert_eq!(payload["messages"][0]["role"], "system");
+        assert_eq!(payload["messages"][2]["role"], "assistant");
+    }
+
+    #[test]
+    fn extracts_text_and_usage() {
+        let result = parse_generation(
+            BackendAiProvider::Deepseek.config(),
+            &json!({
+                "choices": [{ "message": { "content": "SELECT 1" } }],
+                "usage": {
+                    "prompt_tokens": 4,
+                    "completion_tokens": 2,
+                    "total_tokens": 6
+                }
+            }),
+        )
+        .unwrap();
+        assert_eq!(result.text, "SELECT 1");
+        assert_eq!(result.usage.unwrap().total_tokens, 6);
+    }
+}

--- a/apps/desktop/src-tauri/src/ai_backend/chat_completions.rs
+++ b/apps/desktop/src-tauri/src/ai_backend/chat_completions.rs
@@ -17,19 +17,7 @@ pub(super) async fn list_models(
         .send()
         .await
         .map_err(|error| network_error(config, error))?;
-    let status = response.status();
-    let body = response
-        .json::<Value>()
-        .await
-        .map_err(|error| network_error(config, error))?;
-    if !status.is_success() {
-        return Err(provider_error(
-            config,
-            status.as_u16(),
-            &body,
-            "Failed to list models",
-        ));
-    }
+    let body = response_json(response, config, "Failed to list models").await?;
     parse_models(&body)
 }
 
@@ -47,20 +35,35 @@ pub(super) async fn generate(
         .send()
         .await
         .map_err(|error| network_error(config, error))?;
+    let body = response_json(response, config, "Generation failed").await?;
+    parse_generation(config, &body)
+}
+
+async fn response_json(
+    response: reqwest::Response,
+    config: ProviderConfig,
+    failure_fallback: &str,
+) -> CellarResult<Value> {
     let status = response.status();
-    let body = response
-        .json::<Value>()
+    let text = response
+        .text()
         .await
         .map_err(|error| network_error(config, error))?;
     if !status.is_success() {
+        let body = serde_json::from_str::<Value>(&text).ok();
         return Err(provider_error(
             config,
             status.as_u16(),
-            &body,
-            "Generation failed",
+            body.as_ref(),
+            failure_fallback,
         ));
     }
-    parse_generation(config, &body)
+    serde_json::from_str(&text).map_err(|error| {
+        CellarError::decode(format!(
+            "Could not decode the {} response: {error}",
+            config.label
+        ))
+    })
 }
 
 fn chat_payload(config: ProviderConfig, request: &BackendAiGenerateRequest) -> Value {
@@ -158,11 +161,11 @@ fn network_error(config: ProviderConfig, error: reqwest::Error) -> CellarError {
 fn provider_error(
     config: ProviderConfig,
     status: u16,
-    body: &Value,
+    body: Option<&Value>,
     fallback: &str,
 ) -> CellarError {
     let message = body
-        .pointer("/error/message")
+        .and_then(|body| body.pointer("/error/message"))
         .and_then(Value::as_str)
         .unwrap_or(fallback);
     match status {
@@ -174,10 +177,11 @@ fn provider_error(
 
 #[cfg(test)]
 mod tests {
-    use super::{chat_payload, parse_generation, parse_models};
+    use super::{chat_payload, parse_generation, parse_models, provider_error};
     use crate::ai_backend::{
         AiThinkingMode, BackendAiChatMessage, BackendAiGenerateRequest, BackendAiProvider,
     };
+    use cellar_core::error::CellarError;
     use serde_json::json;
 
     #[test]
@@ -238,5 +242,22 @@ mod tests {
         .unwrap();
         assert_eq!(result.text, "SELECT 1");
         assert_eq!(result.usage.unwrap().total_tokens, 6);
+    }
+
+    #[test]
+    fn preserves_status_when_provider_error_is_not_json() {
+        let config = BackendAiProvider::Deepseek.config();
+        let authentication = provider_error(config, 401, None, "Generation failed");
+        assert!(matches!(
+            authentication,
+            CellarError::Authentication(message) if message == "Generation failed"
+        ));
+
+        let provider = provider_error(config, 502, None, "Generation failed");
+        assert!(matches!(
+            provider,
+            CellarError::Query(message)
+                if message == "DeepSeek: Generation failed (HTTP 502)"
+        ));
     }
 }

--- a/apps/desktop/src-tauri/src/ai_backend/mod.rs
+++ b/apps/desktop/src-tauri/src/ai_backend/mod.rs
@@ -1,0 +1,136 @@
+//! Backend-only transports for API-key AI providers.
+//!
+//! Provider keys are loaded from `cellar-secrets` and never cross into the
+//! renderer. The public IPC contract stays provider-neutral so additional
+//! OpenAI-compatible Chat Completions providers can reuse this transport.
+
+mod chat_completions;
+
+use std::time::Duration;
+
+use cellar_core::error::{CellarError, CellarResult};
+use serde::{Deserialize, Serialize};
+use specta::Type;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub enum BackendAiProvider {
+    Deepseek,
+}
+
+impl BackendAiProvider {
+    fn config(self) -> ProviderConfig {
+        match self {
+            Self::Deepseek => ProviderConfig {
+                id: "deepseek",
+                label: "DeepSeek",
+                base_url: "https://api.deepseek.com",
+                supports_thinking: true,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub enum AiThinkingMode {
+    Enabled,
+    Disabled,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct BackendAiModel {
+    pub id: String,
+    pub label: String,
+    pub description: Option<String>,
+    pub is_default: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct BackendAiChatMessage {
+    pub role: String,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct BackendAiGenerateRequest {
+    pub model: String,
+    pub messages: Vec<BackendAiChatMessage>,
+    pub system_instruction: Option<String>,
+    pub thinking: Option<AiThinkingMode>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct BackendAiTokenUsage {
+    pub prompt_tokens: u64,
+    pub completion_tokens: u64,
+    pub total_tokens: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct BackendAiGenerateResult {
+    pub text: String,
+    pub usage: Option<BackendAiTokenUsage>,
+}
+
+#[derive(Clone, Copy)]
+struct ProviderConfig {
+    id: &'static str,
+    label: &'static str,
+    base_url: &'static str,
+    supports_thinking: bool,
+}
+
+pub struct BackendAiService {
+    http: reqwest::Client,
+}
+
+impl Default for BackendAiService {
+    fn default() -> Self {
+        Self {
+            http: reqwest::Client::builder()
+                .user_agent(concat!("Cellar/", env!("CARGO_PKG_VERSION")))
+                .timeout(Duration::from_secs(300))
+                .build()
+                .expect("valid backend AI HTTP client"),
+        }
+    }
+}
+
+impl BackendAiService {
+    pub async fn list_models(
+        &self,
+        provider: BackendAiProvider,
+    ) -> CellarResult<Vec<BackendAiModel>> {
+        let config = provider.config();
+        let key = load_api_key(config)?;
+        chat_completions::list_models(&self.http, config, &key).await
+    }
+
+    pub async fn generate(
+        &self,
+        provider: BackendAiProvider,
+        request: BackendAiGenerateRequest,
+    ) -> CellarResult<BackendAiGenerateResult> {
+        if request.model.trim().is_empty() {
+            return Err(CellarError::invalid_config("no AI model selected"));
+        }
+        if request.messages.is_empty() {
+            return Err(CellarError::invalid_config(
+                "the AI request has no messages",
+            ));
+        }
+        let config = provider.config();
+        let key = load_api_key(config)?;
+        chat_completions::generate(&self.http, config, &key, request).await
+    }
+}
+
+fn load_api_key(config: ProviderConfig) -> CellarResult<String> {
+    cellar_secrets::load(&format!("ai:{}", config.id))?.ok_or_else(|| {
+        CellarError::Authentication(format!(
+            "No {} API key is configured. Add one in AI settings.",
+            config.label
+        ))
+    })
+}

--- a/apps/desktop/src-tauri/src/commands/ai.rs
+++ b/apps/desktop/src-tauri/src/commands/ai.rs
@@ -13,6 +13,10 @@
 use cellar_core::error::CellarError;
 use tauri::State;
 
+use crate::ai_backend::{
+    BackendAiGenerateRequest, BackendAiGenerateResult, BackendAiModel, BackendAiProvider,
+    BackendAiService,
+};
 use crate::openai::{
     OpenAiAuthMode, OpenAiGenerateRequest, OpenAiGenerateResult, OpenAiLoginMethod,
     OpenAiLoginStart, OpenAiModel, OpenAiOAuthStatus, OpenAiService,
@@ -36,10 +40,10 @@ pub async fn ai_store_key(provider: String, key: String) -> Result<(), CellarErr
 #[tauri::command]
 #[specta::specta]
 pub async fn ai_load_key(provider: String) -> Result<Option<String>, CellarError> {
-    if provider == "openai" {
-        return Err(CellarError::InvalidConfig(
-            "OpenAI credentials are backend-only and cannot be loaded by the renderer.".into(),
-        ));
+    if matches!(provider.as_str(), "openai" | "deepseek") {
+        return Err(CellarError::InvalidConfig(format!(
+            "{provider} credentials are backend-only and cannot be loaded by the renderer."
+        )));
     }
     Ok(cellar_secrets::load(&entry_name(&provider))?)
 }
@@ -58,6 +62,25 @@ pub async fn ai_delete_key(provider: String) -> Result<(), CellarError> {
 #[specta::specta]
 pub async fn ai_has_key(provider: String) -> Result<bool, CellarError> {
     Ok(cellar_secrets::load(&entry_name(&provider))?.is_some())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn ai_backend_list_models(
+    service: State<'_, BackendAiService>,
+    provider: BackendAiProvider,
+) -> Result<Vec<BackendAiModel>, CellarError> {
+    service.list_models(provider).await
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn ai_backend_generate(
+    service: State<'_, BackendAiService>,
+    provider: BackendAiProvider,
+    request: BackendAiGenerateRequest,
+) -> Result<BackendAiGenerateResult, CellarError> {
+    service.generate(provider, request).await
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -58,6 +58,8 @@ pub fn builder() -> Builder<tauri::Wry> {
         ai::ai_load_key,
         ai::ai_delete_key,
         ai::ai_has_key,
+        ai::ai_backend_list_models,
+        ai::ai_backend_generate,
         ai::ai_openai_oauth_status,
         ai::ai_openai_start_login,
         ai::ai_openai_cancel_login,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod ai_backend;
 pub mod commands;
 pub mod datagrip;
 pub mod history;
@@ -19,6 +20,7 @@ pub fn run() {
     tauri::Builder::default()
         .manage(registry)
         .manage(history)
+        .manage(ai_backend::BackendAiService::default())
         .manage(openai::OpenAiService::default())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())

--- a/apps/desktop/src/components/modals/settingsAIPanel.tsx
+++ b/apps/desktop/src/components/modals/settingsAIPanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { PROVIDERS, getProvider, type AiProviderId } from "@cellar/ai";
 import { Icon } from "../icons";
-import { CD_INPUT, ED_RUN_DANGER, Row, Section } from "./settingsPrimitives";
+import { CD_INPUT, ED_RUN_DANGER, Row, Section, Toggle } from "./settingsPrimitives";
 import { useAi } from "../../state/ai";
 import { openExternal } from "../../lib/openExternal";
 
@@ -14,6 +14,7 @@ export function SettingsAI() {
   const keyConfigured = useAi((s) => s.keyConfigured);
   const configured = useAi((s) => s.configured);
   const openAiAuthMode = useAi((s) => s.openAiAuthMode);
+  const deepSeekThinking = useAi((s) => s.deepSeekThinking);
   const oauthStatus = useAi((s) => s.oauthStatus);
   const login = useAi((s) => s.login);
   const authLoading = useAi((s) => s.authLoading);
@@ -22,6 +23,7 @@ export function SettingsAI() {
   const init = useAi((s) => s.init);
   const setProvider = useAi((s) => s.setProvider);
   const setOpenAiAuthMode = useAi((s) => s.setOpenAiAuthMode);
+  const setDeepSeekThinking = useAi((s) => s.setDeepSeekThinking);
   const setModel = useAi((s) => s.setModel);
   const saveKey = useAi((s) => s.saveKey);
   const clearKey = useAi((s) => s.clearKey);
@@ -39,6 +41,7 @@ export function SettingsAI() {
 
   const current = getProvider(providerId);
   const isOpenAi = providerId === "openai";
+  const isDeepSeek = providerId === "deepseek";
   const isChatGpt = isOpenAi && openAiAuthMode === "chatgpt";
 
   useEffect(() => {
@@ -119,9 +122,9 @@ export function SettingsAI() {
               Local credentials, by design
             </div>
             <div className="text-sm leading-[1.45] text-fg-1">
-              Provider keys stay in the OS keychain. OpenAI requests run in the
-              Rust backend, and ChatGPT OAuth tokens are owned by a local Codex
-              app-server process rather than the webview.
+              Provider keys stay in the OS keychain. OpenAI and DeepSeek
+              requests run in the Rust backend, and ChatGPT OAuth tokens are
+              owned by a local Codex app-server process rather than the webview.
             </div>
           </div>
         </div>
@@ -129,7 +132,7 @@ export function SettingsAI() {
 
       <Section title="Provider">
         <Row label="Provider">
-          <div className="grid w-full grid-cols-5 gap-1.5">
+          <div className="grid w-full grid-cols-3 gap-1.5">
             {PROVIDERS.map((p) => {
               const active = providerId === p.id;
               const disabled = !p.enabled;
@@ -206,6 +209,22 @@ export function SettingsAI() {
                 );
               })}
             </div>
+          </Row>
+        )}
+
+        {isDeepSeek && (
+          <Row
+            label="Thinking mode"
+            hint="use DeepSeek's reasoning mode for more complex requests"
+          >
+            <Toggle
+              on={deepSeekThinking}
+              onChange={setDeepSeekThinking}
+              ariaLabel="DeepSeek thinking mode"
+            />
+            <span className="text-[11.5px] text-fg-2">
+              {deepSeekThinking ? "enabled" : "disabled"}
+            </span>
           </Row>
         )}
 

--- a/apps/desktop/src/components/modals/settingsAIPanel.tsx
+++ b/apps/desktop/src/components/modals/settingsAIPanel.tsx
@@ -231,11 +231,8 @@ export function SettingsAI() {
         {!isChatGpt && <Row label="API key" hint="stored in OS keychain, never written to disk">
           <div className="flex min-w-0 flex-1 flex-col gap-1.5">
             <div className="inline-flex min-w-0 items-center gap-1">
-              <span className="inline-flex h-[26px] items-center rounded-l-[4px] border border-r-0 border-border-default bg-bg-inset px-1.5 font-mono text-sm text-fg-2">
-                {current.keyPrefix}
-              </span>
               <input
-                className="-ml-px h-[26px] min-w-0 flex-1 border border-border-default bg-bg-inset px-2 font-mono text-sm text-fg-0 outline-none focus:border-accent-line focus:bg-bg-2"
+                className="h-[26px] min-w-0 flex-1 rounded-[4px] border border-border-default bg-bg-inset px-2 font-mono text-sm text-fg-0 outline-none focus:border-accent-line focus:bg-bg-2"
                 type={reveal ? "text" : "password"}
                 aria-label={`${current.label} API key`}
                 value={keyDraft}
@@ -244,7 +241,7 @@ export function SettingsAI() {
                   if (e.key === "Enter") void onSaveKey();
                 }}
                 placeholder={
-                  keyConfigured ? "key stored, paste to replace" : "paste your API key"
+                  keyConfigured ? "key stored, paste to replace" : `${current.keyPrefix}…`
                 }
                 spellCheck={false}
                 autoComplete="off"

--- a/apps/desktop/src/state/ai.test.ts
+++ b/apps/desktop/src/state/ai.test.ts
@@ -26,6 +26,7 @@ function reset() {
     providerId: "google",
     modelId: null,
     openAiAuthMode: "apiKey",
+    deepSeekThinking: true,
     models: [],
     modelsLoading: false,
     modelsError: null,
@@ -44,6 +45,7 @@ function reset() {
 beforeEach(async () => {
   await commands.aiDeleteKey("google");
   await commands.aiDeleteKey("openai");
+  await commands.aiDeleteKey("deepseek");
   await commands.aiOpenaiLogout();
   reset();
   vi.clearAllMocks();
@@ -164,6 +166,38 @@ describe("useAi store", () => {
   it("rejects direct renderer reads of the OpenAI key", async () => {
     await commands.aiStoreKey("openai", "sk-test");
     await expect(unwrap(commands.aiLoadKey("openai"))).rejects.toThrow(
+      "backend-only",
+    );
+  });
+
+  it("discovers DeepSeek models and sends thinking mode through backend IPC", async () => {
+    useAi.setState({ providerId: "deepseek" });
+    const generate = vi.spyOn(commands, "aiBackendGenerate");
+    const loadKey = vi.spyOn(commands, "aiLoadKey");
+
+    await useAi.getState().saveKey("sk-deepseek-test");
+    useAi.getState().setDeepSeekThinking(false);
+    await useAi.getState().send("ask", "write a query");
+
+    expect(useAi.getState().models.map((model) => model.id)).toEqual([
+      "deepseek-v4-flash",
+      "deepseek-v4-pro",
+    ]);
+    expect(generate).toHaveBeenCalledWith(
+      "deepseek",
+      expect.objectContaining({
+        model: "deepseek-v4-flash",
+        thinking: "disabled",
+      }),
+    );
+    expect(loadKey).not.toHaveBeenCalled();
+    expect(useAi.getState().messages.at(-1)).toMatchObject({ role: "model" });
+    expect(useAi.getState().messages.at(-1)?.error).toBeFalsy();
+  });
+
+  it("rejects direct renderer reads of the DeepSeek key", async () => {
+    await commands.aiStoreKey("deepseek", "sk-deepseek-test");
+    await expect(unwrap(commands.aiLoadKey("deepseek"))).rejects.toThrow(
       "backend-only",
     );
   });

--- a/apps/desktop/src/state/ai.ts
+++ b/apps/desktop/src/state/ai.ts
@@ -16,6 +16,7 @@ import {
 import {
   commands,
   unwrap,
+  type AiThinkingMode,
   type OpenAiLoginMethod,
   type OpenAiLoginStart,
   type OpenAiOAuthStatus,
@@ -37,6 +38,7 @@ interface Persisted {
   providerId: AiProviderId;
   modelId: string | null;
   openAiAuthMode: OpenAiAuthMode;
+  deepSeekThinking: boolean;
 }
 
 const STORAGE_KEY = "cellar.ai.v2";
@@ -47,6 +49,7 @@ function defaults(): Persisted {
     providerId: DEFAULT_PROVIDER,
     modelId: null,
     openAiAuthMode: DEFAULT_OPENAI_AUTH,
+    deepSeekThinking: true,
   };
 }
 
@@ -59,6 +62,7 @@ function loadPersisted(): Persisted {
       providerId: parsed.providerId ?? DEFAULT_PROVIDER,
       modelId: parsed.modelId ?? null,
       openAiAuthMode: parsed.openAiAuthMode ?? DEFAULT_OPENAI_AUTH,
+      deepSeekThinking: parsed.deepSeekThinking ?? true,
     };
   } catch {
     return defaults();
@@ -109,6 +113,7 @@ interface AiStore {
   providerId: AiProviderId;
   modelId: string | null;
   openAiAuthMode: OpenAiAuthMode;
+  deepSeekThinking: boolean;
   models: AiModel[];
   modelsLoading: boolean;
   modelsError: string | null;
@@ -125,6 +130,7 @@ interface AiStore {
   init: () => Promise<void>;
   setProvider: (id: AiProviderId) => void;
   setOpenAiAuthMode: (mode: OpenAiAuthMode) => void;
+  setDeepSeekThinking: (enabled: boolean) => void;
   setModel: (id: string) => void;
   saveKey: (key: string) => Promise<void>;
   clearKey: () => Promise<void>;
@@ -194,6 +200,7 @@ export const useAi = create<AiStore>((set, get) => ({
       providerId: id,
       modelId: null,
       openAiAuthMode: get().openAiAuthMode,
+      deepSeekThinking: get().deepSeekThinking,
     });
     void get().init();
   },
@@ -213,8 +220,23 @@ export const useAi = create<AiStore>((set, get) => ({
       modelsLoading: false,
       modelsError: null,
     });
-    persist({ providerId: get().providerId, modelId: null, openAiAuthMode: mode });
+    persist({
+      providerId: get().providerId,
+      modelId: null,
+      openAiAuthMode: mode,
+      deepSeekThinking: get().deepSeekThinking,
+    });
     void get().init();
+  },
+
+  setDeepSeekThinking(enabled) {
+    set({ deepSeekThinking: enabled });
+    persist({
+      providerId: get().providerId,
+      modelId: get().modelId,
+      openAiAuthMode: get().openAiAuthMode,
+      deepSeekThinking: enabled,
+    });
   },
 
   setModel(id) {
@@ -223,6 +245,7 @@ export const useAi = create<AiStore>((set, get) => ({
       providerId: get().providerId,
       modelId: id,
       openAiAuthMode: get().openAiAuthMode,
+      deepSeekThinking: get().deepSeekThinking,
     });
   },
 
@@ -328,6 +351,13 @@ export const useAi = create<AiStore>((set, get) => ({
           id: model.id,
           label: model.label,
         }));
+      } else if (providerId === "deepseek") {
+        const discovered = await unwrap(commands.aiBackendListModels("deepseek"));
+        preferred = discovered.find((model) => model.is_default)?.id;
+        models = discovered.map((model) => ({
+          id: model.id,
+          label: model.label,
+        }));
       } else {
         throw new Error("This AI provider is not implemented yet.");
       }
@@ -338,7 +368,12 @@ export const useAi = create<AiStore>((set, get) => ({
           ? current
           : (preferred ?? models[0]?.id ?? null);
       set({ models, modelsLoading: false, configured: true, modelId });
-      persist({ providerId, modelId, openAiAuthMode });
+      persist({
+        providerId,
+        modelId,
+        openAiAuthMode,
+        deepSeekThinking: get().deepSeekThinking,
+      });
     } catch (error) {
       if (!isCurrentDiscovery()) return;
       set({ modelsLoading: false, modelsError: describeError(error) });
@@ -396,6 +431,26 @@ export const useAi = create<AiStore>((set, get) => ({
             }
           : undefined;
         set({ openAiThreadId: result.thread_id });
+      } else if (providerId === "deepseek") {
+        const thinking: AiThinkingMode = get().deepSeekThinking
+          ? "enabled"
+          : "disabled";
+        const result = await unwrap(
+          commands.aiBackendGenerate("deepseek", {
+            model,
+            messages: history,
+            system_instruction: SYSTEM_PROMPT,
+            thinking,
+          }),
+        );
+        content = result.text;
+        usage = result.usage
+          ? {
+              promptTokens: result.usage.prompt_tokens,
+              completionTokens: result.usage.completion_tokens,
+              totalTokens: result.usage.total_tokens,
+            }
+          : undefined;
       } else {
         throw new Error("This AI provider is not implemented yet.");
       }

--- a/docs/architecture/adr/0003-deepseek-provider.md
+++ b/docs/architecture/adr/0003-deepseek-provider.md
@@ -1,0 +1,43 @@
+# ADR 0003: DeepSeek backend provider
+
+- **Status:** Accepted
+- **Date:** 2026-08-01
+
+## Context
+
+Cellar supports bring-your-own AI credentials and sends requests directly to
+the selected provider. DeepSeek exposes model discovery and generation through
+an OpenAI-compatible Chat Completions API, but it has provider-specific options
+such as thinking mode.
+
+Loading the key into the React webview would expand the credential trust
+boundary. Building a one-off DeepSeek command surface would also make planned
+compatible providers repeat the same model, message, usage, and error mapping.
+
+## Decision
+
+DeepSeek is a fixed first-party profile on a provider-neutral Rust backend
+transport. Typed IPC accepts a closed provider enum, so the renderer cannot
+choose an arbitrary destination. The service loads `ai:deepseek` from
+`cellar-secrets`, discovers models from `https://api.deepseek.com/models`, and
+sends full conversation history to `https://api.deepseek.com/chat/completions`.
+
+Thinking mode is persisted as a DeepSeek setting and sent explicitly on each
+generation request. Model identifiers are never maintained as an allowlist;
+the provider's model endpoint remains authoritative.
+
+## Consequences
+
+- The DeepSeek key never enters the webview or plain-text settings.
+- Cellar does not proxy or store DeepSeek requests.
+- Model changes do not require a Cellar release.
+- The shared transport can support additional fixed Chat Completions profiles
+  without allowing arbitrary network destinations.
+- OpenAI keeps its separate Responses API and ChatGPT OAuth implementations.
+
+## Follow-up
+
+- Add user-defined compatible endpoints when Cellar has capability and URL
+  validation suitable for custom network destinations.
+- Extend provider capabilities if future profiles need additional controls.
+- Add streaming and cancellation across backend AI providers.

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -1,7 +1,7 @@
 // AI providers, prompts, and context building.
 //
-// Gemini runs directly from the renderer. OpenAI runs behind typed desktop IPC
-// so API keys and ChatGPT OAuth tokens never enter the webview.
+// Gemini runs directly from the renderer. OpenAI and DeepSeek run behind typed
+// desktop IPC so their API credentials never enter the webview.
 
 export type {
   AiProviderId,

--- a/packages/ai/src/prompts.test.ts
+++ b/packages/ai/src/prompts.test.ts
@@ -152,9 +152,9 @@ describe("buildSchemaContext", () => {
 });
 
 describe("providers", () => {
-  it("enables google and openai", () => {
+  it("enables the implemented providers", () => {
     const enabled = PROVIDERS.filter((p) => p.enabled).map((p) => p.id);
-    expect(enabled).toEqual(["google", "openai"]);
+    expect(enabled).toEqual(["google", "openai", "deepseek"]);
   });
   it("getProvider throws on unknown", () => {
     // @ts-expect-error testing the runtime guard

--- a/packages/ai/src/providers.ts
+++ b/packages/ai/src/providers.ts
@@ -8,7 +8,7 @@ export interface ProviderMeta {
   /** Short mono subtitle, e.g. `gemini-* family`. */
   sub: string;
   enabled: boolean;
-  /** Leading hint shown next to the API-key input. */
+  /** Example prefix shown in the API-key input placeholder. */
   keyPrefix: string;
   /** Base endpoint, shown read-only in settings. */
   endpoint: string;

--- a/packages/ai/src/providers.ts
+++ b/packages/ai/src/providers.ts
@@ -26,6 +26,7 @@ export const PROVIDERS: ProviderMeta[] = [
   // ponytail: disabled providers keep full shape (getProvider returns ProviderMeta), just compacted
   { id: "anthropic", label: "Anthropic", sub: "claude-* family",      enabled: false, keyPrefix: "sk-ant-", endpoint: "https://api.anthropic.com/v1" },
   { id: "openai",    label: "OpenAI",    sub: "GPT + ChatGPT",          enabled: true,  keyPrefix: "sk-",     endpoint: "https://api.openai.com/v1" },
+  { id: "deepseek", label: "DeepSeek", sub: "V4 Flash + Pro", enabled: true, keyPrefix: "sk-", endpoint: "https://api.deepseek.com" },
   { id: "local",     label: "Local",     sub: "Ollama, LM Studio",     enabled: false, keyPrefix: "none",    endpoint: "http://localhost:11434/v1" },
   { id: "custom",    label: "Custom",    sub: "OpenAI-compatible URL", enabled: false, keyPrefix: "key",     endpoint: "https://example.invalid/v1" },
 ];

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -1,9 +1,15 @@
 // Shared AI types. This package is provider-agnostic at the type level: the
 // concrete provider clients live either alongside it (Gemini) or behind typed
-// desktop IPC when credentials must stay out of the renderer (OpenAI).
+// desktop IPC when credentials must stay out of the renderer (OpenAI and DeepSeek).
 
 /** Providers Cellar knows about. */
-export type AiProviderId = "google" | "anthropic" | "openai" | "local" | "custom";
+export type AiProviderId =
+  | "google"
+  | "anthropic"
+  | "openai"
+  | "deepseek"
+  | "local"
+  | "custom";
 
 /** OpenAI supports usage-based Platform API keys and ChatGPT subscription
  * access. The latter is implemented by the local Codex app-server OAuth flow. */

--- a/packages/ipc/src/generated.ts
+++ b/packages/ipc/src/generated.ts
@@ -361,6 +361,22 @@ async aiHasKey(provider: string) : Promise<Result<boolean, CellarError>> {
     else return { status: "error", error: e  as any };
 }
 },
+async aiBackendListModels(provider: BackendAiProvider) : Promise<Result<BackendAiModel[], CellarError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("ai_backend_list_models", { provider }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async aiBackendGenerate(provider: BackendAiProvider, request: BackendAiGenerateRequest) : Promise<Result<BackendAiGenerateResult, CellarError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("ai_backend_generate", { provider, request }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async aiOpenaiOauthStatus() : Promise<Result<OpenAiOAuthStatus, CellarError>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("ai_openai_oauth_status") };
@@ -421,6 +437,13 @@ async aiOpenaiGenerate(authMode: OpenAiAuthMode, request: OpenAiGenerateRequest)
 
 /** user-defined types **/
 
+export type AiThinkingMode = "enabled" | "disabled"
+export type BackendAiChatMessage = { role: string; content: string }
+export type BackendAiGenerateRequest = { model: string; messages: BackendAiChatMessage[]; system_instruction: string | null; thinking: AiThinkingMode | null }
+export type BackendAiGenerateResult = { text: string; usage: BackendAiTokenUsage | null }
+export type BackendAiModel = { id: string; label: string; description: string | null; is_default: boolean }
+export type BackendAiProvider = "deepseek"
+export type BackendAiTokenUsage = { prompt_tokens: number; completion_tokens: number; total_tokens: number }
 export type CellAssignment = { column: string; value: DiffValue }
 /**
  * One cell value, tagged so the frontend can render the right editor and

--- a/packages/ipc/src/index.test.ts
+++ b/packages/ipc/src/index.test.ts
@@ -16,6 +16,8 @@ describe("@cellar/ipc", () => {
     expect(Object.keys(commands).sort()).toEqual(
       [
         "aiDeleteKey",
+        "aiBackendGenerate",
+        "aiBackendListModels",
         "aiHasKey",
         "aiLoadKey",
         "aiOpenaiCancelLogin",

--- a/packages/ipc/src/mock.ts
+++ b/packages/ipc/src/mock.ts
@@ -30,6 +30,10 @@ import type {
   MigrationApplyResult,
   SchemaSnapshotMeta,
   Dialect,
+  BackendAiGenerateRequest,
+  BackendAiGenerateResult,
+  BackendAiModel,
+  BackendAiProvider,
   OpenAiAuthMode,
   OpenAiGenerateRequest,
   OpenAiGenerateResult,
@@ -297,12 +301,12 @@ export const mockCommands = {
   },
 
   aiLoadKey: async (provider: string): Promise<Result<string | null, CellarError>> =>
-    provider === "openai"
+    provider === "openai" || provider === "deepseek"
       ? {
           status: "error",
           error: {
             kind: "InvalidConfig",
-            detail: "OpenAI credentials are backend-only and cannot be loaded by the renderer.",
+            detail: `${provider} credentials are backend-only and cannot be loaded by the renderer.`,
           },
         }
       : ok(mockAiKeys.get(provider) ?? null),
@@ -314,6 +318,33 @@ export const mockCommands = {
 
   aiHasKey: async (provider: string): Promise<Result<boolean, CellarError>> =>
     ok(mockAiKeys.has(provider)),
+
+  aiBackendListModels: async (
+    _provider: BackendAiProvider,
+  ): Promise<Result<BackendAiModel[], CellarError>> =>
+    ok([
+      {
+        id: "deepseek-v4-flash",
+        label: "deepseek-v4-flash",
+        description: null,
+        is_default: true,
+      },
+      {
+        id: "deepseek-v4-pro",
+        label: "deepseek-v4-pro",
+        description: null,
+        is_default: false,
+      },
+    ]),
+
+  aiBackendGenerate: async (
+    _provider: BackendAiProvider,
+    _request: BackendAiGenerateRequest,
+  ): Promise<Result<BackendAiGenerateResult, CellarError>> =>
+    ok({
+      text: "```sql\nSELECT 1;\n```",
+      usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
+    }),
 
   aiOpenaiOauthStatus: async (): Promise<
     Result<OpenAiOAuthStatus, CellarError>


### PR DESCRIPTION
## Summary

- add DeepSeek as a first-party AI provider with live model discovery
- keep DeepSeek API keys in the OS keychain and execute requests in Rust through typed IPC
- add a reusable backend Chat Completions transport for future fixed provider profiles
- expose persisted DeepSeek thinking mode in the existing AI settings UI
- document the credential boundary and provider architecture in SPEC.md and ADR 0003

## User impact

Users can select DeepSeek, save their own API key, discover all models currently available to that key, choose a model from the existing model picker, and use DeepSeek for full multi-turn AI conversations. Thinking mode can be enabled or disabled in settings.

## Validation

- `pnpm test`
- `pnpm build`
- `node scripts/turbo-guard.mjs lint`
- `cargo check -p cellar-desktop`
- `cargo clippy -p cellar-desktop --all-targets` (passes with existing workspace warnings)
- scoped `rustfmt --check`
- live local UI verification of provider selection and thinking-mode interaction
- `clawpatch review --include-dirty`