### PR TITLE
fix: keep table filters across tab swaps

### DIFF
--- a/apps/desktop/src/components/Workspace.tsx
+++ b/apps/desktop/src/components/Workspace.tsx
@@ -240,8 +240,8 @@ function renderTab(tab: WorkspaceTab, onCommit?: () => void) {
     // `key` resets zoom/pan and node positions per diagram tab.
     return <ErDiagram key={tab.id} tab={tab} />;
   }
-  // `key` resets the grid's local state (filters/selection) when the user
-  // switches to a different table tab.
+  // `key` resets ephemeral grid state (selection/editing) when the user
+  // switches table tabs. Filters restore from `useTabs.tableFilters`.
   return <TableTabPane key={tab.id} tab={tab} onCommit={onCommit} />;
 }
 
@@ -258,21 +258,39 @@ function TableTabPane({
   const changes = useTabs((s) => s.tableChanges[tab.id] ?? EMPTY_CHANGES);
   const columnLayout = useTabs((s) => s.tableLayouts[tab.id]);
   const savedSort = useTabs((s) => s.tableSorts[tab.id] ?? null);
+  // Session toolbar state — kept in the tabs store so remounting after a tab
+  // swap restores chips / quick filter (named presets live in filterPresets).
+  const savedFiltersState = useTabs((s) => s.tableFilters[tab.id]);
   const setTableChanges = useTabs((s) => s.setTableChanges);
   const setTableLayout = useTabs((s) => s.setTableLayout);
   const setTableSort = useTabs((s) => s.setTableSort);
+  const setTableFilters = useTabs((s) => s.setTableFilters);
   const clearTableChanges = useTabs((s) => s.clearTableChanges);
   const [pageIndex, setPageIndex] = useState(0);
   const [pageSize, setPageSize] = useState(500);
   const grid = useGridState({
     initialSort: rememberSort ? savedSort : null,
+    initialFilters: savedFiltersState?.filters ?? [],
   });
   // Quick filter is kept separate from the advanced chips (`grid.filters`) so
   // clearing one never disturbs the other. FilterBar owns the typed text and
   // debounces it, so `quickFilter` only updates (and re-queries) once the user
   // pauses — keystrokes never re-render the grid.
-  const [quickFilter, setQuickFilter] = useState("");
-  const [quickColumn, setQuickColumn] = useState<string | null>(null);
+  const [quickFilter, setQuickFilter] = useState(
+    () => savedFiltersState?.quickFilter ?? "",
+  );
+  const [quickColumn, setQuickColumn] = useState<string | null>(
+    () => savedFiltersState?.quickColumn ?? null,
+  );
+
+  // Keep the tabs store in sync so the next remount (tab swap) rehydrates.
+  useEffect(() => {
+    setTableFilters(tab.id, {
+      filters: grid.filters,
+      quickFilter,
+      quickColumn,
+    });
+  }, [tab.id, grid.filters, quickFilter, quickColumn, setTableFilters]);
   // A table refresh (e.g. after committing a transaction) reloads rows under
   // any open inline editor, so close it — otherwise the editor UI lingers over
   // the freshly committed value.

--- a/apps/desktop/src/components/Workspace.tsx
+++ b/apps/desktop/src/components/Workspace.tsx
@@ -284,6 +284,13 @@ function TableTabPane({
   );
 
   // Keep the tabs store in sync so the next remount (tab swap) rehydrates.
+  // Quick-filter updates also write here synchronously: FilterBar may flush a
+  // pending draft during unmount, when a React setState alone would not re-run
+  // this effect before the pane is gone.
+  const filtersRef = useRef(grid.filters);
+  filtersRef.current = grid.filters;
+  const quickColumnRef = useRef(quickColumn);
+  quickColumnRef.current = quickColumn;
   useEffect(() => {
     setTableFilters(tab.id, {
       filters: grid.filters,
@@ -291,6 +298,17 @@ function TableTabPane({
       quickColumn,
     });
   }, [tab.id, grid.filters, quickFilter, quickColumn, setTableFilters]);
+  const handleQuickFilterChange = useCallback(
+    (next: string) => {
+      setQuickFilter(next);
+      setTableFilters(tab.id, {
+        filters: filtersRef.current,
+        quickFilter: next,
+        quickColumn: quickColumnRef.current,
+      });
+    },
+    [tab.id, setTableFilters],
+  );
   // A table refresh (e.g. after committing a transaction) reloads rows under
   // any open inline editor, so close it — otherwise the editor UI lingers over
   // the freshly committed value.
@@ -553,7 +571,7 @@ function TableTabPane({
         filters={grid.filters}
         onFiltersChange={grid.setFilters}
         quickFilter={quickFilter}
-        onQuickFilterChange={setQuickFilter}
+        onQuickFilterChange={handleQuickFilterChange}
         quickFilterColumn={quickColumn}
         onQuickFilterColumnChange={setQuickColumn}
         sort={grid.sort}

--- a/apps/desktop/src/state/tabs.test.ts
+++ b/apps/desktop/src/state/tabs.test.ts
@@ -32,6 +32,7 @@ describe("tab workspace state", () => {
       tableChanges: {},
       tableLayouts: {},
       tableSorts: {},
+      tableFilters: {},
       refreshKeys: {},
     });
     if (typeof localStorage !== "undefined") localStorage.clear();
@@ -389,5 +390,60 @@ describe("tab workspace state", () => {
 
     useTabs.getState().setTableSort(id, null);
     expect(useTabs.getState().tableSorts[id]).toBeUndefined();
+  });
+
+  it("keeps active table filters across tab swaps and clears them on close", () => {
+    const orders = "conn-1::app.public.orders";
+    const users = "conn-1::app.public.users";
+    const store = useTabs.getState();
+    store.openTable("conn-1", "app", "public", "orders");
+    store.openTable("conn-1", "app", "public", "users");
+
+    useTabs.getState().setTableFilters(orders, {
+      filters: [
+        {
+          id: "f1",
+          columnKey: "status",
+          operator: "equals",
+          value: "open",
+          logic: "and",
+        },
+      ],
+      quickFilter: "rush",
+      quickColumn: "name",
+    });
+
+    // Swap away and back — filters must still be in the store for remount.
+    useTabs.getState().setActive(users);
+    useTabs.getState().setActive(orders);
+    expect(useTabs.getState().tableFilters[orders]).toEqual({
+      filters: [
+        {
+          id: "f1",
+          columnKey: "status",
+          operator: "equals",
+          value: "open",
+          logic: "and",
+        },
+      ],
+      quickFilter: "rush",
+      quickColumn: "name",
+    });
+
+    // Empty toolbar drops the entry; close drops any remaining session state.
+    useTabs.getState().setTableFilters(orders, {
+      filters: [],
+      quickFilter: "",
+      quickColumn: null,
+    });
+    expect(useTabs.getState().tableFilters[orders]).toBeUndefined();
+
+    useTabs.getState().setTableFilters(orders, {
+      filters: [],
+      quickFilter: "kept-until-close",
+      quickColumn: null,
+    });
+    useTabs.getState().closeTab(orders);
+    expect(useTabs.getState().tableFilters[orders]).toBeUndefined();
   });
 });

--- a/apps/desktop/src/state/tabs.test.ts
+++ b/apps/desktop/src/state/tabs.test.ts
@@ -445,5 +445,13 @@ describe("tab workspace state", () => {
     });
     useTabs.getState().closeTab(orders);
     expect(useTabs.getState().tableFilters[orders]).toBeUndefined();
+
+    // FilterBar unmount flush runs after closeTab — must not resurrect state.
+    useTabs.getState().setTableFilters(orders, {
+      filters: [],
+      quickFilter: "kept-until-close",
+      quickColumn: null,
+    });
+    expect(useTabs.getState().tableFilters[orders]).toBeUndefined();
   });
 });

--- a/apps/desktop/src/state/tabs.ts
+++ b/apps/desktop/src/state/tabs.ts
@@ -1,5 +1,10 @@
 import { create } from "zustand";
-import type { GridColumnLayout, PendingChanges, SortState } from "@cellar/data-grid";
+import type {
+  ColumnFilters,
+  GridColumnLayout,
+  PendingChanges,
+  SortState,
+} from "@cellar/data-grid";
 import { useNotices } from "./notices";
 import { useQueryMessages } from "./queryMessages";
 import { useTabResults } from "./tabResults";
@@ -77,6 +82,19 @@ export type TableLayouts = Record<string, GridColumnLayout>;
 /** Last-used column sort per table id (`tableKey`). `null` means unsorted. */
 export type TableSorts = Record<string, SortState>;
 
+/**
+ * Active filter toolbar for an open table tab (chips + quick filter).
+ * Session-scoped — survives tab swaps while the tab stays open, cleared on close.
+ * Named presets live separately in `useFilterPresets`.
+ */
+export type TableFilterState = {
+  filters: ColumnFilters;
+  quickFilter: string;
+  quickColumn: string | null;
+};
+
+export type TableFilters = Record<string, TableFilterState>;
+
 let queryTabSeq = 0;
 let schemaCompareSeq = 0;
 
@@ -98,6 +116,8 @@ interface TabsStore {
   tableChanges: Record<string, PendingChanges>;
   tableLayouts: TableLayouts;
   tableSorts: TableSorts;
+  /** Active filter toolbar per open table tab id. */
+  tableFilters: TableFilters;
   refreshKeys: Record<string, number>;
   openTable: (
     connectionId: string,
@@ -149,7 +169,17 @@ interface TabsStore {
   importTableLayouts: (entries: TableLayouts) => void;
   setTableChanges: (id: string, changes: PendingChanges) => void;
   clearTableChanges: (id: string) => void;
+  /** Remember (or clear) the active filter toolbar for an open table tab. */
+  setTableFilters: (id: string, state: TableFilterState) => void;
   refreshTable: (id: string) => void;
+}
+
+function isEmptyFilterState(state: TableFilterState): boolean {
+  return (
+    state.filters.length === 0 &&
+    state.quickFilter === "" &&
+    state.quickColumn === null
+  );
 }
 
 function tableKey(
@@ -242,15 +272,20 @@ function saveTableSorts(sorts: TableSorts) {
 function dropTabScopedState(
   ids: string[],
   tableChanges: Record<string, PendingChanges>,
+  tableFilters: TableFilters,
   refreshKeys: Record<string, number>,
 ): {
   tableChanges: Record<string, PendingChanges>;
+  tableFilters: TableFilters;
   refreshKeys: Record<string, number>;
 } {
   const closed = new Set(ids);
   return {
     tableChanges: Object.fromEntries(
       Object.entries(tableChanges).filter(([id]) => !closed.has(id)),
+    ),
+    tableFilters: Object.fromEntries(
+      Object.entries(tableFilters).filter(([id]) => !closed.has(id)),
     ),
     refreshKeys: Object.fromEntries(
       Object.entries(refreshKeys).filter(([id]) => !closed.has(id)),
@@ -366,6 +401,7 @@ export const useTabs = create<TabsStore>((set, get) => ({
   tableChanges: {},
   tableLayouts: loadTableLayouts(),
   tableSorts: loadTableSorts(),
+  tableFilters: {},
   refreshKeys: {},
 
   openTable(connectionId, database, schema, table) {
@@ -477,15 +513,17 @@ export const useTabs = create<TabsStore>((set, get) => ({
     set((s) => {
       const closed = s.tabs.find((t) => t.id === id);
       const tabs = s.tabs.filter((t) => t.id !== id);
-      const { tableChanges, refreshKeys } = dropTabScopedState(
+      const { tableChanges, tableFilters, refreshKeys } = dropTabScopedState(
         [id],
         s.tableChanges,
+        s.tableFilters,
         s.refreshKeys,
       );
       return {
         tabs,
         closedTabs: closed ? [closed, ...s.closedTabs].slice(0, 12) : s.closedTabs,
         tableChanges,
+        tableFilters,
         refreshKeys,
         ...reconcile({ ...s, tabs }),
       };
@@ -501,15 +539,17 @@ export const useTabs = create<TabsStore>((set, get) => ({
     set((s) => {
       const tabs = s.tabs.filter((t) => t.id === id);
       const closed = s.tabs.filter((t) => t.id !== id);
-      const { tableChanges, refreshKeys } = dropTabScopedState(
+      const { tableChanges, tableFilters, refreshKeys } = dropTabScopedState(
         closedIds,
         s.tableChanges,
+        s.tableFilters,
         s.refreshKeys,
       );
       return {
         tabs,
         closedTabs: stackClosedTabs(closed, s.closedTabs),
         tableChanges,
+        tableFilters,
         refreshKeys,
         ...reconcile({ ...s, tabs }),
       };
@@ -526,15 +566,17 @@ export const useTabs = create<TabsStore>((set, get) => ({
     set((s) => {
       const tabs = s.tabs.slice(0, tabIndex + 1);
       const closed = s.tabs.slice(tabIndex + 1);
-      const { tableChanges, refreshKeys } = dropTabScopedState(
+      const { tableChanges, tableFilters, refreshKeys } = dropTabScopedState(
         closedIds,
         s.tableChanges,
+        s.tableFilters,
         s.refreshKeys,
       );
       return {
         tabs,
         closedTabs: stackClosedTabs(closed, s.closedTabs),
         tableChanges,
+        tableFilters,
         refreshKeys,
         ...reconcile({ ...s, tabs }),
       };
@@ -549,9 +591,10 @@ export const useTabs = create<TabsStore>((set, get) => ({
     set((s) => {
       const removed = new Set(removedIds);
       const tabs = s.tabs.filter((t) => !removed.has(t.id));
-      const { tableChanges, refreshKeys } = dropTabScopedState(
+      const { tableChanges, tableFilters, refreshKeys } = dropTabScopedState(
         removedIds,
         s.tableChanges,
+        s.tableFilters,
         s.refreshKeys,
       );
       return {
@@ -562,6 +605,7 @@ export const useTabs = create<TabsStore>((set, get) => ({
           (t) => t.connectionId !== connectionId,
         ),
         tableChanges,
+        tableFilters,
         refreshKeys,
         ...reconcile({ ...s, tabs }),
       };
@@ -726,6 +770,18 @@ export const useTabs = create<TabsStore>((set, get) => ({
     set((s) => {
       const { [id]: _changes, ...tableChanges } = s.tableChanges;
       return { tableChanges };
+    });
+  },
+
+  setTableFilters(id, state) {
+    set((s) => {
+      // Drop empty toolbars so the map stays small while a tab is idle.
+      if (isEmptyFilterState(state)) {
+        if (!(id in s.tableFilters)) return s;
+        const { [id]: _removed, ...rest } = s.tableFilters;
+        return { tableFilters: rest };
+      }
+      return { tableFilters: { ...s.tableFilters, [id]: state } };
     });
   },
 

--- a/apps/desktop/src/state/tabs.ts
+++ b/apps/desktop/src/state/tabs.ts
@@ -775,6 +775,10 @@ export const useTabs = create<TabsStore>((set, get) => ({
 
   setTableFilters(id, state) {
     set((s) => {
+      // closeTab drops session filters before React unmounts the pane. The
+      // FilterBar then flushes its quick-filter draft on cleanup — ignore that
+      // write so closed tabs don't come back with resurrected toolbar state.
+      if (!s.tabs.some((t) => t.id === id)) return s;
       // Drop empty toolbars so the map stays small while a tab is idle.
       if (isEmptyFilterState(state)) {
         if (!(id in s.tableFilters)) return s;

--- a/packages/data-grid/src/FilterBar.tsx
+++ b/packages/data-grid/src/FilterBar.tsx
@@ -300,10 +300,19 @@ export function FilterBar({
   }, [quickFilter]);
   const onQuickRef = useRef(onQuickFilterChange);
   onQuickRef.current = onQuickFilterChange;
+  const quickDraftRef = useRef(quickDraft);
+  quickDraftRef.current = quickDraft;
   useEffect(() => {
     const handle = setTimeout(() => onQuickRef.current?.(quickDraft.trim()), 250);
     return () => clearTimeout(handle);
   }, [quickDraft]);
+  // Tab swaps unmount this bar and cancel the debounce above — flush so the
+  // parent can persist the in-progress draft before the pane is torn down.
+  useEffect(() => {
+    return () => {
+      onQuickRef.current?.(quickDraftRef.current.trim());
+    };
+  }, []);
   // Saved presets: the "presets" word is the dropdown (apply / hover-× delete);
   // the save button swaps it for a small name input. No selected-preset state —
   // applying is a one-shot action, not a mode.


### PR DESCRIPTION
## Summary
- Persist each open table tab’s active filter toolbar (chips + quick filter) in `useTabs` so remounting after a tab swap restores it.
- Clear that session state when the tab closes; named filter presets are unchanged.
- Add coverage for swap retention and close cleanup.

## Test plan
- [ ] Open a table, apply filters (or a saved preset), switch to another tab and back — filters should still be applied
- [ ] Clear filters, swap tabs — toolbar should stay empty
- [ ] Close a filtered table tab and reopen it — session filters should not return (presets still available)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Table filters now persist when switching between table tabs.
  * Advanced filters, quick-filter text, and selected quick-filter columns are restored when returning to a tab.
  * Empty filters are automatically removed, and filters are cleared when tabs or connections are closed.

* **Bug Fixes**
  * Improved quick-filter behavior so the latest filter text is retained when navigating away from a table.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->