### PR TITLE
fix(gpui): drop vendor padding from nested chrome inputs

### DIFF
--- a/apps/desktop-gpui/src/app.rs
+++ b/apps/desktop-gpui/src/app.rs
@@ -82,7 +82,6 @@ use gpui::{
     MouseDownEvent, Pixels, Render, SharedString, Subscription, Window,
 };
 use gpui_component::{
-    input::Input,
     input::InputState,
     slider::{SliderEvent, SliderState, SliderValue},
     Icon,
@@ -105,6 +104,7 @@ use cellar_desktop_gpui::{
         ui_px, BG, BORDER, BORDER_SEPARATOR, FG, FG_DISABLED, FG_MUTED, INSERT, INSET, PANEL_MUTED,
         PANEL_RAISED, WARN, WARN_SOFT,
     },
+    widgets::compact_input,
 };
 
 pub struct CellarApp {
@@ -599,12 +599,7 @@ impl CellarApp {
                     .bg(INSET)
                     .text_color(FG_MUTED)
                     .child(Icon::empty().path("icons/search.svg").size(ui_px(11.)))
-                    .child(
-                        Input::new(&self.sidebar_filter)
-                            .h_full()
-                            .flex_1()
-                            .appearance(false),
-                    )
+                    .child(compact_input(&self.sidebar_filter).flex_1())
                     .child(shell_widgets::keycap("⌘F")),
             )
             .child(

--- a/apps/desktop-gpui/src/app/ai_panel.rs
+++ b/apps/desktop-gpui/src/app/ai_panel.rs
@@ -2,16 +2,17 @@ use gpui::{
     div, prelude::*, px, AnyElement, Context, KeyDownEvent, MouseButton, MouseDownEvent,
     SharedString,
 };
-use gpui_component::{input::Input, scroll::ScrollableElement, Icon};
+use gpui_component::{scroll::ScrollableElement, Icon};
 
 use super::{
     ai::{AiRole, AiTopic},
     CellarApp,
 };
 use cellar_desktop_gpui::theme::{
-    ui_px, ACCENT, BORDER, BORDER_SEPARATOR, FG, FG_MUTED, FG_SECONDARY, INSET, PANEL, PANEL_RAISED,
-    PROD,
+    ui_px, ACCENT, BORDER, BORDER_SEPARATOR, FG, FG_MUTED, FG_SECONDARY, INSET, PANEL,
+    PANEL_RAISED, PROD,
 };
+use cellar_desktop_gpui::widgets::compact_input;
 
 impl CellarApp {
     pub(super) fn render_ai_panel(&self, cx: &mut Context<Self>) -> AnyElement {
@@ -341,7 +342,7 @@ impl CellarApp {
                                             }
                                         },
                                     ))
-                                    .child(Input::new(&self.ai.draft).h_full().appearance(false)),
+                                    .child(compact_input(&self.ai.draft)),
                             )
                             .child(
                                 div()

--- a/apps/desktop-gpui/src/app/bottom_panel_views.rs
+++ b/apps/desktop-gpui/src/app/bottom_panel_views.rs
@@ -1,6 +1,6 @@
 use cellar_runtime::history::QueryHistoryRecord;
 use gpui::{div, prelude::*, px, AnyElement, ClipboardItem, Context, SharedString};
-use gpui_component::{input::Input, scroll::ScrollableElement, Icon};
+use gpui_component::{scroll::ScrollableElement, Icon};
 
 use super::{bottom_panel_support::*, shell_widgets::bottom_empty, CellarApp};
 use cellar_desktop_gpui::model::{QueryState, TabKind, TableLoadState, WorkspaceTab};
@@ -8,6 +8,7 @@ use cellar_desktop_gpui::theme::{
     accent_soft, ACCENT, ACCENT_FG, BORDER, BORDER_DIVIDER, DELETE_SOFT, FG, FG_DISABLED, FG_MUTED,
     FG_SECONDARY, INSERT, INSERT_SOFT, INSET, PANEL, PANEL_MUTED, PROD, WARN,
 };
+use cellar_desktop_gpui::widgets::compact_input;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum MessageFilter {
@@ -237,11 +238,11 @@ impl CellarApp {
                                     .text_color(FG_MUTED),
                             )
                             .child(
-                                div().h_full().min_w_0().flex_1().child(
-                                    Input::new(&self.bottom_history_search)
-                                        .h_full()
-                                        .appearance(false),
-                                ),
+                                div()
+                                    .h_full()
+                                    .min_w_0()
+                                    .flex_1()
+                                    .child(compact_input(&self.bottom_history_search)),
                             ),
                     )
                     .child(

--- a/apps/desktop-gpui/src/app/command_palette.rs
+++ b/apps/desktop-gpui/src/app/command_palette.rs
@@ -1,10 +1,11 @@
 use gpui::{div, prelude::*, px, AnyElement, Context, KeyDownEvent, SharedString, Window};
-use gpui_component::{input::Input, input::InputState, Icon};
+use gpui_component::{input::InputState, Icon};
 
 use super::{shell_widgets::keycap, CellarApp};
 use cellar_desktop_gpui::{
     model::TableTarget,
     theme::{ACCENT, BORDER, FG, FG_MUTED, FG_SECONDARY, FG_TERTIARY, PANEL, PANEL_MUTED, WARN},
+    widgets::compact_input,
 };
 
 use super::shell::BottomPanelTab;
@@ -617,7 +618,7 @@ impl CellarApp {
                                     .size(px(13.))
                                     .text_color(FG_MUTED),
                             )
-                            .child(Input::new(input).h_full().flex_1().appearance(false))
+                            .child(compact_input(input).flex_1())
                             .child(keycap("esc")),
                     )
                     .child(

--- a/apps/desktop-gpui/src/app/connection_editor_view.rs
+++ b/apps/desktop-gpui/src/app/connection_editor_view.rs
@@ -1,10 +1,6 @@
 use cellar_core::driver::{Engine, EnvTag, SslMode};
 use gpui::{div, prelude::*, px, AnyElement, Context, Entity, SharedString};
-use gpui_component::{
-    input::{Input, InputState},
-    scroll::ScrollableElement,
-    Icon,
-};
+use gpui_component::{input::InputState, scroll::ScrollableElement, Icon};
 
 use super::{
     connection_editor::{ConnectionEditor, ConnectionTab, EditorBusy, ENGINES},
@@ -15,6 +11,7 @@ use cellar_desktop_gpui::theme::{
     accent, ACCENT, ACCENT_FG, BORDER, BORDER_DIVIDER, BORDER_STRONG, FG, FG_MUTED, FG_SECONDARY,
     FG_TERTIARY, INSET, PANEL, PANEL_MUTED, PANEL_RAISED, WARN,
 };
+use cellar_desktop_gpui::widgets::compact_input;
 
 const SWATCHES: [(&str, u32); 7] = [
     ("#4f8ff7", 0x4f8ff7),
@@ -587,7 +584,7 @@ fn input_box(state: &Entity<InputState>, mono: bool, width: Option<f32>) -> AnyE
         .when(mono, |element| {
             element.font_family(cellar_desktop_gpui::theme::mono_font())
         })
-        .child(Input::new(state).h_full().appearance(false))
+        .child(compact_input(state))
         .into_any_element()
 }
 

--- a/apps/desktop-gpui/src/app/connection_import.rs
+++ b/apps/desktop-gpui/src/app/connection_import.rs
@@ -3,16 +3,13 @@ use std::{collections::HashSet, sync::Arc};
 use cellar_core::driver::ConnectionConfig;
 use cellar_runtime::datagrip::DatagripImport;
 use gpui::{div, prelude::*, px, AnyElement, Context, Entity, SharedString, Window};
-use gpui_component::{
-    checkbox::Checkbox,
-    input::{Input, InputState},
-    Disableable, Icon,
-};
+use gpui_component::{checkbox::Checkbox, input::InputState, Disableable, Icon};
 
 use cellar_desktop_gpui::theme::{
     accent, ACCENT, ACCENT_FG, BORDER, BORDER_STRONG, FG, FG_MUTED, FG_SECONDARY, INSET, PANEL,
     PANEL_MUTED, PANEL_RAISED, WARN,
 };
+use cellar_desktop_gpui::widgets::compact_input;
 
 use super::CellarApp;
 
@@ -580,12 +577,7 @@ fn import_row_input(state: &Entity<InputState>, width: f32, enabled: bool) -> An
         .px_2()
         .font_family(cellar_desktop_gpui::theme::mono_font())
         .opacity(if enabled { 1. } else { 0.4 })
-        .child(
-            Input::new(state)
-                .h_full()
-                .appearance(false)
-                .disabled(!enabled),
-        )
+        .child(compact_input(state).disabled(!enabled))
         .into_any_element()
 }
 

--- a/apps/desktop-gpui/src/app/query_parameter_view.rs
+++ b/apps/desktop-gpui/src/app/query_parameter_view.rs
@@ -1,5 +1,5 @@
 use gpui::{div, prelude::*, px, AnyElement, Context, SharedString};
-use gpui_component::{input::Input, scroll::ScrollableElement, Icon};
+use gpui_component::{scroll::ScrollableElement, Icon};
 
 use super::{
     query_params::{parameter_value, ParamKind, QueryParameterInput},
@@ -9,6 +9,7 @@ use super::{
 use cellar_desktop_gpui::theme::{
     ACCENT, ACCENT_FG, BORDER, FG, FG_MUTED, FG_SECONDARY, INSET, PANEL, PANEL_RAISED, PROD,
 };
+use cellar_desktop_gpui::widgets::compact_input;
 
 impl CellarApp {
     pub(super) fn query_parameter_panel(
@@ -278,7 +279,7 @@ impl CellarApp {
                 .border_color(BORDER)
                 .bg(INSET)
                 .px(px(7.))
-                .child(Input::new(&input.state).h_full().appearance(false))
+                .child(compact_input(&input.state))
                 .into_any_element(),
         }
     }

--- a/apps/desktop-gpui/src/app/query_templates.rs
+++ b/apps/desktop-gpui/src/app/query_templates.rs
@@ -1,12 +1,13 @@
 use cellar_runtime::query_templates::{self, QueryTemplate};
 use gpui::{div, prelude::*, px, AnyElement, Context, SharedString, Window};
-use gpui_component::{input::Input, input::InputState, scroll::ScrollableElement, Icon};
+use gpui_component::{input::InputState, scroll::ScrollableElement, Icon};
 
 use super::CellarApp;
 use cellar_desktop_gpui::theme::{
     accent, ACCENT, ACCENT_FG, BORDER, BORDER_STRONG, FG, FG_MUTED, FG_SECONDARY, INSET, PANEL,
     PANEL_MUTED, PANEL_RAISED, PROD,
 };
+use cellar_desktop_gpui::widgets::compact_input;
 
 pub(super) struct SaveTemplateEditor {
     sql: String,
@@ -219,7 +220,7 @@ impl CellarApp {
                                     .border_color(BORDER)
                                     .bg(INSET)
                                     .px(px(10.))
-                                    .child(Input::new(&editor.name).h_full().appearance(false)),
+                                    .child(compact_input(&editor.name)),
                             )
                             .child(field_label("Description", Some("(optional)")))
                             .child(
@@ -232,9 +233,7 @@ impl CellarApp {
                                     .border_color(BORDER)
                                     .bg(INSET)
                                     .px(px(10.))
-                                    .child(
-                                        Input::new(&editor.description).h_full().appearance(false),
-                                    ),
+                                    .child(compact_input(&editor.description)),
                             )
                             .child(field_label("SQL", None))
                             .child(

--- a/apps/desktop-gpui/src/app/schema_compare.rs
+++ b/apps/desktop-gpui/src/app/schema_compare.rs
@@ -4,12 +4,13 @@ use cellar_core::driver::{Engine, EnvTag};
 use cellar_runtime::history::NewQueryHistoryRecord;
 use cellar_schema_diff::{assemble_script, MigrationStatement, SchemaComparison};
 use gpui::{div, prelude::*, px, AnyElement, ClipboardItem, Context, Entity, SharedString, Window};
-use gpui_component::{input::Input, input::InputState, Icon};
+use gpui_component::{input::InputState, Icon};
 
 use super::{schema_compare_support::*, CellarApp};
 use cellar_desktop_gpui::{
     model::{SchemaCompareConfig, SchemaCompareSource, SchemaCompareState, TabKind, WorkspaceTab},
     theme::{ACCENT, BG, BORDER, FG_MUTED, INSERT, INSET, PANEL, PANEL_MUTED, PROD, WARN},
+    widgets::compact_input,
 };
 
 pub(super) struct SchemaCompareWorkspace {
@@ -532,7 +533,7 @@ impl CellarApp {
                         div()
                             .flex_1()
                             .min_h_0()
-                            .child(Input::new(&workspace.editor).h_full().appearance(false)),
+                            .child(compact_input(&workspace.editor)),
                     )
                     .child(
                         div()

--- a/apps/desktop-gpui/src/app/schema_visibility.rs
+++ b/apps/desktop-gpui/src/app/schema_visibility.rs
@@ -2,10 +2,7 @@ use std::collections::HashSet;
 
 use cellar_core::schema::Schema;
 use gpui::{div, prelude::*, px, AnyElement, Context, Entity, SharedString, Subscription, Window};
-use gpui_component::{
-    input::{Input, InputState},
-    Icon,
-};
+use gpui_component::{input::InputState, Icon};
 use serde::{Deserialize, Serialize};
 
 use super::CellarApp;
@@ -13,6 +10,7 @@ use cellar_desktop_gpui::theme::{
     ACCENT, ACCENT_FG, BG, BORDER, BORDER_STRONG, FG, FG_MUTED, FG_SECONDARY, INSET, PANEL,
     PANEL_RAISED,
 };
+use cellar_desktop_gpui::widgets::compact_input;
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub(super) struct SchemaVisibilityPrefs {
@@ -290,12 +288,7 @@ impl CellarApp {
                                             .size(px(11.))
                                             .text_color(FG_MUTED),
                                     )
-                                    .child(
-                                        Input::new(&editor.filter)
-                                            .h_full()
-                                            .flex_1()
-                                            .appearance(false),
-                                    ),
+                                    .child(compact_input(&editor.filter).flex_1()),
                             )
                             .child(
                                 div()

--- a/apps/desktop-gpui/src/app/settings.rs
+++ b/apps/desktop-gpui/src/app/settings.rs
@@ -1,11 +1,12 @@
 use gpui::{div, prelude::*, px, AnyElement, Context, SharedString};
-use gpui_component::{input::Input, Icon};
+use gpui_component::Icon;
 
 use super::CellarApp;
 use cellar_desktop_gpui::theme::{
     ACCENT, ACCENT_FG, BG, BORDER, BORDER_DIVIDER, FG, FG_MUTED, FG_SECONDARY, FG_TERTIARY, INSERT,
     INSET, PANEL, PANEL_MUTED, PANEL_RAISED,
 };
+use cellar_desktop_gpui::widgets::compact_input;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(super) enum SettingsCategory {
@@ -176,7 +177,7 @@ impl CellarApp {
                             .child(
                                 div()
                                     .w(px(260.))
-                                    .h(px(24.))
+                                    .h(px(28.))
                                     .flex()
                                     .items_center()
                                     .gap(px(6.))
@@ -188,11 +189,11 @@ impl CellarApp {
                                     .text_color(FG_MUTED)
                                     .child(Icon::empty().path("icons/search.svg").size(px(11.)))
                                     .child(
-                                        div().min_w_0().flex_1().h_full().child(
-                                            Input::new(&self.settings_search)
-                                                .h_full()
-                                                .appearance(false),
-                                        ),
+                                        div()
+                                            .min_w_0()
+                                            .flex_1()
+                                            .h_full()
+                                            .child(compact_input(&self.settings_search)),
                                     )
                                     .child(
                                         div()

--- a/apps/desktop-gpui/src/app/settings.rs
+++ b/apps/desktop-gpui/src/app/settings.rs
@@ -177,7 +177,7 @@ impl CellarApp {
                             .child(
                                 div()
                                     .w(px(260.))
-                                    .h(px(28.))
+                                    .h(px(24.))
                                     .flex()
                                     .items_center()
                                     .gap(px(6.))
@@ -193,10 +193,14 @@ impl CellarApp {
                                             .min_w_0()
                                             .flex_1()
                                             .h_full()
-                                            .child(compact_input(&self.settings_search)),
+                                            .flex()
+                                            .items_center()
+                                            .child(compact_input(&self.settings_search).flex_1()),
                                     )
                                     .child(
                                         div()
+                                            .flex()
+                                            .items_center()
                                             .rounded(px(3.))
                                             .border_1()
                                             .border_color(BORDER)

--- a/apps/desktop-gpui/src/app/settings_ai.rs
+++ b/apps/desktop-gpui/src/app/settings_ai.rs
@@ -1,6 +1,6 @@
 use cellar_ai::openai::OpenAiLoginMethod;
 use gpui::{div, prelude::*, px, AnyElement, Context, SharedString};
-use gpui_component::{input::Input, Icon};
+use gpui_component::Icon;
 
 use super::{
     ai::AiProvider,
@@ -12,6 +12,7 @@ use super::{
 use cellar_desktop_gpui::theme::{
     ACCENT, BORDER, FG, FG_MUTED, FG_SECONDARY, INSET, PANEL, PANEL_RAISED, PROD,
 };
+use cellar_desktop_gpui::widgets::compact_input;
 
 const PROVIDERS: &[(&str, &str, Option<AiProvider>)] = &[
     ("Google", "gemini-* family", Some(AiProvider::Google)),
@@ -180,7 +181,7 @@ impl CellarApp {
                             .border_color(BORDER)
                             .bg(INSET)
                             .px_1()
-                            .child(Input::new(&self.ai.key).h_full().appearance(false)),
+                            .child(compact_input(&self.ai.key)),
                     )
                     .child(
                         action_button(

--- a/apps/desktop-gpui/src/app/settings_workspace.rs
+++ b/apps/desktop-gpui/src/app/settings_workspace.rs
@@ -4,7 +4,6 @@ use gpui::{
 };
 use gpui_component::{
     button::Button,
-    input::Input,
     menu::{DropdownMenu, PopupMenuItem},
     slider::Slider,
     Theme as ComponentTheme, ThemeMode,
@@ -21,6 +20,7 @@ use cellar_desktop_gpui::theme::{
     ACCENT, BORDER, BORDER_DIVIDER, FG, FG_MUTED, FG_SECONDARY, INSET, PANEL, PANEL_MUTED,
     PANEL_RAISED,
 };
+use cellar_desktop_gpui::widgets::compact_input;
 
 const SANS_FONTS: &[&str] = &[
     "Geist",
@@ -227,11 +227,7 @@ impl CellarApp {
                                     .bg(INSET)
                                     .px_2()
                                     .font_family(cellar_desktop_gpui::theme::mono_font())
-                                    .child(
-                                        Input::new(&self.font_size_input)
-                                            .h_full()
-                                            .appearance(false),
-                                    ),
+                                    .child(compact_input(&self.font_size_input)),
                             )
                             .child(div().text_color(FG_SECONDARY).child("px"))
                             .child(

--- a/apps/desktop-gpui/src/app/setup_transfer_widgets.rs
+++ b/apps/desktop-gpui/src/app/setup_transfer_widgets.rs
@@ -1,8 +1,5 @@
 use gpui::{div, prelude::*, px, AnyElement, Context, Entity, SharedString, Window};
-use gpui_component::{
-    input::{Input, InputState},
-    Icon,
-};
+use gpui_component::{input::InputState, Icon};
 
 use super::{
     setup_transfer::{ImportDecision, ImportSetupState, ImportSummary, SetupTransfer},
@@ -12,6 +9,7 @@ use cellar_desktop_gpui::theme::{
     accent, hover_bright, ACCENT, BG, BORDER, BORDER_STRONG, FG, FG_MUTED, FG_SECONDARY, INSET,
     PANEL_MUTED, PANEL_RAISED, PROD,
 };
+use cellar_desktop_gpui::widgets::compact_input;
 
 pub(super) fn modal_header(
     icon: &'static str,
@@ -339,7 +337,7 @@ pub(super) fn import_source(
                 .border_color(BORDER)
                 .bg(INSET)
                 .font_family(cellar_desktop_gpui::theme::mono_font())
-                .child(Input::new(&raw).h_full().appearance(false)),
+                .child(compact_input(&raw)),
         )
         .when_some(error, |element, error| {
             element.child(div().mt_2().text_color(PROD).child(error))

--- a/apps/desktop-gpui/src/app/sidebar_layout.rs
+++ b/apps/desktop-gpui/src/app/sidebar_layout.rs
@@ -438,6 +438,8 @@ impl CellarApp {
                                                 .h(ui_px(20.))
                                                 .min_w_0()
                                                 .flex_1()
+                                                .flex()
+                                                .items_center()
                                                 .overflow_hidden()
                                                 .rounded(ui_px(3.))
                                                 .border_1()
@@ -445,7 +447,7 @@ impl CellarApp {
                                                 .bg(cellar_desktop_gpui::theme::INSET)
                                                 .px_1()
                                                 .on_click(|_, _, cx| cx.stop_propagation())
-                                                .child(compact_input(&input)),
+                                                .child(compact_input(&input).flex_1()),
                                         )
                                     })
                                     .child(

--- a/apps/desktop-gpui/src/app/sidebar_layout.rs
+++ b/apps/desktop-gpui/src/app/sidebar_layout.rs
@@ -4,7 +4,7 @@ use cellar_core::driver::ConnectionConfig;
 use gpui::{
     div, prelude::*, AnyElement, Context, MouseButton, MouseDownEvent, Point, Rgba, SharedString,
 };
-use gpui_component::{input::Input, Icon};
+use gpui_component::Icon;
 use serde::{Deserialize, Serialize};
 use sqlx::{sqlite::SqliteConnectOptions, ConnectOptions, Connection, Row};
 
@@ -15,6 +15,7 @@ use super::{
 use cellar_desktop_gpui::theme::{
     ui_px, ACCENT, BORDER, FG, FG_MUTED, FG_TERTIARY, PANEL_MUTED, PANEL_RAISED,
 };
+use cellar_desktop_gpui::widgets::compact_input;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(tag = "kind", rename_all = "lowercase")]
@@ -437,13 +438,14 @@ impl CellarApp {
                                                 .h(ui_px(20.))
                                                 .min_w_0()
                                                 .flex_1()
+                                                .overflow_hidden()
                                                 .rounded(ui_px(3.))
                                                 .border_1()
                                                 .border_color(FG_MUTED)
                                                 .bg(cellar_desktop_gpui::theme::INSET)
                                                 .px_1()
                                                 .on_click(|_, _, cx| cx.stop_propagation())
-                                                .child(Input::new(&input).h_full().appearance(false)),
+                                                .child(compact_input(&input)),
                                         )
                                     })
                                     .child(

--- a/apps/desktop-gpui/src/app/table_filter_bar.rs
+++ b/apps/desktop-gpui/src/app/table_filter_bar.rs
@@ -1,14 +1,12 @@
 use cellar_core::query::{SortDirection, TableFilterOperator, TableSortClause};
 use gpui::{div, prelude::*, px, AnyElement, ClickEvent, Context, Entity, SharedString};
-use gpui_component::{
-    input::{Input, InputState},
-    Icon,
-};
+use gpui_component::{input::InputState, Icon};
 
 use super::CellarApp;
 use cellar_desktop_gpui::{
     model::{TablePage, TableTarget},
     theme::{ACCENT, ACCENT_FG, BORDER, FG, FG_MUTED, FG_SECONDARY, INSET, PANEL, PANEL_RAISED},
+    widgets::compact_input,
 };
 
 impl CellarApp {
@@ -195,7 +193,7 @@ impl CellarApp {
                             .border_color(BORDER)
                             .rounded(px(3.))
                             .bg(INSET)
-                            .child(Input::new(&input).h_full().appearance(false)),
+                            .child(compact_input(&input)),
                     )
                     .child(
                         div()
@@ -250,7 +248,7 @@ impl CellarApp {
             "icons/sort-asc.svg"
         };
         div()
-            .h(px(28.))
+            .h(px(34.))
             .flex_shrink_0()
             .flex()
             .items_center()
@@ -282,7 +280,7 @@ impl CellarApp {
                             .border_1()
                             .border_color(BORDER)
                             .bg(INSET)
-                            .child(Input::new(&quick_input).h_full().appearance(false)),
+                            .child(compact_input(&quick_input)),
                     )
                     .when_some(quick_column, |element, quick_column| {
                         element.child(
@@ -473,7 +471,7 @@ impl CellarApp {
                             .border_1()
                             .border_color(BORDER)
                             .bg(INSET)
-                            .child(Input::new(&input).h_full().appearance(false)),
+                            .child(compact_input(&input)),
                     )
                     .child(
                         div()

--- a/apps/desktop-gpui/src/app/table_filter_bar.rs
+++ b/apps/desktop-gpui/src/app/table_filter_bar.rs
@@ -188,12 +188,14 @@ impl CellarApp {
                     .child(
                         div()
                             .w(px(132.))
-                            .h(px(18.))
+                            .h(px(20.))
+                            .flex()
+                            .items_center()
                             .border_1()
                             .border_color(BORDER)
                             .rounded(px(3.))
                             .bg(INSET)
-                            .child(compact_input(&input)),
+                            .child(compact_input(&input).flex_1()),
                     )
                     .child(
                         div()
@@ -248,7 +250,7 @@ impl CellarApp {
             "icons/sort-asc.svg"
         };
         div()
-            .h(px(34.))
+            .h(px(28.))
             .flex_shrink_0()
             .flex()
             .items_center()
@@ -276,11 +278,13 @@ impl CellarApp {
                         div()
                             .w(px(180.))
                             .h(px(22.))
+                            .flex()
+                            .items_center()
                             .rounded(px(3.))
                             .border_1()
                             .border_color(BORDER)
                             .bg(INSET)
-                            .child(compact_input(&quick_input)),
+                            .child(compact_input(&quick_input).flex_1()),
                     )
                     .when_some(quick_column, |element, quick_column| {
                         element.child(
@@ -466,12 +470,14 @@ impl CellarApp {
                     .child(
                         div()
                             .w(px(132.))
-                            .h(px(18.))
+                            .h(px(20.))
+                            .flex()
+                            .items_center()
                             .rounded(px(3.))
                             .border_1()
                             .border_color(BORDER)
                             .bg(INSET)
-                            .child(compact_input(&input)),
+                            .child(compact_input(&input).flex_1()),
                     )
                     .child(
                         div()

--- a/apps/desktop-gpui/src/grid/date_picker.rs
+++ b/apps/desktop-gpui/src/grid/date_picker.rs
@@ -1,6 +1,6 @@
 use chrono::{Datelike, Local, NaiveDate};
 use gpui::{div, prelude::*, px, AnyElement, Entity, SharedString, WeakEntity};
-use gpui_component::{input::Input, input::InputState, Icon};
+use gpui_component::{input::InputState, Icon};
 
 use super::DataGrid;
 use crate::theme::{
@@ -154,7 +154,7 @@ pub(super) fn picker(
                             .bg(BG)
                             .px_1()
                             .font_family(crate::theme::mono_font())
-                            .child(Input::new(&time).h_full().appearance(false)),
+                            .child(crate::widgets::compact_input(&time)),
                     ),
             )
         })

--- a/apps/desktop-gpui/src/grid/view.rs
+++ b/apps/desktop-gpui/src/grid/view.rs
@@ -4,7 +4,6 @@ use gpui::{
     div, prelude::*, px, uniform_list, Context, IntoElement, MouseButton, Render, ScrollWheelEvent,
     WeakEntity, Window,
 };
-use gpui_component::input::Input;
 use gpui_component::Icon;
 
 use super::{
@@ -276,7 +275,7 @@ impl Render for DataGrid {
                             .bg(PANEL_RAISED)
                             .border_1()
                             .border_color(ACCENT)
-                            .child(Input::new(&state).h_full().appearance(false)),
+                            .child(crate::widgets::compact_input(&state)),
                     )
                     .when_some(date, |element, date| {
                         let picker_height = date.picker_height();

--- a/apps/desktop-gpui/src/grid/view.rs
+++ b/apps/desktop-gpui/src/grid/view.rs
@@ -272,10 +272,12 @@ impl Render for DataGrid {
                             .top(px(top))
                             .w(px(width))
                             .h(px(crate::theme::row_height()))
+                            .flex()
+                            .items_center()
                             .bg(PANEL_RAISED)
                             .border_1()
                             .border_color(ACCENT)
-                            .child(crate::widgets::compact_input(&state)),
+                            .child(crate::widgets::compact_input(&state).flex_1()),
                     )
                     .when_some(date, |element, date| {
                         let picker_height = date.picker_height();

--- a/apps/desktop-gpui/src/lib.rs
+++ b/apps/desktop-gpui/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod grid;
 pub mod model;
 pub mod theme;
+pub mod widgets;
 mod workspace_model;

--- a/apps/desktop-gpui/src/widgets.rs
+++ b/apps/desktop-gpui/src/widgets.rs
@@ -1,11 +1,7 @@
-use gpui::{prelude::*, px, Entity};
+use gpui::{prelude::*, Entity};
 use gpui_component::input::{Input, InputState};
+use gpui_component::Sizable;
 
 pub fn compact_input(state: &Entity<InputState>) -> Input {
-    Input::new(state)
-        .appearance(false)
-        .h_full()
-        .min_w_0()
-        .px(px(6.))
-        .py(px(0.))
+    Input::new(state).xsmall().appearance(false).min_w_0()
 }

--- a/apps/desktop-gpui/src/widgets.rs
+++ b/apps/desktop-gpui/src/widgets.rs
@@ -1,0 +1,11 @@
+use gpui::{prelude::*, px, Entity};
+use gpui_component::input::{Input, InputState};
+
+pub fn compact_input(state: &Entity<InputState>) -> Input {
+    Input::new(state)
+        .appearance(false)
+        .h_full()
+        .min_w_0()
+        .px(px(6.))
+        .py(px(0.))
+}


### PR DESCRIPTION
## Why

`gpui-component` `Input::render` always applies `self.size` padding and height. Default Medium is `py(8)` and `h_8` (32px). `appearance(false)` only drops border and background. `Input::h_full` applies only in multi-line mode, so overlaying `py(0)` on Medium still left a 32px field inside 18–28px chrome.

## Scope

- `compact_input` in `apps/desktop-gpui/src/widgets.rs` calls `.xsmall().appearance(false).min_w_0()`. XSmall is `py(0)` and `h_5` (20px).
- Call sites that used `Input::new(...).h_full().appearance(false)` now use that helper.
- Folder rename is a flex row with `overflow_hidden` so the field gets a real width and cannot paint over the folder icon.
- Cell editor overlay is a flex row so the 20px field sits in the cell height.

The SQL editor in `query_workspace.rs` is unchanged. It is a real multi-line field.

Depends on https://github.com/MRL-00/cellar/pull/156.

## Tradeoffs

Chrome fields use the vendor XSmall metrics (`text_xs`, 4px horizontal pad) instead of Medium. Growing the filter bar to 34px to swallow Medium `h_8` was reverted.

## Blast Radius

Every GPUI chrome field that nested an appearance-false Input. Text still comes from `InputState`. Only size and clip change.

## Verification

- `cargo test -p cellar-desktop-gpui --offline --lib --bins` passed (26 lib + 47 bin).
- Live window capture of this binary was black (no Screen Recording permission), so the chrome fields were not confirmed on screen.