### PR TITLE
fix(gpui): keep vertical wheel from scrolling the grid sideways

### DIFF
--- a/apps/desktop-gpui/src/grid.rs
+++ b/apps/desktop-gpui/src/grid.rs
@@ -746,13 +746,19 @@ fn clipboard_rows(text: &str) -> Vec<Vec<String>> {
         .collect()
 }
 
+pub(super) fn wheel_scrolls_horizontally(delta: gpui::Point<gpui::Pixels>) -> bool {
+    f32::from(delta.x).abs() > f32::from(delta.y).abs()
+}
+
 #[cfg(test)]
 mod tests {
     use cellar_core::query::SortDirection;
 
     use super::{
         auto_fit_width, clipboard_rows, moved_index, next_sort_direction, visible_column_range,
+        wheel_scrolls_horizontally,
     };
+    use gpui::{point, px};
 
     #[test]
     fn column_autofit_covers_headers_and_values_with_safe_bounds() {
@@ -801,5 +807,13 @@ mod tests {
             (0..5).map(|i| moved_index(i, 3, 1)).collect::<Vec<_>>(),
             vec![0, 2, 3, 1, 4]
         );
+    }
+
+    #[test]
+    fn vertical_wheel_does_not_count_as_horizontal() {
+        assert!(!wheel_scrolls_horizontally(point(px(0.), px(40.))));
+        assert!(!wheel_scrolls_horizontally(point(px(4.), px(40.))));
+        assert!(wheel_scrolls_horizontally(point(px(40.), px(4.))));
+        assert!(!wheel_scrolls_horizontally(point(px(10.), px(10.))));
     }
 }

--- a/apps/desktop-gpui/src/grid/view.rs
+++ b/apps/desktop-gpui/src/grid/view.rs
@@ -202,7 +202,13 @@ impl Render for DataGrid {
                     .min_h_0()
                     .overflow_x_scroll()
                     .track_scroll(&self.horizontal_scroll)
-                    .on_scroll_wheel(cx.listener(|_, _: &ScrollWheelEvent, _, cx| cx.notify()))
+                    .on_scroll_wheel(cx.listener(|_, event: &ScrollWheelEvent, window, cx| {
+                        let delta = event.delta.pixel_delta(window.line_height());
+                        if !super::wheel_scrolls_horizontally(delta) {
+                            cx.stop_propagation();
+                        }
+                        cx.notify();
+                    }))
                     .child(self.header(columns.clone(), horizontal_offset, grid.clone()))
                     .child(
                         uniform_list(


### PR DESCRIPTION
## Why

The native grid wraps the header and row list in `overflow_x_scroll`. GPUI 0.2.2 maps a vertical wheel onto that axis when overflow-y is not Scroll. A trackpad flick then pans the columns as well as the rows.

## Scope

- `wheel_scrolls_horizontally` in `apps/desktop-gpui/src/grid.rs` is true only when `|dx| > |dy|`.
- The `native-grid-scroller` `on_scroll_wheel` handler in `apps/desktop-gpui/src/grid/view.rs` calls `stop_propagation` for vertical-intent wheels so `uniform_list` can consume them.

Out of scope: other overflow-x chrome (sidebar, settings lists).

## Tradeoffs

Equal `|dx|` and `|dy|` counts as vertical. That keeps jittery trackpads from stealing the row list. A true diagonal pan still reaches the column scroller.

`Style.restrict_scroll_to_axis` exists in GPUI but is not refineable from the fluent API, so the handler is the smallest fix.

## Blast Radius

GPUI data grid horizontal scroll only. Header column drag and explicit horizontal wheels are unchanged.

## Verification

- `cargo test -p cellar-desktop-gpui --offline --lib --bins -- grid::tests::vertical_wheel_does_not_count_as_horizontal` passed.
- `cargo test -p cellar-desktop-gpui --offline --lib --bins` passed (26 lib + 47 bin).
- Live window capture of this binary was black (no Screen Recording permission), so the wheel path was not confirmed on screen.


Made with [Cursor](https://cursor.com)