### PR TITLE
fix(gpui): let connection names expand and titlebar databases switch

### DIFF
--- a/apps/desktop-gpui/src/app.rs
+++ b/apps/desktop-gpui/src/app.rs
@@ -401,7 +401,7 @@ impl CellarApp {
     fn connection_row(
         &self,
         config: &ConnectionConfig,
-        active: bool,
+        expanded: bool,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
         let id = config.id.clone();
@@ -438,7 +438,7 @@ impl CellarApp {
                     .justify_center()
                     .child(
                         Icon::empty()
-                            .path(if active {
+                            .path(if expanded {
                                 "icons/chevron-down.svg"
                             } else {
                                 "icons/chevron-right.svg"
@@ -481,15 +481,14 @@ impl CellarApp {
             )
             .on_click(cx.listener(move |this, _, _, cx| {
                 this.model.select_connection(&id);
-                this.start_connect(id.clone(), cx);
+                if this.model.toggle_connection_expanded(&id) {
+                    this.start_connect(id.clone(), cx);
+                }
+                cx.notify();
             }))
     }
 
     fn sidebar(&self, cx: &mut Context<Self>) -> impl IntoElement {
-        let active_id = self
-            .model
-            .active_connection()
-            .map(|config| config.id.as_str());
         let sidebar_query = self.sidebar_filter.read(cx).value().trim().to_lowercase();
         let match_count = self
             .model
@@ -608,7 +607,7 @@ impl CellarApp {
                     .flex_1()
                     .min_h_0()
                     .overflow_y_scroll()
-                    .children(self.sidebar_rows(active_id, cx))
+                    .children(self.sidebar_rows(cx))
                     .pb(ui_px(12.))
                     .when(self.model.connections().is_empty(), |element| {
                         element

--- a/apps/desktop-gpui/src/app/shell.rs
+++ b/apps/desktop-gpui/src/app/shell.rs
@@ -154,11 +154,7 @@ impl CellarApp {
                 MouseButton::Left,
                 cx.listener(|this, event: &MouseDownEvent, window, _| {
                     let now = Instant::now();
-                    if is_titlebar_double_press(
-                        this.last_titlebar_press,
-                        now,
-                        event.click_count,
-                    ) {
+                    if is_titlebar_double_press(this.last_titlebar_press, now, event.click_count) {
                         this.last_titlebar_press = None;
                         window.zoom_window();
                     } else {
@@ -168,54 +164,66 @@ impl CellarApp {
             )
             .child(
                 div()
+                    .w(ui_px(68.))
+                    .flex_shrink_0()
+                    .h_full()
+                    .window_control_area(WindowControlArea::Drag),
+            )
+            .when_some(
+                active,
+                |element, (connection, database, context, context_icon, query_tab, engine)| {
+                    let database_crumb = if let Some(tab_id) = query_tab {
+                        title_database_crumb(database, engine)
+                            .id("switch-query-database")
+                            .cursor_pointer()
+                            .hover(|style| style.bg(PANEL_RAISED))
+                            .child(
+                                Icon::empty()
+                                    .path("icons/chevron-down.svg")
+                                    .size(ui_px(10.))
+                                    .text_color(FG_MUTED),
+                            )
+                            .on_mouse_down(
+                                MouseButton::Left,
+                                cx.listener(move |this, event: &MouseDownEvent, _, cx| {
+                                    cx.stop_propagation();
+                                    this.query_database_menu = if this
+                                        .query_database_menu
+                                        .as_ref()
+                                        .is_some_and(|menu| menu.tab_id == tab_id)
+                                    {
+                                        None
+                                    } else {
+                                        Some(QueryDatabaseMenu {
+                                            tab_id,
+                                            position: Point {
+                                                x: event.position.x,
+                                                y: ui_px(38.),
+                                            },
+                                        })
+                                    };
+                                    cx.notify();
+                                }),
+                            )
+                            .into_any_element()
+                    } else {
+                        title_database_crumb(database, engine).into_any_element()
+                    };
+                    element
+                        .child(div().mx(ui_px(4.)).h(ui_px(16.)).w(ui_px(1.)).bg(BORDER))
+                        .child(title_crumb("icons/database.svg", connection, 12.))
+                        .child(title_separator())
+                        .child(database_crumb)
+                        .child(title_separator())
+                        .child(title_crumb(context_icon, context, 11.))
+                },
+            )
+            .child(
+                div()
                     .flex_1()
                     .min_w_0()
                     .h_full()
-                    .window_control_area(WindowControlArea::Drag)
-                    .flex()
-                    .items_center()
-                    .child(div().w(ui_px(68.)).flex_shrink_0())
-                    .when_some(
-                        active,
-                        |element, (connection, database, context, context_icon, query_tab, engine)| {
-                            let database_crumb = if let Some(tab_id) = query_tab {
-                                title_database_crumb(database, engine)
-                                    .id("switch-query-database")
-                                    .cursor_pointer()
-                                    .hover(|style| style.bg(PANEL_RAISED))
-                                    .child(
-                                        Icon::empty()
-                                            .path("icons/chevron-down.svg")
-                                            .size(ui_px(10.))
-                                            .text_color(FG_MUTED),
-                                    )
-                                    .on_mouse_down(
-                                        MouseButton::Left,
-                                        cx.listener(move |this, event: &MouseDownEvent, _, cx| {
-                                            cx.stop_propagation();
-                                            this.query_database_menu = Some(QueryDatabaseMenu {
-                                                tab_id,
-                                                position: Point {
-                                                    x: event.position.x,
-                                                    y: ui_px(38.),
-                                                },
-                                            });
-                                            cx.notify();
-                                        }),
-                                    )
-                                    .into_any_element()
-                            } else {
-                                title_database_crumb(database, engine).into_any_element()
-                            };
-                            element
-                                .child(div().mx(ui_px(4.)).h(ui_px(16.)).w(ui_px(1.)).bg(BORDER))
-                                .child(title_crumb("icons/database.svg", connection, 12.))
-                                .child(title_separator())
-                                .child(database_crumb)
-                                .child(title_separator())
-                                .child(title_crumb(context_icon, context, 11.))
-                        },
-                    ),
+                    .window_control_area(WindowControlArea::Drag),
             )
             .child(
                 div()
@@ -404,9 +412,12 @@ impl CellarApp {
                                     .child(if active { "●" } else { "○" }),
                             )
                             .child(database)
-                            .on_click(cx.listener(move |this, _, _, cx| {
-                                this.select_query_database(tab_id, choose.clone(), cx);
-                            }))
+                            .on_mouse_down(
+                                MouseButton::Left,
+                                cx.listener(move |this, _, _, cx| {
+                                    this.select_query_database(tab_id, choose.clone(), cx);
+                                }),
+                            )
                     })),
             )
             .into_any_element()

--- a/apps/desktop-gpui/src/app/sidebar_layout.rs
+++ b/apps/desktop-gpui/src/app/sidebar_layout.rs
@@ -204,11 +204,7 @@ impl CellarApp {
         reconcile(&mut self.sidebar_layout, self.model.connections());
     }
 
-    pub(super) fn sidebar_rows(
-        &self,
-        active_id: Option<&str>,
-        cx: &mut Context<Self>,
-    ) -> Vec<AnyElement> {
+    pub(super) fn sidebar_rows(&self, cx: &mut Context<Self>) -> Vec<AnyElement> {
         let filter = self.sidebar_filter.read(cx).value().trim().to_lowercase();
         let filtering = !filter.is_empty();
         let mut rows = Vec::new();
@@ -261,10 +257,10 @@ impl CellarApp {
                                 })
                                 .child(self.connection_row(
                                     config,
-                                    active_id == Some(id.as_str()),
+                                    self.model.connection_expanded(&id),
                                     cx,
                                 ))
-                                .when(active_id == Some(id.as_str()), |element| {
+                                .when(self.model.connection_expanded(&id), |element| {
                                     element.child(self.schema_tree(Some(&id), cx))
                                 })
                                 .into_any_element(),
@@ -616,10 +612,10 @@ impl CellarApp {
                                             })
                                             .child(self.connection_row(
                                                 config,
-                                                active_id == Some(child_id.as_str()),
+                                                self.model.connection_expanded(&child_id),
                                                 cx,
                                             ))
-                                            .when(active_id == Some(child_id.as_str()), |element| {
+                                            .when(self.model.connection_expanded(&child_id), |element| {
                                                 element.child(self.schema_tree(Some(&child_id), cx))
                                             }),
                                     )

--- a/apps/desktop-gpui/src/model.rs
+++ b/apps/desktop-gpui/src/model.rs
@@ -57,6 +57,7 @@ pub struct AppModel {
     states: HashMap<String, ConnectionState>,
     schemas: HashMap<String, Vec<Database>>,
     expanded_nodes: HashSet<SchemaNode>,
+    expanded_connections: HashSet<String>,
     tabs: Vec<WorkspaceTab>,
     active_tab: Option<u64>,
     split: Option<SplitOrientation>,
@@ -80,6 +81,7 @@ impl AppModel {
             active_connection,
             schemas: HashMap::new(),
             expanded_nodes: HashSet::new(),
+            expanded_connections: HashSet::new(),
             tabs: Vec::new(),
             active_tab: None,
             split: None,
@@ -117,6 +119,7 @@ impl AppModel {
         self.connections.retain(|config| config.id != id);
         self.states.remove(id);
         self.schemas.remove(id);
+        self.expanded_connections.remove(id);
         self.tabs.retain(|tab| match &tab.kind {
             TabKind::Table { target, .. } => target.connection_id != id,
             TabKind::Query { target, .. } => target.connection_id != id,
@@ -150,6 +153,22 @@ impl AppModel {
         }
         self.active_connection = Some(id.to_owned());
         true
+    }
+
+    pub fn connection_expanded(&self, id: &str) -> bool {
+        self.expanded_connections.contains(id)
+    }
+
+    pub fn toggle_connection_expanded(&mut self, id: &str) -> bool {
+        if !self.connections.iter().any(|config| config.id == id) {
+            return false;
+        }
+        if self.expanded_connections.remove(id) {
+            false
+        } else {
+            self.expanded_connections.insert(id.to_owned());
+            true
+        }
     }
 
     pub fn connection_state(&self, id: &str) -> &ConnectionState {

--- a/apps/desktop-gpui/src/model/tests.rs
+++ b/apps/desktop-gpui/src/model/tests.rs
@@ -39,6 +39,13 @@ fn selects_only_known_connections() {
         Some("two")
     );
 
+    assert!(!model.connection_expanded("one"));
+    assert!(model.toggle_connection_expanded("one"));
+    assert!(model.connection_expanded("one"));
+    assert!(!model.toggle_connection_expanded("one"));
+    assert!(!model.connection_expanded("one"));
+    assert!(!model.toggle_connection_expanded("missing"));
+
     assert!(model.begin_connect("two"));
     assert_eq!(model.connection_state("two"), &ConnectionState::Connecting);
     assert!(!model.begin_connect("two"));


### PR DESCRIPTION
## Why

A sidebar connection click always called `select_connection` and `start_connect`. The schema tree rendered only when that connection was active, so a second click never collapsed it.

Titlebar crumbs lived inside `WindowControlArea::Drag`. macOS ate the click before the database menu could toggle. Menu items used `on_click` while the backdrop used `on_mouse_down`, so the backdrop won.

## Scope

- `AppModel.expanded_connections` with `connection_expanded` and `toggle_connection_expanded`. Expand connects. Collapse does not disconnect.
- `connection_row` and `sidebar_rows` key the chevron and schema tree off expanded state, not active id.
- Titlebar crumbs sit outside the traffic-light drag region. The database crumb toggles `query_database_menu`. Menu rows use `on_mouse_down`.

Depends on https://github.com/MRL-00/cellar/pull/157.

## Tradeoffs

Expand is independent of which connection is selected. You can keep one tree open while another row is active. That matches the classic sidebar more closely than "active implies open."

## Blast Radius

GPUI sidebar connection rows and the titlebar database switcher. Schema load still happens through `start_connect` on expand.

## Verification

- `cargo test -p cellar-desktop-gpui --offline --lib --bins -- model::tests::selects_only_known_connections` passed, including expand/collapse of known ids and a missing id.
- `cargo test -p cellar-desktop-gpui --offline --lib --bins` passed (26 lib + 47 bin).
- Live window capture of this binary was black (no Screen Recording permission), so the click path was not confirmed on screen.


Made with [Cursor](https://cursor.com)