### PR TITLE
docs: add 0.3.9 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.3.9
+
+### Bug fixes
+
+- **Table filters survive tab switches** — filter chips and the quick-filter
+  text stay in place when you move between tables, including values you were
+  still typing.
+- **Tables stay loaded when you switch away** — visited table panes remain
+  mounted, so switching back is instant and no longer reloads rows or resets
+  the grid.
+
 ## 0.3.8
 
 ### Features


### PR DESCRIPTION
## Summary
- Add the 0.3.9 changelog covering table filters that persist across tab switches and visited tables that stay loaded in the background.
- Prep for tagging and releasing 0.3.9.

## Test plan
- [x] Confirm CHANGELOG.md has a `## 0.3.9` section at the top
- [ ] After merge, tag `0.3.9` and push to trigger the Release workflow


Made with [Cursor](https://cursor.com)