### PR TITLE
fix: keep table panes alive across tab swaps

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -130,6 +130,7 @@ export function App() {
 
   const openModal = useCallback((m: ModalId) => setModal(m), []);
   const closeModal = useCallback(() => setModal(null), []);
+  const openCommit = useCallback(() => openModal("commit"), [openModal]);
   const openSchemaCompare = useCallback((preset?: ComparePreset) => {
     setComparePreset(preset ?? null);
     setModal("schemaCompare");
@@ -241,7 +242,7 @@ export function App() {
           ) : (
             <>
               <TabBar />
-              <Workspace onCommit={() => openModal("commit")} />
+              <Workspace onCommit={openCommit} />
               {panels.bottom && (
                 <>
                   <ResizeHandle

--- a/apps/desktop/src/components/KeepAlivePanes.test.ts
+++ b/apps/desktop/src/components/KeepAlivePanes.test.ts
@@ -58,6 +58,19 @@ describe("nextMountedTabIds", () => {
   it("returns an empty list when nothing is open", () => {
     expect(nextMountedTabIds(["orders"], null, [])).toEqual([]);
   });
+
+  it("does not keep a tab that was only active in a discarded render", () => {
+    const committed = ["orders"];
+    const open = ["orders", "users"];
+    // Speculative switch to users — derived, but not written back.
+    expect(nextMountedTabIds(committed, "users", open)).toEqual([
+      "orders",
+      "users",
+    ]);
+    // The committed snapshot is unchanged, so landing back on orders must
+    // not mount users or start its table query.
+    expect(nextMountedTabIds(committed, "orders", open)).toEqual(["orders"]);
+  });
 });
 
 describe("KeepAlivePanes", () => {

--- a/apps/desktop/src/components/KeepAlivePanes.test.ts
+++ b/apps/desktop/src/components/KeepAlivePanes.test.ts
@@ -1,0 +1,83 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import type { QueryTab, WorkspaceTab } from "../state/tabs";
+import { KeepAlivePanes, nextMountedTabIds } from "./KeepAlivePanes";
+
+function queryTab(id: string, title: string): QueryTab {
+  return {
+    id,
+    kind: "query",
+    connectionId: "conn-1",
+    database: "app",
+    title,
+    sql: "",
+    savedSql: "",
+    dirty: false,
+  };
+}
+
+describe("nextMountedTabIds", () => {
+  it("mounts the active tab on first visit", () => {
+    expect(nextMountedTabIds([], "orders", ["orders", "users"])).toEqual([
+      "orders",
+    ]);
+  });
+
+  it("keeps a visited tab mounted after swapping away", () => {
+    expect(
+      nextMountedTabIds(["orders"], "users", ["orders", "users"]),
+    ).toEqual(["orders", "users"]);
+  });
+
+  it("does not pre-mount tabs that have never been active", () => {
+    expect(
+      nextMountedTabIds(["orders"], "orders", ["orders", "users", "items"]),
+    ).toEqual(["orders"]);
+  });
+
+  it("drops a tab when it is closed", () => {
+    expect(
+      nextMountedTabIds(["orders", "users"], "users", ["users"]),
+    ).toEqual(["users"]);
+  });
+
+  it("mounts a reopened tab fresh after close", () => {
+    expect(nextMountedTabIds(["users"], "orders", ["users", "orders"])).toEqual(
+      ["users", "orders"],
+    );
+  });
+
+  it("ignores an active id that is no longer open", () => {
+    expect(nextMountedTabIds(["orders"], "gone", ["orders"])).toEqual([
+      "orders",
+    ]);
+  });
+
+  it("returns an empty list when nothing is open", () => {
+    expect(nextMountedTabIds(["orders"], null, [])).toEqual([]);
+  });
+});
+
+describe("KeepAlivePanes", () => {
+  it("renders the active tab and leaves never-visited tabs unmounted", () => {
+    const orders = queryTab("orders", "orders.sql");
+    const users = queryTab("users", "users.sql");
+    const html = renderToStaticMarkup(
+      createElement(KeepAlivePanes, {
+        tabs: [orders, users],
+        activeId: "orders",
+        children: (tab: WorkspaceTab) =>
+          createElement(
+            "span",
+            null,
+            tab.kind === "query" ? tab.title : tab.id,
+          ),
+      }),
+    );
+    expect(html).toContain("orders.sql");
+    expect(html).not.toContain("users.sql");
+    expect(html).not.toContain("invisible");
+  });
+});

--- a/apps/desktop/src/components/KeepAlivePanes.tsx
+++ b/apps/desktop/src/components/KeepAlivePanes.tsx
@@ -1,0 +1,94 @@
+import { memo, useRef, type ReactNode } from "react";
+
+import type { WorkspaceTab } from "../state/tabs";
+
+/**
+ * Decide which tabs stay mounted after a swap.
+ *
+ * A tab is mounted the first time it becomes active and stays mounted (hidden)
+ * until it is closed. Never-visited tabs are not pre-mounted so opening many
+ * tables doesn't fire a query for each of them.
+ */
+export function nextMountedTabIds(
+  previouslyMounted: readonly string[],
+  activeId: string | null,
+  openIds: readonly string[],
+): string[] {
+  const open = new Set(openIds);
+  const next: string[] = [];
+  const seen = new Set<string>();
+  for (const id of previouslyMounted) {
+    if (!open.has(id) || seen.has(id)) continue;
+    seen.add(id);
+    next.push(id);
+  }
+  if (activeId && open.has(activeId) && !seen.has(activeId)) {
+    next.push(activeId);
+  }
+  return next;
+}
+
+/**
+ * Keep the heavy pane (grid, editor) from re-rendering when some other tab
+ * becomes active. Visibility is handled by the wrapper; this only receives
+ * the tab and a stable render callback.
+ */
+const FrozenPane = memo(function FrozenPane({
+  tab,
+  render,
+}: {
+  tab: WorkspaceTab;
+  render: (tab: WorkspaceTab) => ReactNode;
+}) {
+  return <>{render(tab)}</>;
+});
+
+/**
+ * Render visited tabs and hide the inactive ones instead of unmounting them.
+ * Table filters, loaded rows, and editor caret survive tab swaps; close still
+ * tears the pane down.
+ *
+ * `children` must be a stable callback (useCallback). An inline function
+ * would re-render every frozen pane on each tab click.
+ */
+export function KeepAlivePanes({
+  tabs,
+  activeId,
+  children,
+}: {
+  tabs: WorkspaceTab[];
+  activeId: string | null;
+  children: (tab: WorkspaceTab) => ReactNode;
+}) {
+  const openIds = tabs.map((tab) => tab.id);
+  const mountedRef = useRef<string[]>([]);
+  const mountedIds = nextMountedTabIds(
+    mountedRef.current,
+    activeId,
+    openIds,
+  );
+  mountedRef.current = mountedIds;
+  const byId = new Map(tabs.map((tab) => [tab.id, tab]));
+
+  return (
+    <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
+      {mountedIds.map((id) => {
+        const tab = byId.get(id);
+        if (!tab) return null;
+        const active = id === activeId;
+        return (
+          <div
+            key={id}
+            className={
+              "absolute inset-0 flex flex-col overflow-hidden " +
+              (active ? "z-10" : "invisible pointer-events-none z-0")
+            }
+            aria-hidden={!active}
+          >
+            <FrozenPane tab={tab} render={children} />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/KeepAlivePanes.tsx
+++ b/apps/desktop/src/components/KeepAlivePanes.tsx
@@ -1,4 +1,4 @@
-import { memo, useRef, type ReactNode } from "react";
+import { memo, useEffect, useState, type ReactNode } from "react";
 
 import type { WorkspaceTab } from "../state/tabs";
 
@@ -8,6 +8,10 @@ import type { WorkspaceTab } from "../state/tabs";
  * A tab is mounted the first time it becomes active and stays mounted (hidden)
  * until it is closed. Never-visited tabs are not pre-mounted so opening many
  * tables doesn't fire a query for each of them.
+ *
+ * `previouslyMounted` is the last *committed* visit set. Callers must not
+ * write this during render — an interrupted concurrent render would otherwise
+ * keep a tab that was never actually shown.
  */
 export function nextMountedTabIds(
   previouslyMounted: readonly string[],
@@ -26,6 +30,10 @@ export function nextMountedTabIds(
     next.push(activeId);
   }
   return next;
+}
+
+function sameIds(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((id, i) => id === b[i]);
 }
 
 /**
@@ -60,14 +68,20 @@ export function KeepAlivePanes({
   activeId: string | null;
   children: (tab: WorkspaceTab) => ReactNode;
 }) {
+  // Committed after paint so a discarded concurrent render cannot leak an
+  // unvisited tab into the mount set (and kick off its table query).
+  const [visited, setVisited] = useState<string[]>([]);
   const openIds = tabs.map((tab) => tab.id);
-  const mountedRef = useRef<string[]>([]);
-  const mountedIds = nextMountedTabIds(
-    mountedRef.current,
-    activeId,
-    openIds,
-  );
-  mountedRef.current = mountedIds;
+  const mountedIds = nextMountedTabIds(visited, activeId, openIds);
+
+  useEffect(() => {
+    const open = tabs.map((tab) => tab.id);
+    setVisited((prev) => {
+      const next = nextMountedTabIds(prev, activeId, open);
+      return sameIds(prev, next) ? prev : next;
+    });
+  }, [activeId, tabs]);
+
   const byId = new Map(tabs.map((tab) => [tab.id, tab]));
 
   return (

--- a/apps/desktop/src/components/SqlEditor.tsx
+++ b/apps/desktop/src/components/SqlEditor.tsx
@@ -51,6 +51,9 @@ const EMPTY_DATABASES: Database[] = [];
 
 export function SqlEditor({ tab }: { tab: QueryTab }) {
   const setQuerySql = useTabs((s) => s.setQuerySql);
+  // Keep-alive leaves this editor mounted while hidden; the window-level
+  // cancel shortcut must only fire for the focused tab.
+  const isActiveTab = useTabs((s) => s.activeId === tab.id);
   const connectionState = useConnections((s) => s.byId[tab.connectionId]);
   const status = connectionState?.status;
   const databases = connectionState?.databases ?? EMPTY_DATABASES;
@@ -240,9 +243,10 @@ export function SqlEditor({ tab }: { tab: QueryTab }) {
   }, [clearError, closePanel, errorLine, setQuerySql, tab.id]);
 
   // ⌘. / Ctrl+. cancels the in-flight statement, matching the toolbar button.
-  // Window-level so it works while focus sits inside the code editor.
+  // Window-level so it works while focus sits inside the code editor. Skip
+  // hidden keep-alive editors so the shortcut cannot cancel another tab.
   useEffect(() => {
-    if (!running) return;
+    if (!running || !isActiveTab) return;
     const onKey = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === ".") {
         e.preventDefault();
@@ -251,7 +255,7 @@ export function SqlEditor({ tab }: { tab: QueryTab }) {
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [running, cancel]);
+  }, [running, cancel, isActiveTab]);
 
   useEffect(() => {
     if (!connected || loadingSchema || databases.length > 0) return;

--- a/apps/desktop/src/components/Workspace.tsx
+++ b/apps/desktop/src/components/Workspace.tsx
@@ -25,6 +25,7 @@ import {
   type ContextMenuState,
   type MenuItem,
 } from "./ContextMenu";
+import { KeepAlivePanes } from "./KeepAlivePanes";
 import { TabBar } from "./TabBar";
 import { CellarMark } from "./CellarMark";
 import { Icon } from "./icons";
@@ -48,9 +49,15 @@ export function Workspace({ onCommit }: { onCommit?: () => void } = {}) {
   const tabs = useTabs((s) => s.tabs);
   const activeId = useTabs((s) => s.activeId);
   const split = useTabs((s) => s.split);
+  const tabPane = useTabs((s) => s.tabPane);
   const paneActive = useTabs((s) => s.paneActive);
   const focusedPane = useTabs((s) => s.focusedPane);
   const active = tabs.find((t) => t.id === activeId) ?? null;
+  // Stable across tab swaps so KeepAlivePanes can skip re-rendering hidden grids.
+  const renderPane = useCallback(
+    (tab: WorkspaceTab) => renderTab(tab, onCommit),
+    [onCommit],
+  );
   // Fraction of the split given to the primary pane; dragging the divider moves it.
   const [ratio, setRatio] = useState(0.5);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -100,6 +107,7 @@ export function Workspace({ onCommit }: { onCommit?: () => void } = {}) {
         <SplitPane
           pane={0}
           tab={primary}
+          tabs={tabs.filter((t) => (tabPane[t.id] ?? 0) === 0)}
           focused={focusedPane === 0}
           grow={ratio}
           onCommit={onCommit}
@@ -126,15 +134,16 @@ export function Workspace({ onCommit }: { onCommit?: () => void } = {}) {
         <SplitPane
           pane={1}
           tab={secondary}
+          tabs={tabs.filter((t) => (tabPane[t.id] ?? 0) === 1)}
           focused={focusedPane === 1}
           grow={1 - ratio}
           onCommit={onCommit}
         />
       </div>
     ) : (
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        {renderTab(active, onCommit)}
-      </div>
+      <KeepAlivePanes tabs={tabs} activeId={active.id}>
+        {renderPane}
+      </KeepAlivePanes>
     );
 
   return (
@@ -148,17 +157,23 @@ export function Workspace({ onCommit }: { onCommit?: () => void } = {}) {
 function SplitPane({
   pane,
   tab,
+  tabs,
   focused,
   grow,
   onCommit,
 }: {
   pane: PaneIndex;
   tab: WorkspaceTab;
+  tabs: WorkspaceTab[];
   focused: boolean;
   grow: number;
   onCommit?: () => void;
 }) {
   const focusPane = useTabs((s) => s.focusPane);
+  const renderPane = useCallback(
+    (paneTab: WorkspaceTab) => renderTab(paneTab, onCommit),
+    [onCommit],
+  );
   return (
     <section
       style={{ flexGrow: grow }}
@@ -169,9 +184,9 @@ function SplitPane({
       onMouseDown={() => focusPane(pane)}
     >
       <TabBar pane={pane} />
-      <div className="flex min-h-0 flex-1 overflow-hidden">
-        {renderTab(tab, onCommit)}
-      </div>
+      <KeepAlivePanes tabs={tabs} activeId={tab.id}>
+        {renderPane}
+      </KeepAlivePanes>
     </section>
   );
 }
@@ -240,8 +255,8 @@ function renderTab(tab: WorkspaceTab, onCommit?: () => void) {
     // `key` resets zoom/pan and node positions per diagram tab.
     return <ErDiagram key={tab.id} tab={tab} />;
   }
-  // `key` resets ephemeral grid state (selection/editing) when the user
-  // switches table tabs. Filters restore from `useTabs.tableFilters`.
+  // KeepAlivePanes keeps this mounted (hidden) across tab swaps so filters
+  // and loaded rows survive. `key` still resets state if the tab remounts.
   return <TableTabPane key={tab.id} tab={tab} onCommit={onCommit} />;
 }
 


### PR DESCRIPTION
## Summary
Visited table tabs stay mounted and hidden instead of remounting, so filters and loaded rows survive a switch without a reload. Inactive grids skip re-render so clicking a tab stays snappy. Closing a tab still tears the pane down, and never-visited tabs are not pre-mounted.

## Test plan
- Open two tables, filter A, switch to B, filter B, switch back — A's filter and rows should still be there with no loading spinner.
- Click between the tabs and confirm the switch feels immediate.
- Close a table tab and reopen it — it should load fresh.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace tabs now preserve their content and state when switching between tabs.
  * Previously visited tabs remain ready for faster switching, while unvisited and closed tabs are handled efficiently.

* **Tests**
  * Added coverage for tab mounting, retention, reopening, closing, invalid selections, empty tab lists, and server-rendered pane behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->