### PR TITLE
fix(gpui): select grid cells and rows on mouse down

### DIFF
--- a/apps/desktop-gpui/src/grid/row.rs
+++ b/apps/desktop-gpui/src/grid/row.rs
@@ -96,7 +96,26 @@ impl RenderOnce for GridRow {
                             .justify_center()
                             .text_size(px(11.))
                             .text_color(FG_MUTED)
+                            .when(
+                                self.selection
+                                    .is_some_and(|selection| selection.row == self.row),
+                                |element| element.bg(accent_soft()),
+                            )
                             .child((self.row + 1).to_string())
+                            .on_mouse_down(MouseButton::Left, {
+                                let grid = self.grid.clone();
+                                let row = self.row;
+                                move |_, window, cx| {
+                                    grid.update(cx, |grid, cx| {
+                                        grid.select(
+                                            super::CellPosition { row, column: 0 },
+                                            window,
+                                            cx,
+                                        );
+                                    })
+                                    .ok();
+                                }
+                            })
                             .context_menu({
                                 let grid = self.grid.clone();
                                 let row = self.row;
@@ -380,10 +399,10 @@ fn grid_cell(
         .whitespace_nowrap()
         .truncate()
         .child(content)
-        .on_click(move |event, window, cx| {
+        .on_mouse_down(MouseButton::Left, move |event, window, cx| {
             grid.update(cx, |grid, cx| {
                 let position = CellPosition { row, column };
-                if editable && event.click_count() >= 2 {
+                if editable && event.click_count >= 2 {
                     grid.begin_edit(position, window, cx);
                 } else {
                     grid.select(position, window, cx);


### PR DESCRIPTION
## Why

Grid cells used `on_click` inside the overflow-x scroller. Those clicks never arrived. Row numbers had no select handler. A double-click still needs to open the editor without losing the first click's selection.

## Scope

- Cell and row-number handlers in `apps/desktop-gpui/src/grid/row.rs` use `on_mouse_down`.
- `click_count >= 2` still calls `begin_edit`. A single press calls `select`.
- The selected row number uses `accent_soft()`.

Depends on https://github.com/MRL-00/cellar/pull/158.

## Tradeoffs

Mouse down selects before mouse up. Dragging to resize a column still `stop_propagation`s on its own handle. Context menus are unchanged.

## Blast Radius

GPUI data grid selection and the double-click editor. Pending edits and commit review are untouched.

## Verification

- `cargo test -p cellar-desktop-gpui --offline --lib --bins` passed (26 lib + 47 bin).
- Live window capture of this binary was black (no Screen Recording permission), so cell selection was not confirmed on screen.


Made with [Cursor](https://cursor.com)