### PR TITLE
fix(gpui): dispatch Cmd+K through ToggleCommandPalette

### DIFF
--- a/apps/desktop-gpui/src/app/command_palette.rs
+++ b/apps/desktop-gpui/src/app/command_palette.rs
@@ -71,7 +71,7 @@ impl PaletteEntry {
 }
 
 impl CellarApp {
-    pub(super) fn toggle_command_palette(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+    pub(crate) fn toggle_command_palette(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if self.command_palette.take().is_some() {
             self.command_palette_subscription = None;
             cx.notify();

--- a/apps/desktop-gpui/src/app/commit.rs
+++ b/apps/desktop-gpui/src/app/commit.rs
@@ -31,6 +31,17 @@ impl CommitReview {
 }
 
 impl CellarApp {
+    pub(crate) fn review_pending_changes(&mut self, cx: &mut Context<Self>) {
+        if let Some(grid) = self
+            .model
+            .active_tab()
+            .and_then(|tab| self.grids.get(&tab.id))
+            .cloned()
+        {
+            grid.update(cx, |grid, cx| grid.request_review(cx));
+        }
+    }
+
     pub(super) fn open_commit_review(
         &mut self,
         tab_id: u64,

--- a/apps/desktop-gpui/src/app/connection_editor.rs
+++ b/apps/desktop-gpui/src/app/connection_editor.rs
@@ -205,7 +205,7 @@ impl ConnectionEditor {
 }
 
 impl CellarApp {
-    pub(super) fn open_connection_editor(
+    pub(crate) fn open_connection_editor(
         &mut self,
         config: Option<ConnectionConfig>,
         window: &mut Window,

--- a/apps/desktop-gpui/src/app/query_control.rs
+++ b/apps/desktop-gpui/src/app/query_control.rs
@@ -16,6 +16,12 @@ pub(super) fn required_analyze_confirmations(_production: bool, _destructive: bo
 }
 
 impl CellarApp {
+    pub(crate) fn cancel_active_query(&mut self, cx: &mut Context<Self>) {
+        if let Some(tab_id) = self.model.active_tab().map(|tab| tab.id) {
+            self.cancel_query(tab_id, cx);
+        }
+    }
+
     pub(super) fn cancel_query(&mut self, tab_id: u64, cx: &mut Context<Self>) {
         let Some((connection_id, engine)) = self.model.tabs().iter().find_map(|tab| {
             if tab.id != tab_id {

--- a/apps/desktop-gpui/src/app/query_workspace.rs
+++ b/apps/desktop-gpui/src/app/query_workspace.rs
@@ -34,7 +34,7 @@ enum QueryUiEvent {
 }
 
 impl CellarApp {
-    pub(super) fn new_query(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+    pub(crate) fn new_query(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let target = self
             .model
             .active_tab()
@@ -169,6 +169,30 @@ impl CellarApp {
                 .update(cx, |state, cx| state.set_value("false", window, cx));
         }
         cx.notify();
+    }
+
+    pub(crate) fn run_active_query(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.save_template_editor.is_some() {
+            self.save_query_template(cx);
+            return;
+        }
+        if let Some(tab_id) = self
+            .model
+            .active_tab()
+            .and_then(|tab| matches!(&tab.kind, TabKind::Query { .. }).then_some(tab.id))
+        {
+            self.start_query(tab_id, window, cx);
+        }
+    }
+
+    pub(crate) fn run_active_query_all(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if let Some(tab_id) = self
+            .model
+            .active_tab()
+            .and_then(|tab| matches!(&tab.kind, TabKind::Query { .. }).then_some(tab.id))
+        {
+            self.start_query_all(tab_id, window, cx);
+        }
     }
 
     pub(super) fn start_query(&mut self, tab_id: u64, window: &mut Window, cx: &mut Context<Self>) {

--- a/apps/desktop-gpui/src/app/render.rs
+++ b/apps/desktop-gpui/src/app/render.rs
@@ -29,9 +29,7 @@ impl Render for CellarApp {
                 let app = app.clone();
                 move |_: &crate::app_menu::NewConnection, window, cx| {
                     if let Some(app) = app.upgrade() {
-                        app.update(cx, |this, cx| {
-                            this.open_connection_editor(None, window, cx)
-                        });
+                        app.update(cx, |this, cx| this.open_connection_editor(None, window, cx));
                     }
                 }
             })
@@ -55,11 +53,7 @@ impl Render for CellarApp {
                 let app = app.clone();
                 move |_: &crate::app_menu::CloseTab, _, cx| {
                     if let Some(app) = app.upgrade() {
-                        app.update(cx, |this, cx| {
-                            if let Some(tab_id) = this.model.active_tab().map(|tab| tab.id) {
-                                this.close_tab(tab_id, cx);
-                            }
-                        });
+                        app.update(cx, |this, cx| this.close_active_tab(cx));
                     }
                 }
             })
@@ -67,10 +61,7 @@ impl Render for CellarApp {
                 let app = app.clone();
                 move |_: &crate::app_menu::ToggleSidebar, _, cx| {
                     if let Some(app) = app.upgrade() {
-                        app.update(cx, |this, cx| {
-                            this.sidebar_open = !this.sidebar_open;
-                            cx.notify();
-                        });
+                        app.update(cx, |this, cx| this.toggle_sidebar(cx));
                     }
                 }
             })
@@ -78,10 +69,7 @@ impl Render for CellarApp {
                 let app = app.clone();
                 move |_: &crate::app_menu::ToggleAiPanel, _, cx| {
                     if let Some(app) = app.upgrade() {
-                        app.update(cx, |this, cx| {
-                            this.right_panel_open = !this.right_panel_open;
-                            cx.notify();
-                        });
+                        app.update(cx, |this, cx| this.toggle_ai_panel(cx));
                     }
                 }
             })
@@ -89,10 +77,47 @@ impl Render for CellarApp {
                 let app = app.clone();
                 move |_: &crate::app_menu::ToggleBottomPanel, _, cx| {
                     if let Some(app) = app.upgrade() {
-                        app.update(cx, |this, cx| {
-                            this.bottom_panel_open = !this.bottom_panel_open;
-                            cx.notify();
-                        });
+                        app.update(cx, |this, cx| this.toggle_bottom_panel(cx));
+                    }
+                }
+            })
+            .on_action({
+                let app = app.clone();
+                move |_: &crate::app_menu::RunQuery, window, cx| {
+                    if let Some(app) = app.upgrade() {
+                        app.update(cx, |this, cx| this.run_active_query(window, cx));
+                    }
+                }
+            })
+            .on_action({
+                let app = app.clone();
+                move |_: &crate::app_menu::RunQueryAll, window, cx| {
+                    if let Some(app) = app.upgrade() {
+                        app.update(cx, |this, cx| this.run_active_query_all(window, cx));
+                    }
+                }
+            })
+            .on_action({
+                let app = app.clone();
+                move |_: &crate::app_menu::CancelQuery, _, cx| {
+                    if let Some(app) = app.upgrade() {
+                        app.update(cx, |this, cx| this.cancel_active_query(cx));
+                    }
+                }
+            })
+            .on_action({
+                let app = app.clone();
+                move |_: &crate::app_menu::ReviewChanges, _, cx| {
+                    if let Some(app) = app.upgrade() {
+                        app.update(cx, |this, cx| this.review_pending_changes(cx));
+                    }
+                }
+            })
+            .on_action({
+                let app = app.clone();
+                move |_: &crate::app_menu::Find, window, cx| {
+                    if let Some(app) = app.upgrade() {
+                        app.update(cx, |this, cx| this.focus_find(window, cx));
                     }
                 }
             })
@@ -123,74 +148,6 @@ impl Render for CellarApp {
                         .is_some_and(|review| review.preview.is_some() && !review.committing)
                 {
                     this.start_commit(cx);
-                    cx.stop_propagation();
-                } else if event.keystroke.modifiers.secondary() && event.keystroke.key == "," {
-                    this.open_settings(settings::SettingsCategory::Appearance, cx);
-                    cx.stop_propagation();
-                } else if event.keystroke.modifiers.secondary() && event.keystroke.key == "n" {
-                    this.open_connection_editor(None, window, cx);
-                    cx.stop_propagation();
-                } else if event.keystroke.modifiers.secondary() && event.keystroke.key == "t" {
-                    this.new_query(window, cx);
-                    cx.stop_propagation();
-                } else if this.save_template_editor.is_some()
-                    && event.keystroke.modifiers.secondary()
-                    && event.keystroke.key == "enter"
-                {
-                    this.save_query_template(cx);
-                    cx.stop_propagation();
-                } else if event.keystroke.modifiers.secondary() && event.keystroke.key == "enter" {
-                    if let Some(tab_id) = this.model.active_tab().and_then(|tab| {
-                        matches!(&tab.kind, cellar_desktop_gpui::model::TabKind::Query { .. })
-                            .then_some(tab.id)
-                    }) {
-                        if event.keystroke.modifiers.shift {
-                            this.start_query_all(tab_id, window, cx);
-                        } else {
-                            this.start_query(tab_id, window, cx);
-                        }
-                    }
-                    cx.stop_propagation();
-                } else if event.keystroke.modifiers.secondary() && event.keystroke.key == "." {
-                    if let Some(tab_id) = this.model.active_tab().map(|tab| tab.id) {
-                        this.cancel_query(tab_id, cx);
-                    }
-                    cx.stop_propagation();
-                } else if event.keystroke.modifiers.secondary() && event.keystroke.key == "w" {
-                    if let Some(tab_id) = this.model.active_tab().map(|tab| tab.id) {
-                        this.close_tab(tab_id, cx);
-                    }
-                    cx.stop_propagation();
-                } else if event.keystroke.modifiers.secondary() && event.keystroke.key == "s" {
-                    if let Some(grid) = this
-                        .model
-                        .active_tab()
-                        .and_then(|tab| this.grids.get(&tab.id))
-                        .cloned()
-                    {
-                        grid.update(cx, |grid, cx| grid.request_review(cx));
-                    }
-                    cx.stop_propagation();
-                } else if event.keystroke.modifiers.secondary() && event.keystroke.key == "b" {
-                    this.sidebar_open = !this.sidebar_open;
-                    cx.notify();
-                    cx.stop_propagation();
-                } else if event.keystroke.modifiers.secondary() && event.keystroke.key == "j" {
-                    this.right_panel_open = !this.right_panel_open;
-                    cx.notify();
-                    cx.stop_propagation();
-                } else if event.keystroke.modifiers.secondary() && event.keystroke.key == "down" {
-                    this.bottom_panel_open = !this.bottom_panel_open;
-                    cx.notify();
-                    cx.stop_propagation();
-                } else if event.keystroke.modifiers.secondary() && event.keystroke.key == "f" {
-                    if this.settings_open {
-                        this.settings_search
-                            .update(cx, |search, cx| search.focus(window, cx));
-                    } else {
-                        this.sidebar_filter
-                            .update(cx, |filter, cx| filter.focus(window, cx));
-                    }
                     cx.stop_propagation();
                 } else if event.keystroke.key == "escape" {
                     if this.save_template_editor.take().is_some() {

--- a/apps/desktop-gpui/src/app/render.rs
+++ b/apps/desktop-gpui/src/app/render.rs
@@ -45,6 +45,14 @@ impl Render for CellarApp {
             })
             .on_action({
                 let app = app.clone();
+                move |_: &crate::app_menu::ToggleCommandPalette, window, cx| {
+                    if let Some(app) = app.upgrade() {
+                        app.update(cx, |this, cx| this.toggle_command_palette(window, cx));
+                    }
+                }
+            })
+            .on_action({
+                let app = app.clone();
                 move |_: &crate::app_menu::CloseTab, _, cx| {
                     if let Some(app) = app.upgrade() {
                         app.update(cx, |this, cx| {

--- a/apps/desktop-gpui/src/app/render.rs
+++ b/apps/desktop-gpui/src/app/render.rs
@@ -116,9 +116,6 @@ impl Render for CellarApp {
                 {
                     this.start_commit(cx);
                     cx.stop_propagation();
-                } else if event.keystroke.modifiers.secondary() && event.keystroke.key == "k" {
-                    this.toggle_command_palette(window, cx);
-                    cx.stop_propagation();
                 } else if event.keystroke.modifiers.secondary() && event.keystroke.key == "," {
                     this.open_settings(settings::SettingsCategory::Appearance, cx);
                     cx.stop_propagation();

--- a/apps/desktop-gpui/src/app/shell.rs
+++ b/apps/desktop-gpui/src/app/shell.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 
 use gpui::{
     div, prelude::*, AnyElement, Context, MouseButton, MouseDownEvent, Pixels, Point, SharedString,
-    WindowControlArea,
+    Window, WindowControlArea,
 };
 use gpui_component::Icon;
 
@@ -542,6 +542,31 @@ impl CellarApp {
 
     pub(super) fn ai_panel(&self, cx: &mut Context<Self>) -> impl IntoElement {
         self.render_ai_panel(cx)
+    }
+
+    pub(crate) fn toggle_sidebar(&mut self, cx: &mut Context<Self>) {
+        self.sidebar_open = !self.sidebar_open;
+        cx.notify();
+    }
+
+    pub(crate) fn toggle_ai_panel(&mut self, cx: &mut Context<Self>) {
+        self.right_panel_open = !self.right_panel_open;
+        cx.notify();
+    }
+
+    pub(crate) fn toggle_bottom_panel(&mut self, cx: &mut Context<Self>) {
+        self.bottom_panel_open = !self.bottom_panel_open;
+        cx.notify();
+    }
+
+    pub(crate) fn focus_find(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.settings_open {
+            self.settings_search
+                .update(cx, |search, cx| search.focus(window, cx));
+        } else {
+            self.sidebar_filter
+                .update(cx, |filter, cx| filter.focus(window, cx));
+        }
     }
 }
 

--- a/apps/desktop-gpui/src/app/workspace.rs
+++ b/apps/desktop-gpui/src/app/workspace.rs
@@ -573,6 +573,12 @@ impl CellarApp {
             .into_any_element()
     }
 
+    pub(crate) fn close_active_tab(&mut self, cx: &mut Context<Self>) {
+        if let Some(tab_id) = self.model.active_tab().map(|tab| tab.id) {
+            self.close_tab(tab_id, cx);
+        }
+    }
+
     pub(super) fn close_tab(&mut self, id: u64, cx: &mut Context<Self>) {
         if let Some(tab) = self.model.tabs().iter().find(|tab| tab.id == id) {
             if let TabKind::Table { target, .. } = &tab.kind {

--- a/apps/desktop-gpui/src/app_menu.rs
+++ b/apps/desktop-gpui/src/app_menu.rs
@@ -21,6 +21,7 @@ actions!(
         ToggleSidebar,
         ToggleAiPanel,
         ToggleBottomPanel,
+        ToggleCommandPalette,
         OpenGitHub,
         OpenChangelog
     ]
@@ -35,6 +36,7 @@ pub fn setup(app: &Entity<CellarApp>, cx: &mut App) {
         KeyBinding::new("cmd-q", Quit, None),
         KeyBinding::new("cmd-n", NewConnection, None),
         KeyBinding::new("cmd-t", NewQuery, None),
+        KeyBinding::new("cmd-k", ToggleCommandPalette, None),
         KeyBinding::new("cmd-w", CloseTab, None),
         KeyBinding::new("cmd-b", ToggleSidebar, None),
         KeyBinding::new("cmd-j", ToggleAiPanel, None),
@@ -44,6 +46,18 @@ pub fn setup(app: &Entity<CellarApp>, cx: &mut App) {
     let settings_app = app.clone();
     cx.on_action(move |_: &Settings, cx| {
         settings_app.update(cx, |app, cx| app.open_appearance_settings(cx));
+    });
+    let palette_app = app.clone();
+    cx.on_action(move |_: &ToggleCommandPalette, cx| {
+        let Some(window) = cx.active_window() else {
+            return;
+        };
+        let app = palette_app.clone();
+        window
+            .update(cx, |_, window, cx| {
+                app.update(cx, |app, cx| app.toggle_command_palette(window, cx));
+            })
+            .ok();
     });
     let about_app = app.clone();
     cx.on_action(move |_: &About, cx| {
@@ -100,6 +114,8 @@ pub fn setup(app: &Entity<CellarApp>, cx: &mut App) {
         Menu {
             name: "View".into(),
             items: vec![
+                MenuItem::action("Command Palette", ToggleCommandPalette),
+                MenuItem::separator(),
                 MenuItem::action("Toggle Sidebar", ToggleSidebar),
                 MenuItem::action("Toggle AI Panel", ToggleAiPanel),
                 MenuItem::action("Toggle Output Panel", ToggleBottomPanel),

--- a/apps/desktop-gpui/src/app_menu.rs
+++ b/apps/desktop-gpui/src/app_menu.rs
@@ -53,11 +53,13 @@ pub fn setup(app: &Entity<CellarApp>, cx: &mut App) {
             return;
         };
         let app = palette_app.clone();
-        window
-            .update(cx, |_, window, cx| {
-                app.update(cx, |app, cx| app.toggle_command_palette(window, cx));
-            })
-            .ok();
+        cx.defer(move |cx| {
+            window
+                .update(cx, |_, window, cx| {
+                    app.update(cx, |app, cx| app.toggle_command_palette(window, cx));
+                })
+                .ok();
+        });
     });
     let about_app = app.clone();
     cx.on_action(move |_: &About, cx| {

--- a/apps/desktop-gpui/src/app_menu.rs
+++ b/apps/desktop-gpui/src/app_menu.rs
@@ -1,4 +1,4 @@
-use gpui::{actions, App, Entity, KeyBinding, Menu, MenuItem, OsAction, SystemMenuType};
+use gpui::{actions, App, Entity, KeyBinding, Menu, MenuItem, OsAction, SystemMenuType, Window};
 use gpui_component::input::{Copy, Cut, Paste, Redo, SelectAll, Undo};
 
 use crate::app::CellarApp;
@@ -22,6 +22,11 @@ actions!(
         ToggleAiPanel,
         ToggleBottomPanel,
         ToggleCommandPalette,
+        RunQuery,
+        RunQueryAll,
+        CancelQuery,
+        ReviewChanges,
+        Find,
         OpenGitHub,
         OpenChangelog
     ]
@@ -41,39 +46,42 @@ pub fn setup(app: &Entity<CellarApp>, cx: &mut App) {
         KeyBinding::new("cmd-b", ToggleSidebar, None),
         KeyBinding::new("cmd-j", ToggleAiPanel, None),
         KeyBinding::new("cmd-down", ToggleBottomPanel, None),
+        KeyBinding::new("cmd-enter", RunQuery, None),
+        KeyBinding::new("cmd-shift-enter", RunQueryAll, None),
+        KeyBinding::new("cmd-.", CancelQuery, None),
+        KeyBinding::new("cmd-s", ReviewChanges, None),
+        KeyBinding::new("cmd-f", Find, None),
     ]);
 
-    let settings_app = app.clone();
-    cx.on_action(move |_: &Settings, cx| {
-        settings_app.update(cx, |app, cx| app.open_appearance_settings(cx));
+    on_app_action::<Settings>(app, cx, |app, cx| app.open_appearance_settings(cx));
+    on_app_action::<About>(app, cx, |app, cx| app.open_about_settings(cx));
+    on_app_action::<CloseTab>(app, cx, |app, cx| app.close_active_tab(cx));
+    on_app_action::<ToggleSidebar>(app, cx, |app, cx| app.toggle_sidebar(cx));
+    on_app_action::<ToggleAiPanel>(app, cx, |app, cx| app.toggle_ai_panel(cx));
+    on_app_action::<ToggleBottomPanel>(app, cx, |app, cx| app.toggle_bottom_panel(cx));
+    on_app_action::<CancelQuery>(app, cx, |app, cx| app.cancel_active_query(cx));
+    on_app_action::<ReviewChanges>(app, cx, |app, cx| app.review_pending_changes(cx));
+
+    on_window_action::<ToggleCommandPalette>(app, cx, |app, window, cx| {
+        app.toggle_command_palette(window, cx)
     });
-    let palette_app = app.clone();
-    cx.on_action(move |_: &ToggleCommandPalette, cx| {
-        let Some(window) = cx.active_window() else {
-            return;
-        };
-        let app = palette_app.clone();
-        cx.defer(move |cx| {
-            window
-                .update(cx, |_, window, cx| {
-                    app.update(cx, |app, cx| app.toggle_command_palette(window, cx));
-                })
-                .ok();
-        });
+    on_window_action::<NewConnection>(app, cx, |app, window, cx| {
+        app.open_connection_editor(None, window, cx)
     });
-    let about_app = app.clone();
-    cx.on_action(move |_: &About, cx| {
-        about_app.update(cx, |app, cx| app.open_about_settings(cx));
+    on_window_action::<NewQuery>(app, cx, |app, window, cx| app.new_query(window, cx));
+    on_window_action::<RunQuery>(app, cx, |app, window, cx| app.run_active_query(window, cx));
+    on_window_action::<RunQueryAll>(app, cx, |app, window, cx| {
+        app.run_active_query_all(window, cx)
     });
+    on_window_action::<Find>(app, cx, |app, window, cx| app.focus_find(window, cx));
+
     cx.on_action(|_: &Hide, cx| cx.hide());
     cx.on_action(|_: &HideOthers, cx| cx.hide_other_apps());
     cx.on_action(|_: &ShowAll, cx| cx.unhide_other_apps());
     cx.on_action(|_: &BringAllToFront, cx| cx.activate(true));
     cx.on_action(|_: &Quit, cx| cx.quit());
     cx.on_action(|_: &OpenGitHub, cx| cx.open_url("https://github.com/MRL-00/cellar"));
-    cx.on_action(|_: &OpenChangelog, cx| {
-        cx.open_url("https://github.com/MRL-00/cellar/releases")
-    });
+    cx.on_action(|_: &OpenChangelog, cx| cx.open_url("https://github.com/MRL-00/cellar/releases"));
 
     cx.set_menus(vec![
         Menu {
@@ -111,6 +119,8 @@ pub fn setup(app: &Entity<CellarApp>, cx: &mut App) {
                 MenuItem::os_action("Copy", Copy, OsAction::Copy),
                 MenuItem::os_action("Paste", Paste, OsAction::Paste),
                 MenuItem::os_action("Select All", SelectAll, OsAction::SelectAll),
+                MenuItem::separator(),
+                MenuItem::action("Find", Find),
             ],
         },
         Menu {
@@ -140,4 +150,37 @@ pub fn setup(app: &Entity<CellarApp>, cx: &mut App) {
             ],
         },
     ]);
+}
+
+fn on_app_action<A: gpui::Action>(
+    app: &Entity<CellarApp>,
+    cx: &mut App,
+    listener: impl Fn(&mut CellarApp, &mut gpui::Context<CellarApp>) + 'static,
+) {
+    let app = app.clone();
+    cx.on_action(move |_: &A, cx| {
+        app.update(cx, |app, cx| listener(app, cx));
+    });
+}
+
+fn on_window_action<A: gpui::Action>(
+    app: &Entity<CellarApp>,
+    cx: &mut App,
+    listener: impl Fn(&mut CellarApp, &mut Window, &mut gpui::Context<CellarApp>) + Clone + 'static,
+) {
+    let app = app.clone();
+    cx.on_action(move |_: &A, cx| {
+        let Some(handle) = cx.active_window() else {
+            return;
+        };
+        let app = app.clone();
+        let listener = listener.clone();
+        cx.defer(move |cx| {
+            handle
+                .update(cx, |_, window, cx| {
+                    app.update(cx, |app, cx| listener(app, window, cx));
+                })
+                .ok();
+        });
+    });
 }

--- a/apps/desktop-gpui/src/grid/keyboard.rs
+++ b/apps/desktop-gpui/src/grid/keyboard.rs
@@ -110,5 +110,9 @@ mod tests {
             Some(GridKeyAction::DeleteRow)
         );
         assert_eq!(grid_key_action("k", true, false), None);
+        assert_eq!(grid_key_action("n", true, false), None);
+        assert_eq!(grid_key_action("t", true, false), None);
+        assert_eq!(grid_key_action("f", true, false), None);
+        assert_eq!(grid_key_action("enter", true, false), None);
     }
 }

--- a/apps/desktop-gpui/src/grid/keyboard.rs
+++ b/apps/desktop-gpui/src/grid/keyboard.rs
@@ -109,5 +109,6 @@ mod tests {
             grid_key_action("delete", false, false),
             Some(GridKeyAction::DeleteRow)
         );
+        assert_eq!(grid_key_action("k", true, false), None);
     }
 }


### PR DESCRIPTION
## Why

Cmd+K worked after the last commit. The rest still failed because macOS menu key equivalents dispatch an action on the focused node, and only ToggleCommandPalette had a global handler. Root focus also skips the app view's `on_key_down`.

## Scope

- Bind the remaining implemented chords as actions (`cmd-n/t/w/b/j/,/down/enter/shift-enter/./s/f`).
- Register global `on_action` handlers. Handlers that need a `Window` defer `window.update` so GPUI is not re-entered.
- Handle the same actions on the CellarApp view when it is on the dispatch path.
- Delete the duplicate `on_key_down` branches.
- Grid-local chords (edit, revert, Cmd+Shift+Z, Cmd+Backspace) stay on the grid.

Out of scope: settings entries that were never wired (Alt+Enter run selection, Format, Tab ghost text, F12, keymap rebinding).

## Verification

- `cargo test -p cellar-desktop-gpui --offline --lib --bins -- grid::keyboard::tests app::command_palette::tests` passed.
- Rebuilt `target/debug/cellar-desktop-gpui`.
- Live Cmd+N opened New connection. Cmd+, opened Appearance settings.